### PR TITLE
fix(video): preserve playback position when switching quality

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
@@ -202,6 +202,7 @@ fun VideoPlayerScreen(
     var adaptiveData by remember { mutableStateOf<YTPlayerUtils.AdaptiveVideoData?>(null) }
     var adaptiveQualities by remember { mutableStateOf<List<YTPlayerUtils.VideoQualityInfo>>(emptyList()) }
     var selectedQualityHeight by remember { mutableStateOf(1080) } // Default to 1080p
+    var savedPositionForQualityChange by remember { mutableStateOf(0L) } // Save position before quality switch
     var playbackInfo by remember { mutableStateOf<String?>(null) }
     var isInPipMode by remember { mutableStateOf(activity?.isInPictureInPictureMode == true) }
     var artistName by remember(videoId, artist) { mutableStateOf(artist?.takeIf { it.isNotBlank() }) }
@@ -356,10 +357,16 @@ fun VideoPlayerScreen(
         onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
     }
 
+    // Track if this is a quality change (to preserve position) vs initial load
+    var isQualityChange by remember { mutableStateOf(false) }
+
     LaunchedEffect(videoId, maxVideoBitrateKbps, reloadKey, selectedQualityHeight) {
-        isLoading = true
-        loadError = null
-        videoItem = null
+        // Don't show loading spinner for quality changes - player handles transition smoothly
+        if (!isQualityChange) {
+            isLoading = true
+            loadError = null
+            videoItem = null
+        }
         adaptiveData = null
 
         // Try adaptive playback first (for 1080p+ support)
@@ -406,6 +413,7 @@ fun VideoPlayerScreen(
                     drmConfiguration = null
                 )
                 isLoading = false
+                isQualityChange = false
                 return@LaunchedEffect
             }
         }
@@ -429,6 +437,7 @@ fun VideoPlayerScreen(
             if (validatedUrl == null) {
                 loadError = "Invalid stream URL"
                 isLoading = false
+                isQualityChange = false
                 return@onSuccess
             }
 
@@ -462,9 +471,11 @@ fun VideoPlayerScreen(
                 drmConfiguration = null
             )
             isLoading = false
+            isQualityChange = false
         }.onFailure {
             loadError = it.localizedMessage ?: "Playback error"
             isLoading = false
+            isQualityChange = false
         }
     }
 
@@ -882,8 +893,13 @@ fun VideoPlayerScreen(
 
                                 // Update media source when URLs change (quality switch)
                                 LaunchedEffect(adaptive.videoUrl, adaptive.audioUrl) {
-                                    val currentPos = adaptivePlayer.currentPosition
-                                    val wasPlaying = adaptivePlayer.isPlaying
+                                    // Use saved position for quality changes, otherwise use player's current position
+                                    val restorePosition = if (savedPositionForQualityChange > 0) {
+                                        savedPositionForQualityChange
+                                    } else {
+                                        adaptivePlayer.currentPosition
+                                    }
+                                    val wasPlaying = adaptivePlayer.isPlaying || savedPositionForQualityChange > 0
 
                                     val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory)
                                         .createMediaSource(MediaItem.fromUri(adaptive.videoUrl))
@@ -896,12 +912,15 @@ fun VideoPlayerScreen(
                                     adaptivePlayer.prepare()
 
                                     // Restore position on quality changes (not initial load)
-                                    if (currentPos > 0) {
-                                        adaptivePlayer.seekTo(currentPos)
+                                    if (restorePosition > 0) {
+                                        adaptivePlayer.seekTo(restorePosition)
                                     }
-                                    adaptivePlayer.playWhenReady = wasPlaying || currentPos == 0L
+                                    adaptivePlayer.playWhenReady = wasPlaying
 
-                                    Timber.tag("VideoPlayer").d("Updated media source: video=${adaptive.videoFormat.height}p, restored pos=${currentPos}ms")
+                                    // Clear saved position after restoring
+                                    savedPositionForQualityChange = 0L
+
+                                    Timber.tag("VideoPlayer").d("Updated media source: video=${adaptive.videoFormat.height}p, restored pos=${restorePosition}ms")
                                 }
 
                                 // Set playerInstance for controls
@@ -1435,7 +1454,12 @@ fun VideoPlayerScreen(
                         adaptiveQualities.forEach { quality ->
                             TextButton(
                                 onClick = {
-                                    selectedQualityHeight = quality.height
+                                    if (quality.height != selectedQualityHeight) {
+                                        // Save current position before quality change
+                                        savedPositionForQualityChange = playerInstance?.currentPosition ?: positionMs
+                                        isQualityChange = true
+                                        selectedQualityHeight = quality.height
+                                    }
                                     showQualityDialog = false
                                 },
                                 modifier = Modifier.fillMaxWidth()


### PR DESCRIPTION
## Summary
- Save current position before triggering quality change
- Use saved position when loading new quality stream
- Auto-resume playback after quality switch
- Avoid showing loading spinner during quality transitions

## Test plan
- [ ] Start playing a video and skip to middle
- [ ] Switch quality via quality dialog
- [ ] Verify playback resumes at same position
- [ ] Verify no loading spinner shown during quality switch