### PR TITLE
Fix external download routing and add download location mode setting

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -85,6 +85,13 @@ val AutoDownloadOnLikeKey = booleanPreferencesKey("autoDownloadOnLike")
 val AutoSkipNextOnErrorKey = booleanPreferencesKey("autoSkipNextOnError")
 val StopMusicOnTaskClearKey = booleanPreferencesKey("stopMusicOnTaskClear")
 val CustomDownloadPathKey = stringPreferencesKey("customDownloadPath")
+val DownloadLocationModeKey = stringPreferencesKey("downloadLocationMode")
+
+enum class DownloadLocationMode {
+    NORMAL,   // MediaStore only (Music/Zemer/)
+    CUSTOM,   // Custom path only (via SAF)
+    BOTH,     // Save to both locations
+}
 
 val MaxImageCacheSizeKey = intPreferencesKey("maxImageCacheSize")
 val MaxSongCacheSizeKey = intPreferencesKey("maxSongCacheSize")

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
@@ -44,6 +44,8 @@ import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.CustomDownloadPathKey
+import com.jtech.zemer.constants.DownloadLocationMode
+import com.jtech.zemer.constants.DownloadLocationModeKey
 import com.jtech.zemer.constants.MaxImageCacheSizeKey
 import com.jtech.zemer.constants.MaxSongCacheSizeKey
 import com.jtech.zemer.extensions.tryOrNull
@@ -56,6 +58,7 @@ import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.formatFileSize
 import com.jtech.zemer.utils.EnvironmentPaths.DEFAULT_RELATIVE_DOWNLOAD_PATH
 import com.jtech.zemer.utils.EnvironmentPaths.toUserFacingPath
+import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -86,6 +89,10 @@ fun StorageSettings(
     val (customDownloadPath, onCustomDownloadPathChange) = rememberPreference(
         key = CustomDownloadPathKey,
         defaultValue = ""
+    )
+    val (downloadLocationMode, onDownloadLocationModeChange) = rememberEnumPreference(
+        key = DownloadLocationModeKey,
+        defaultValue = DownloadLocationMode.NORMAL
     )
     val resolvedDownloadPath = remember(customDownloadPath) {
         customDownloadPath.toUserFacingPath().ifBlank { DEFAULT_RELATIVE_DOWNLOAD_PATH }
@@ -193,21 +200,38 @@ fun StorageSettings(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
         )
 
-        PreferenceEntry(
-            title = { Text(stringResource(R.string.custom_download_path)) },
-            description = stringResource(
-                R.string.custom_download_path_summary,
-                resolvedDownloadPath
-            ),
-            onClick = { downloadPickerLauncher.launch(null) }
+        ListPreference(
+            title = { Text(stringResource(R.string.download_location_mode)) },
+            selectedValue = downloadLocationMode,
+            values = DownloadLocationMode.entries.toList(),
+            valueText = { mode ->
+                when (mode) {
+                    DownloadLocationMode.NORMAL -> stringResource(R.string.download_mode_normal)
+                    DownloadLocationMode.CUSTOM -> stringResource(R.string.download_mode_custom)
+                    DownloadLocationMode.BOTH -> stringResource(R.string.download_mode_both)
+                }
+            },
+            onValueSelected = onDownloadLocationModeChange,
         )
 
-        if (customDownloadPath.isNotBlank()) {
+        // Show custom path picker only for CUSTOM or BOTH modes
+        if (downloadLocationMode != DownloadLocationMode.NORMAL) {
             PreferenceEntry(
-                title = { Text(stringResource(R.string.reset_download_path)) },
-                description = stringResource(R.string.reset_download_path_summary),
-                onClick = onResetDownloadPath
+                title = { Text(stringResource(R.string.custom_download_path)) },
+                description = stringResource(
+                    R.string.custom_download_path_summary,
+                    resolvedDownloadPath
+                ),
+                onClick = { downloadPickerLauncher.launch(null) }
             )
+
+            if (customDownloadPath.isNotBlank()) {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.reset_download_path)) },
+                    description = stringResource(R.string.reset_download_path_summary),
+                    onClick = onResetDownloadPath
+                )
+            }
         }
 
         PreferenceEntry(

--- a/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
@@ -10,6 +10,8 @@ import android.os.Environment
 import android.provider.MediaStore
 import androidx.documentfile.provider.DocumentFile
 import com.jtech.zemer.constants.CustomDownloadPathKey
+import com.jtech.zemer.constants.DownloadLocationMode
+import com.jtech.zemer.constants.DownloadLocationModeKey
 import com.jtech.zemer.utils.EnvironmentPaths.DEFAULT_RELATIVE_DOWNLOAD_PATH
 import com.jtech.zemer.utils.EnvironmentPaths.toRelativePath
 import com.jtech.zemer.utils.EnvironmentPaths.toStorageRoot
@@ -50,6 +52,24 @@ class MediaStoreHelper(private val context: Context) {
     private val customDownloadPathKey = CustomDownloadPathKey
 
     /**
+     * Get the custom download URI from preferences, if set
+     */
+    private fun getCustomDownloadUri(): Uri? {
+        return context.dataStore[customDownloadPathKey]
+            ?.takeIf { it.isNotBlank() }
+            ?.let { Uri.parse(it) }
+    }
+
+    /**
+     * Get the download location mode from preferences
+     */
+    private fun getDownloadLocationMode(): DownloadLocationMode {
+        return context.dataStore[DownloadLocationModeKey]
+            ?.let { runCatching { DownloadLocationMode.valueOf(it) }.getOrNull() }
+            ?: DownloadLocationMode.NORMAL
+    }
+
+    /**
      * Save a downloaded audio file to MediaStore in the Music/Zemer folder
      *
      * @param inputStream The audio file data stream
@@ -73,10 +93,11 @@ class MediaStoreHelper(private val context: Context) {
         try {
             val sanitizedFileName = sanitizeFileName(fileName)
             val contentResolver = context.contentResolver
-            val baseDownloadPath = getBaseDownloadPath()
 
+            // MediaStore always uses the default Music/Zemer path
+            // Custom paths are handled separately via SAF
             val relativePath = buildRelativePath(
-                baseDownloadPath = baseDownloadPath,
+                baseDownloadPath = DEFAULT_RELATIVE_DOWNLOAD_PATH,
                 artist = artist,
                 album = album,
             )
@@ -143,9 +164,9 @@ class MediaStoreHelper(private val context: Context) {
     }
 
     /**
-     * Save a file from a temporary location to MediaStore
+     * Save a file from a temporary location based on download location mode
      *
-     * @param tempFile Temporary file to move to MediaStore
+     * @param tempFile Temporary file to save
      * @param fileName Desired filename
      * @param mimeType Audio MIME type
      * @param title Song title
@@ -164,13 +185,7 @@ class MediaStoreHelper(private val context: Context) {
         durationMs: Long? = null
     ): Uri? = withContext(Dispatchers.IO) {
         try {
-            if (!tempFile.exists()) {
-                return@withContext null
-            }
-
-            val fileSize = tempFile.length()
-
-            if (fileSize == 0L) {
+            if (!tempFile.exists() || tempFile.length() == 0L) {
                 return@withContext null
             }
 
@@ -178,29 +193,97 @@ class MediaStoreHelper(private val context: Context) {
             val sanitizedArtist = sanitizeFolderName(artist)
             val sanitizedAlbum = album?.takeIf { it.isNotBlank() }?.let { sanitizeFolderName(it) }
 
-            val mediaStoreUri = tempFile.inputStream().use { inputStream ->
-                saveToMediaStore(
-                    inputStream = inputStream,
-                    fileName = sanitizedFileName,
-                    mimeType = mimeType,
-                    title = title,
-                    artist = artist,
-                    album = album,
-                    durationMs = durationMs
-                )
+            val downloadLocationMode = getDownloadLocationMode()
+            val customDownloadUri = getCustomDownloadUri()
+
+            when (downloadLocationMode) {
+                DownloadLocationMode.NORMAL -> {
+                    // Save to MediaStore only (Music/Zemer/)
+                    saveToMediaStoreInternal(
+                        tempFile = tempFile,
+                        sanitizedFileName = sanitizedFileName,
+                        mimeType = mimeType,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        durationMs = durationMs
+                    )
+                }
+                DownloadLocationMode.CUSTOM -> {
+                    // Save to custom path only
+                    if (customDownloadUri != null) {
+                        saveToCustomPath(
+                            tempFile = tempFile,
+                            customDownloadUri = customDownloadUri,
+                            mimeType = mimeType,
+                            sanitizedFileName = sanitizedFileName,
+                            sanitizedArtist = sanitizedArtist,
+                            sanitizedAlbum = sanitizedAlbum
+                        )
+                    } else {
+                        // Fallback to MediaStore if no custom path set
+                        saveToMediaStoreInternal(
+                            tempFile = tempFile,
+                            sanitizedFileName = sanitizedFileName,
+                            mimeType = mimeType,
+                            title = title,
+                            artist = artist,
+                            album = album,
+                            durationMs = durationMs
+                        )
+                    }
+                }
+                DownloadLocationMode.BOTH -> {
+                    // Save to both locations
+                    val mediaStoreUri = saveToMediaStoreInternal(
+                        tempFile = tempFile,
+                        sanitizedFileName = sanitizedFileName,
+                        mimeType = mimeType,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        durationMs = durationMs
+                    )
+                    if (customDownloadUri != null) {
+                        saveToCustomPath(
+                            tempFile = tempFile,
+                            customDownloadUri = customDownloadUri,
+                            mimeType = mimeType,
+                            sanitizedFileName = sanitizedFileName,
+                            sanitizedArtist = sanitizedArtist,
+                            sanitizedAlbum = sanitizedAlbum
+                        )
+                    }
+                    mediaStoreUri  // Return MediaStore URI as primary
+                }
             }
-
-            val customUri = saveToCustomPath(
-                tempFile = tempFile,
-                mimeType = mimeType,
-                sanitizedFileName = sanitizedFileName,
-                sanitizedArtist = sanitizedArtist,
-                sanitizedAlbum = sanitizedAlbum
-            )
-
-            mediaStoreUri ?: customUri
         } catch (e: Exception) {
             null
+        }
+    }
+
+    /**
+     * Internal helper to save file to MediaStore (Music/Zemer/)
+     */
+    private suspend fun saveToMediaStoreInternal(
+        tempFile: File,
+        sanitizedFileName: String,
+        mimeType: String,
+        title: String,
+        artist: String,
+        album: String?,
+        durationMs: Long?
+    ): Uri? {
+        return tempFile.inputStream().use { inputStream ->
+            saveToMediaStore(
+                inputStream = inputStream,
+                fileName = sanitizedFileName,
+                mimeType = mimeType,
+                title = title,
+                artist = artist,
+                album = album,
+                durationMs = durationMs
+            )
         }
     }
 
@@ -277,16 +360,12 @@ class MediaStoreHelper(private val context: Context) {
 
     private fun saveToCustomPath(
         tempFile: File,
+        customDownloadUri: Uri,
         mimeType: String,
         sanitizedFileName: String,
         sanitizedArtist: String,
         sanitizedAlbum: String?,
     ): Uri? {
-        val customDownloadUri = context.dataStore[customDownloadPathKey]
-            ?.takeIf { it.isNotBlank() }
-            ?.let(Uri::parse)
-            ?: return null
-
         val rootDocument = DocumentFile.fromTreeUri(context, customDownloadUri) ?: return null
 
         val artistDir = ensureDirectory(rootDocument, sanitizedArtist) ?: return null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,6 +347,10 @@
     <string name="song_cache">Song Cache</string>
     <string name="max_cache_size">Max cache size</string>
     <string name="unlimited">Unlimited</string>
+    <string name="download_location_mode">Download location</string>
+    <string name="download_mode_normal">Music folder (default)</string>
+    <string name="download_mode_custom">Custom folder only</string>
+    <string name="download_mode_both">Both locations</string>
     <string name="custom_download_path">Custom download path</string>
     <string name="custom_download_path_summary">Current: %1$s</string>
     <string name="reset_download_path">Reset download path</string>


### PR DESCRIPTION
## Summary

- **Fixed broken download routing**: Previously, when a custom download path was set, files were saved to BOTH MediaStore and the custom path (duplicate files), with custom path only used as fallback
- **Added Download Location Mode preference** with three options:
  - **Normal**: Save to Music/Zemer/ only (MediaStore) - visible in other music apps
  - **Custom**: Save to custom folder only (via SAF)
  - **Both**: Save to both locations for redundancy
- **Improved Settings UI**: Custom path picker now only shows when mode is Custom or Both

## Changes

| File | Changes |
|------|---------|
| `PreferenceKeys.kt` | Added `DownloadLocationModeKey` and `DownloadLocationMode` enum |
| `MediaStoreHelper.kt` | Refactored with three-way routing based on mode, fixed MediaStore to always use default path |
| `StorageSettings.kt` | Added mode selector ListPreference, conditional custom path UI |
| `strings.xml` | Added new UI strings for mode options |

## Behavior

| Mode | Custom Path Set | Download Location(s) | Files Created |
|------|-----------------|---------------------|---------------|
| NORMAL | N/A | `Music/Zemer/{Artist}/{Album}/` | 1 |
| CUSTOM | Yes | Custom path only | 1 |
| CUSTOM | No | `Music/Zemer/` (fallback) | 1 |
| BOTH | Yes | Both locations | 2 |
| BOTH | No | `Music/Zemer/` | 1 |

All modes properly update the database so downloads appear in the app's Library.

## Test plan

- [ ] Test NORMAL mode: download → file appears only in `Music/Zemer/`
- [ ] Test CUSTOM mode with path set: download → file appears only in custom path
- [ ] Test BOTH mode with path set: download → file appears in both locations
- [ ] Verify downloads show in Library for all modes
- [ ] Verify custom path picker only shows for CUSTOM/BOTH modes