### PR TITLE
Fix token login race condition

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
@@ -1,7 +1,7 @@
 package com.jtech.zemer.ui.screens
 
 import android.annotation.SuppressLint
-import android.content.Context
+import android.content.Intent
 import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
@@ -125,18 +125,20 @@ fun LoginScreen(
                                             accountEmail = it.email.orEmpty()
                                             accountChannelHandle = it.channelHandle.orEmpty()
                                             loginMethod = "google"
-                                            // Clean up WebView to prevent showing YouTube Music
+
+                                            android.util.Log.d("LoginScreen", "Successfully logged in as ${it.name}, restarting app...")
+
+                                            // Clean up WebView before restart
                                             cleanupWebView(webView)
 
-                                            // CRITICAL: Navigate to homescreen instead of navigateUp()
-                                            navController.navigate("home") {
-                                                popUpTo(navController.graph.startDestinationId) {
-                                                    inclusive = true
-                                                }
-                                                launchSingleTop = true
-                                            }
+                                            // Small delay to ensure preferences are saved
+                                            kotlinx.coroutines.delay(300)
 
-                                            android.util.Log.d("LoginScreen", "Successfully logged in and navigated to homescreen")
+                                            // Restart app to apply login state throughout all components
+                                            val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                                            intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                                            context.startActivity(intent)
+                                            Runtime.getRuntime().exit(0)
                                         }.onFailure { exception ->
                                             // Clear invalid credentials and show error
                                             android.util.Log.e("LoginScreen", "Authentication validation failed: ${exception.message}")

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -318,22 +318,46 @@ fun AccountSettings(
             TextFieldDialog(
                 initialTextFieldValue = TextFieldValue(text),
                 onDone = { data ->
+                    // Collect all values first to avoid race conditions with separate DataStore writes
+                    var newCookie = ""
+                    var newVisitorData = ""
+                    var newDataSyncId = ""
+                    var newAccountName = ""
+                    var newAccountEmail = ""
+                    var newAccountChannelHandle = ""
+
                     data.split("\n").forEach {
                         when {
-                            it.startsWith("***INNERTUBE COOKIE*** =") -> onInnerTubeCookieChange(it.substringAfter("="))
-                            it.startsWith("***VISITOR DATA*** =") -> onVisitorDataChange(it.substringAfter("="))
-                            it.startsWith("***DATASYNC ID*** =") -> onDataSyncIdChange(it.substringAfter("="))
-                            it.startsWith("***ACCOUNT NAME*** =") -> onAccountNameChange(it.substringAfter("="))
-                            it.startsWith("***ACCOUNT EMAIL*** =") -> onAccountEmailChange(it.substringAfter("="))
-                            it.startsWith("***ACCOUNT CHANNEL HANDLE*** =") -> onAccountChannelHandleChange(it.substringAfter("="))
+                            it.startsWith("***INNERTUBE COOKIE*** =") -> newCookie = it.substringAfter("=")
+                            it.startsWith("***VISITOR DATA*** =") -> newVisitorData = it.substringAfter("=")
+                            it.startsWith("***DATASYNC ID*** =") -> newDataSyncId = it.substringAfter("=")
+                            it.startsWith("***ACCOUNT NAME*** =") -> newAccountName = it.substringAfter("=")
+                            it.startsWith("***ACCOUNT EMAIL*** =") -> newAccountEmail = it.substringAfter("=")
+                            it.startsWith("***ACCOUNT CHANNEL HANDLE*** =") -> newAccountChannelHandle = it.substringAfter("=")
                         }
                     }
+
+                    // Atomically save all credentials and restart app
+                    accountSettingsViewModel.saveTokenAndRestart(
+                        context = context,
+                        cookie = newCookie,
+                        visitorData = newVisitorData,
+                        dataSyncId = newDataSyncId,
+                        accountName = newAccountName,
+                        accountEmail = newAccountEmail,
+                        accountChannelHandle = newAccountChannelHandle,
+                    )
                 },
                 onDismiss = { showTokenEditor = false },
                 singleLine = false,
                 maxLines = 20,
-                isInputValid = {
-                    it.isNotEmpty() && "SAPISID" in parseCookieString(it)
+                isInputValid = { input ->
+                    // Extract only the cookie line for validation (don't pass entire template)
+                    val cookieLine = input.split("\n")
+                        .find { it.startsWith("***INNERTUBE COOKIE*** =") }
+                        ?.substringAfter("=")
+                        ?: ""
+                    cookieLine.isNotEmpty() && "SAPISID" in parseCookieString(cookieLine)
                 },
                 extraContent = {
                     InfoLabel(text = stringResource(R.string.token_adv_login_description))

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt
@@ -1,13 +1,23 @@
 package com.jtech.zemer.viewmodels
 
 import android.content.Context
+import android.content.Intent
+import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jtech.zemer.App
+import com.jtech.zemer.constants.AccountChannelHandleKey
+import com.jtech.zemer.constants.AccountEmailKey
+import com.jtech.zemer.constants.AccountNameKey
+import com.jtech.zemer.constants.DataSyncIdKey
+import com.jtech.zemer.constants.InnerTubeCookieKey
+import com.jtech.zemer.constants.VisitorDataKey
 import com.jtech.zemer.utils.SyncUtils
+import com.jtech.zemer.utils.dataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -37,6 +47,40 @@ class AccountSettingsViewModel @Inject constructor(
     fun clearAllLibraryData() {
         viewModelScope.launch(Dispatchers.IO) {
             syncUtils.clearAllLibraryData()
+        }
+    }
+
+    /**
+     * Atomically save all token credentials to DataStore and restart the app.
+     * This prevents race conditions where the app restarts before all credentials are saved.
+     */
+    fun saveTokenAndRestart(
+        context: Context,
+        cookie: String,
+        visitorData: String,
+        dataSyncId: String,
+        accountName: String,
+        accountEmail: String,
+        accountChannelHandle: String,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            // Atomically write all credentials to DataStore in a single transaction
+            context.dataStore.edit { preferences ->
+                preferences[InnerTubeCookieKey] = cookie
+                preferences[VisitorDataKey] = visitorData
+                preferences[DataSyncIdKey] = dataSyncId
+                preferences[AccountNameKey] = accountName
+                preferences[AccountEmailKey] = accountEmail
+                preferences[AccountChannelHandleKey] = accountChannelHandle
+            }
+
+            // Restart app on Main thread after DataStore write completes
+            withContext(Dispatchers.Main) {
+                val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                context.startActivity(intent)
+                Runtime.getRuntime().exit(0)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix race condition in token login by using atomic DataStore writes
- Add app restart after Google WebView login to apply auth changes
- Add `saveTokenAndRestart()` function in AccountSettingsViewModel for reliable token persistence

## Test plan
- [ ] Test anonymous token login - credentials should persist after app restart
- [ ] Test Google WebView login - app should restart and apply auth immediately
- [ ] Verify no auth loss when quickly switching between screens after login