### PR TITLE
feat: add live performance support

### DIFF
--- a/app/schemas/com.jtech.zemer.db.InternalDatabase/32.json
+++ b/app/schemas/com.jtech.zemer.db.InternalDatabase/32.json
@@ -1,0 +1,1157 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 32,
+    "identityHash": "45e7a43c147111dff72190476a187810",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `mediaStoreUri` TEXT DEFAULT NULL, `videoMediaStoreUri` TEXT DEFAULT NULL, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreUri",
+            "columnName": "mediaStoreUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "videoMediaStoreUri",
+            "columnName": "videoMediaStoreUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_song_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_song_liked",
+            "unique": false,
+            "columnNames": [
+              "liked"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_liked` ON `${TABLE_NAME}` (`liked`)"
+          },
+          {
+            "name": "index_song_isVideo",
+            "unique": false,
+            "columnNames": [
+              "isVideo"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_isVideo` ON `${TABLE_NAME}` (`isVideo`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `playbackUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_event_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "artist_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistId` TEXT NOT NULL, `artistName` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `source` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `isFemale` INTEGER NOT NULL, `isChasid` INTEGER NOT NULL, `isGenZ` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `isKidZone` INTEGER NOT NULL, PRIMARY KEY(`artistId`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFemale",
+            "columnName": "isFemale",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isChasid",
+            "columnName": "isChasid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenZ",
+            "columnName": "isGenZ",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKidZone",
+            "columnName": "isKidZone",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistId"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '45e7a43c147111dff72190476a187810')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -525,19 +525,19 @@ interface DatabaseDao {
     fun videos(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE isVideo = 1 AND isDownloaded = 1")
+    @Query("SELECT * FROM song WHERE videoMediaStoreUri IS NOT NULL")
     fun downloadedVideos(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE isVideo = 1 AND isDownloaded = 1 ORDER BY dateDownload")
+    @Query("SELECT * FROM song WHERE videoMediaStoreUri IS NOT NULL ORDER BY dateDownload")
     fun downloadedVideosByCreateDateAsc(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE isVideo = 1 AND isDownloaded = 1 ORDER BY title")
+    @Query("SELECT * FROM song WHERE videoMediaStoreUri IS NOT NULL ORDER BY title")
     fun downloadedVideosByNameAsc(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE isVideo = 1 AND isDownloaded = 1 ORDER BY totalPlayTime")
+    @Query("SELECT * FROM song WHERE videoMediaStoreUri IS NOT NULL ORDER BY totalPlayTime")
     fun downloadedVideosByPlayTimeAsc(): Flow<List<Song>>
 
     fun downloadedVideosSorted(
@@ -1065,8 +1065,21 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE isDownloaded = 1 AND isVideo = 0 ORDER BY totalPlayTime")
     fun downloadedSongsByPlayTimeAsc(): Flow<List<Song>>
 
-    @Query("UPDATE song SET isDownloaded = :downloaded, dateDownload = :date WHERE id = :songId")
+    // When audio is downloaded, also set isVideo = false to ensure it appears in downloaded music
+    // (even if a video was downloaded first, this song now has an audio download)
+    @Query("UPDATE song SET isDownloaded = :downloaded, dateDownload = :date, isVideo = CASE WHEN :downloaded = 1 THEN 0 ELSE isVideo END WHERE id = :songId")
     fun updateDownloadedInfo(songId: String, downloaded: Boolean, date: LocalDateTime?)
+
+    @Query("UPDATE song SET isDownloaded = :downloaded, dateDownload = :date, isVideo = :isVideo, mediaStoreUri = :mediaStoreUri WHERE id = :songId")
+    fun updateVideoDownloadInfo(songId: String, downloaded: Boolean, date: LocalDateTime?, isVideo: Boolean, mediaStoreUri: String?)
+
+    // Update only mediaStoreUri without changing isVideo flag (for live performances that can be both audio and video)
+    @Query("UPDATE song SET mediaStoreUri = :mediaStoreUri WHERE id = :songId")
+    fun updateMediaStoreUri(songId: String, mediaStoreUri: String?)
+
+    // Update videoMediaStoreUri for video downloads (separate from audio downloads)
+    @Query("UPDATE song SET videoMediaStoreUri = :videoMediaStoreUri WHERE id = :songId")
+    fun updateVideoMediaStoreUri(songId: String, videoMediaStoreUri: String?)
 
     @Query("UPDATE song SET isVideo = :isVideo WHERE id = :songId")
     fun setIsVideo(songId: String, isVideo: Boolean)

--- a/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
@@ -91,7 +91,7 @@ class MusicDatabase(
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 31,
+    version = 32,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -134,7 +134,7 @@ abstract class InternalDatabase : RoomDatabase() {
             val builtDb = try {
                 Room
                     .databaseBuilder(context, InternalDatabase::class.java, DB_NAME)
-                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32)
                     .setJournalMode(JournalMode.TRUNCATE)
                     .enableMultiInstanceInvalidation()
                     .build().also {
@@ -406,6 +406,14 @@ val MIGRATION_30_31 =
             db.execSQL("CREATE INDEX IF NOT EXISTS index_song_isVideo ON song(isVideo)")
             // Add timestamp index for event table (time-range queries)
             db.execSQL("CREATE INDEX IF NOT EXISTS index_event_timestamp ON event(timestamp)")
+        }
+    }
+
+val MIGRATION_31_32 =
+    object : Migration(31, 32) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Add videoMediaStoreUri column for dual audio+video downloads
+            db.execSQL("ALTER TABLE song ADD COLUMN videoMediaStoreUri TEXT DEFAULT NULL")
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/SongEntity.kt
@@ -49,6 +49,8 @@ data class SongEntity(
     val isDownloaded: Boolean = false,
     @ColumnInfo(name = "mediaStoreUri", defaultValue = "NULL")
     val mediaStoreUri: String? = null,
+    @ColumnInfo(name = "videoMediaStoreUri", defaultValue = "NULL")
+    val videoMediaStoreUri: String? = null,
     @ColumnInfo(name = "isUploaded", defaultValue = false.toString())
     val isUploaded: Boolean = false,
     @ColumnInfo(name = "isVideo", defaultValue = "0")

--- a/app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt
@@ -24,6 +24,7 @@ data class MediaMetadata(
     val libraryAddToken: String? = null,
     val libraryRemoveToken: String? = null,
     val isVideo: Boolean = false,
+    val isLive: Boolean = false,
 ) : Serializable {
     data class Artist(
         val id: String?,
@@ -81,7 +82,7 @@ fun Song.toMediaMetadata() =
         isVideo = song.isVideo,
     )
 
-fun SongItem.toMediaMetadata() =
+fun SongItem.toMediaMetadata(isLive: Boolean = false) =
     MediaMetadata(
         id = id,
         title = title,
@@ -104,5 +105,6 @@ fun SongItem.toMediaMetadata() =
         explicit = explicit,
         setVideoId = setVideoId,
         libraryAddToken = libraryAddToken,
-        libraryRemoveToken = libraryRemoveToken
+        libraryRemoveToken = libraryRemoveToken,
+        isLive = isLive
     )

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
@@ -411,6 +411,24 @@ constructor(
         Timber.tag("DownloadRemoval").i("=== REMOVE DOWNLOAD END: $songId ===")
     }
 
+    /**
+     * Remove a video download only (keeps audio download intact).
+     * Used for dual downloads where a song can have both audio and video.
+     */
+    suspend fun removeVideoDownload(songId: String) = withContext(Dispatchers.IO) {
+        Timber.tag("DownloadRemoval").i("=== REMOVE VIDEO DOWNLOAD START: $songId ===")
+
+        // Delete video file from MediaStore and clear videoMediaStoreUri
+        runCatching {
+            mediaStoreDownloadManager.deleteDownloadedVideo(songId)
+            Timber.tag("DownloadRemoval").d("[$songId] Video delete completed")
+        }.onFailure {
+            Timber.tag("DownloadRemoval").e(it, "[$songId] Video delete failed")
+        }
+
+        Timber.tag("DownloadRemoval").i("=== REMOVE VIDEO DOWNLOAD END: $songId ===")
+    }
+
     fun release() {
         scope.cancel()
     }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -441,6 +441,43 @@ constructor(
     }
 
     /**
+     * Delete a downloaded video and remove it from MediaStore/DB.
+     * This only removes the video download, not the audio download.
+     */
+    suspend fun deleteDownloadedVideo(songId: String) {
+        Timber.tag("DownloadRemoval").i("=== deleteDownloadedVideo START: $songId ===")
+
+        var song = database.song(songId).first()
+        val videoUriString = song?.song?.videoMediaStoreUri
+        Timber.tag("DownloadRemoval").d("[$songId] Video DB state: found=${song != null}, videoUri=$videoUriString")
+
+        // Delete by stored video URI
+        if (videoUriString != null) {
+            Timber.tag("DownloadRemoval").d("[$songId] Deleting video from MediaStore by URI: $videoUriString")
+            val deleteResult = runCatching {
+                mediaStoreHelper.deleteFromMediaStore(Uri.parse(videoUriString))
+            }
+            if (deleteResult.isSuccess) {
+                Timber.tag("DownloadRemoval").i("[$songId] Video MediaStore delete SUCCESS: ${deleteResult.getOrNull()}")
+            } else {
+                Timber.tag("DownloadRemoval").e("[$songId] Video MediaStore delete FAILED: ${deleteResult.exceptionOrNull()?.message}")
+            }
+        } else {
+            Timber.tag("DownloadRemoval").d("[$songId] No video MediaStore URI stored")
+        }
+
+        // Clear only videoMediaStoreUri (keep audio download intact)
+        song?.let {
+            database.query {
+                updateVideoMediaStoreUri(songId, null)
+            }
+            Timber.tag("DownloadRemoval").d("[$songId] Video URI cleared from database")
+        }
+
+        Timber.tag("DownloadRemoval").i("=== deleteDownloadedVideo END: $songId ===")
+    }
+
+    /**
      * Process the download queue
      */
     private suspend fun processQueue() {
@@ -858,19 +895,30 @@ constructor(
     }
 
     /**
-     * Mark a song as downloaded in the database with MediaStore URI
+     * Mark a song as downloaded in the database with MediaStore URI.
+     * For video downloads: Updates videoMediaStoreUri (separate from audio downloads).
+     * For audio downloads: Updates isDownloaded, isVideo=false, and mediaStoreUri.
+     * This allows dual downloads where a song can have both audio AND video files.
      */
     private suspend fun markSongAsDownloaded(song: Song, mediaStoreUri: String) {
         ensureSongPersisted(song)
 
         database.query {
-            database.upsert(
-                song.song.copy(
-                    isDownloaded = true,
-                    dateDownload = LocalDateTime.now(),
-                    mediaStoreUri = mediaStoreUri
+            if (song.song.isVideo) {
+                // Video download: Update videoMediaStoreUri (separate from audio's mediaStoreUri)
+                // This allows a song to have both audio AND video downloads
+                database.updateVideoMediaStoreUri(song.id, mediaStoreUri)
+            } else {
+                // Audio download: Full update with mediaStoreUri
+                database.upsert(
+                    song.song.copy(
+                        isDownloaded = true,
+                        dateDownload = LocalDateTime.now(),
+                        mediaStoreUri = mediaStoreUri,
+                        isVideo = false
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -90,6 +90,7 @@ fun PlayerMenu(
     navController: NavController,
     playerBottomSheetState: BottomSheetState,
     isQueueTrigger: Boolean? = false,
+    isLive: Boolean = false, // For live performances, show both song and video download options
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -457,6 +458,9 @@ fun PlayerMenu(
     val configuration = LocalConfiguration.current
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
+    // Live performance support - query song state for dual download tracking
+    val librarySong by database.song(mediaMetadata.id).collectAsState(initial = null)
+
     LazyColumn(
         userScrollEnabled = !isPortrait,
         contentPadding = PaddingValues(
@@ -573,20 +577,24 @@ fun PlayerMenu(
                 )
             }
         }
-        item {
-            when (mediaStoreDownload?.status) {
-                MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> {
-                    // Show "Remove Download" option
+        // Download section - for live performances (isLive=true), show both song and video download options
+        if (isLive) {
+            val hasAudioDownload = librarySong?.song?.isDownloaded == true && librarySong?.song?.mediaStoreUri != null
+            val hasVideoDownload = librarySong?.song?.videoMediaStoreUri != null
+
+            // Show "Download Song" option (audio)
+            item {
+                if (hasAudioDownload) {
                     ListItem(
                         headlineContent = {
                             Text(
-                                text = stringResource(R.string.remove_download),
-                                color = MaterialTheme.colorScheme.error
+                                text = stringResource(R.string.downloaded_to_device),
+                                color = MaterialTheme.colorScheme.primary
                             )
                         },
                         leadingContent = {
                             Icon(
-                                painter = painterResource(R.drawable.offline),
+                                painter = painterResource(R.drawable.download),
                                 contentDescription = null,
                             )
                         },
@@ -597,96 +605,197 @@ fun PlayerMenu(
                             }
                         }
                     )
-                }
-
-                MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-                MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING -> {
-                    val progress = mediaStoreDownload?.progress ?: 0f
+                } else {
                     ListItem(
-                        headlineContent = { Text(text = stringResource(R.string.downloading)) },
-                        supportingContent = { Text(text = "${(progress * 100).toInt()}%") },
+                        headlineContent = { Text(text = stringResource(R.string.download_song)) },
                         leadingContent = {
-                            CircularProgressIndicator(
-                                progress = { progress.coerceIn(0f, 1f) },
-                                modifier = Modifier.size(24.dp),
-                                strokeWidth = 2.dp
+                            Icon(
+                                painter = painterResource(R.drawable.download),
+                                contentDescription = null,
+                            )
+                        },
+                        modifier = Modifier.clickable {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                database.transaction {
+                                    insert(mediaMetadata)
+                                }
+                                val song = database.song(mediaMetadata.id).first()
+                                song?.let {
+                                    downloadUtil.downloadToMediaStore(it)
+                                }
+                            }
+                            // Don't dismiss - keep menu open
+                        }
+                    )
+                }
+            }
+
+            // Show "Download Video" option
+            item {
+                if (hasVideoDownload) {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = stringResource(R.string.downloaded_to_device),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        supportingContent = { Text("Video") },
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(R.drawable.slow_motion_video),
+                                contentDescription = null,
                             )
                         },
                         modifier = Modifier.clickable {
                             coroutineScope.launch {
-                                downloadUtil.cancelMediaStoreDownload(mediaMetadata.id)
+                                downloadUtil.removeVideoDownload(mediaMetadata.id)
+                                Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
                             }
                         }
                     )
+                } else {
+                    ListItem(
+                        headlineContent = { Text(text = stringResource(R.string.download_video_to_device)) },
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(R.drawable.slow_motion_video),
+                                contentDescription = null,
+                            )
+                        },
+                        modifier = Modifier.clickable {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                database.transaction {
+                                    insert(mediaMetadata)
+                                }
+                                val song = database.song(mediaMetadata.id).first()
+                                song?.let {
+                                    downloadUtil.downloadVideoToMediaStore(it)
+                                }
+                            }
+                            // Don't dismiss - keep menu open
+                        }
+                    )
                 }
-
-                MediaStoreDownloadManager.DownloadState.Status.FAILED,
-                MediaStoreDownloadManager.DownloadState.Status.CANCELLED,
-                null -> {
-                    when (download?.state) {
-                        Download.STATE_COMPLETED -> {
-                            ListItem(
-                                headlineContent = {
-                                    Text(
-                                        text = stringResource(R.string.remove_download),
-                                        color = MaterialTheme.colorScheme.error
-                                    )
-                                },
-                                leadingContent = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.offline),
-                                        contentDescription = null,
-                                    )
-                                },
-                                modifier = Modifier.clickable {
-                                    coroutineScope.launch {
-                                        downloadUtil.removeDownload(mediaMetadata.id)
-                                        Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
-                                    }
+            }
+        } else {
+            // Standard download section - single option based on content type
+            item {
+                when (mediaStoreDownload?.status) {
+                    MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> {
+                        // Show "Remove Download" option
+                        ListItem(
+                            headlineContent = {
+                                Text(
+                                    text = stringResource(R.string.remove_download),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.offline),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                coroutineScope.launch {
+                                    downloadUtil.removeDownload(mediaMetadata.id)
+                                    Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
                                 }
-                            )
-                        }
+                            }
+                        )
+                    }
 
-                        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-                            ListItem(
-                                headlineContent = { Text(text = stringResource(R.string.downloading)) },
-                                leadingContent = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-                                },
-                                modifier = Modifier.clickable {
-                                    coroutineScope.launch {
-                                        downloadUtil.removeDownload(mediaMetadata.id)
-                                        Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
-                                    }
+                    MediaStoreDownloadManager.DownloadState.Status.QUEUED,
+                    MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING -> {
+                        val progress = mediaStoreDownload?.progress ?: 0f
+                        ListItem(
+                            headlineContent = { Text(text = stringResource(R.string.downloading)) },
+                            supportingContent = { Text(text = "${(progress * 100).toInt()}%") },
+                            leadingContent = {
+                                CircularProgressIndicator(
+                                    progress = { progress.coerceIn(0f, 1f) },
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                coroutineScope.launch {
+                                    downloadUtil.cancelMediaStoreDownload(mediaMetadata.id)
                                 }
-                            )
-                        }
+                            }
+                        )
+                    }
 
-                        else -> {
-                            // Quick download with current quality settings
-                            ListItem(
-                                headlineContent = { Text(text = stringResource(R.string.action_download)) },
-                                leadingContent = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null,
-                                    )
-                                },
-                                modifier = Modifier.clickable {
-                                    coroutineScope.launch(Dispatchers.IO) {
-                                        database.transaction {
-                                            insert(mediaMetadata)
+                    MediaStoreDownloadManager.DownloadState.Status.FAILED,
+                    MediaStoreDownloadManager.DownloadState.Status.CANCELLED,
+                    null -> {
+                        when (download?.state) {
+                            Download.STATE_COMPLETED -> {
+                                ListItem(
+                                    headlineContent = {
+                                        Text(
+                                            text = stringResource(R.string.remove_download),
+                                            color = MaterialTheme.colorScheme.error
+                                        )
+                                    },
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    modifier = Modifier.clickable {
+                                        coroutineScope.launch {
+                                            downloadUtil.removeDownload(mediaMetadata.id)
+                                            Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
                                         }
-                                        val song = database.song(mediaMetadata.id).first()
-                                        song?.let {
-                                            downloadUtil.downloadToMediaStore(it)
+                                    }
+                                )
+                            }
+
+                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
+                                ListItem(
+                                    headlineContent = { Text(text = stringResource(R.string.downloading)) },
+                                    leadingContent = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
+                                        )
+                                    },
+                                    modifier = Modifier.clickable {
+                                        coroutineScope.launch {
+                                            downloadUtil.removeDownload(mediaMetadata.id)
+                                            Toast.makeText(context, context.getString(R.string.download_removed), Toast.LENGTH_SHORT).show()
                                         }
                                     }
-                                }
-                            )
+                                )
+                            }
+
+                            else -> {
+                                // Quick download with current quality settings
+                                ListItem(
+                                    headlineContent = { Text(text = stringResource(R.string.action_download)) },
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    modifier = Modifier.clickable {
+                                        coroutineScope.launch(Dispatchers.IO) {
+                                            database.transaction {
+                                                insert(mediaMetadata)
+                                            }
+                                            val song = database.song(mediaMetadata.id).first()
+                                            song?.let {
+                                                downloadUtil.downloadToMediaStore(it)
+                                            }
+                                        }
+                                        // Don't dismiss - keep menu open
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -109,6 +109,7 @@ fun SongMenu(
     playlistBrowseId: String? = null,
     onDismiss: () -> Unit,
     isFromCache: Boolean = false,
+    isLive: Boolean = false, // For live performances, show both song and video download options
 ) {
     val context = LocalContext.current
     val database = LocalDatabase.current
@@ -146,7 +147,7 @@ fun SongMenu(
             } else {
                 downloadUtil.downloadToMediaStore(song)
             }
-            onDismiss()
+            // Don't dismiss - keep menu open to show download progress
         } else {
             // Permissions denied - show error message
             android.widget.Toast.makeText(
@@ -746,6 +747,52 @@ fun SongMenu(
                     // Skip showing download option for videos when blocked
                     if (isVideo && blockVideos) {
                         null
+                    } else if (isLive && !blockVideos) {
+                        // For live performances, show both song and video download options
+                        Column {
+                            // Download as song option
+                            ListItem(
+                                headlineContent = {
+                                    Text(text = stringResource(R.string.download_song))
+                                },
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.download),
+                                        contentDescription = null,
+                                    )
+                                },
+                                modifier = Modifier.clickable {
+                                    pendingVideoDownload = false
+                                    if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                        downloadUtil.downloadToMediaStore(song)
+                                        // Don't dismiss - keep menu open to show download progress
+                                    } else {
+                                        permissionLauncher.launch(PermissionHelper.getRequiredWritePermissions())
+                                    }
+                                }
+                            )
+                            // Download as video option
+                            ListItem(
+                                headlineContent = {
+                                    Text(text = stringResource(R.string.download_video_to_device))
+                                },
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.slow_motion_video),
+                                        contentDescription = null,
+                                    )
+                                },
+                                modifier = Modifier.clickable {
+                                    pendingVideoDownload = true
+                                    if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                        downloadUtil.downloadVideoToMediaStore(song)
+                                        // Don't dismiss - keep menu open to show download progress
+                                    } else {
+                                        permissionLauncher.launch(PermissionHelper.getRequiredWritePermissions())
+                                    }
+                                }
+                            )
+                        }
                     } else {
                         ListItem(
                             headlineContent = {
@@ -769,7 +816,7 @@ fun SongMenu(
                                     } else {
                                         downloadUtil.downloadToMediaStore(song)
                                     }
-                                    onDismiss()
+                                    // Don't dismiss - keep menu open to show download progress
                                 } else {
                                     val permissions = PermissionHelper.getRequiredWritePermissions()
                                     permissionLauncher.launch(permissions)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -147,7 +147,7 @@ fun SongMenu(
             } else {
                 downloadUtil.downloadToMediaStore(song)
             }
-            // Don't dismiss - keep menu open to show download progress
+            onDismiss()
         } else {
             // Permissions denied - show error message
             android.widget.Toast.makeText(
@@ -671,9 +671,15 @@ fun SongMenu(
                 )
             }
         }
-        item {
-            when (mediaStoreDownload?.status) {
-                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> {
+        // Download section - for live performances (isLive=true), show both song and video download options
+        if (isLive) {
+            // Live performance - check audio download status
+            val hasAudioDownload = song.song.isDownloaded && song.song.mediaStoreUri != null
+            val hasVideoDownload = song.song.videoMediaStoreUri != null
+
+            // Show "Download Song" option (audio)
+            item {
+                if (hasAudioDownload) {
                     ListItem(
                         headlineContent = {
                             Text(
@@ -688,118 +694,94 @@ fun SongMenu(
                             )
                         },
                         modifier = Modifier.clickable {
-                            // TODO: Option to remove from MediaStore
-                            onDismiss()
+                            // Remove audio download
+                            coroutineScope.launch {
+                                downloadUtil.removeDownload(song.id)
+                            }
                         }
                     )
-                }
-                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING,
-                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED -> {
-                    val downloadState = mediaStoreDownload!!
+                } else {
                     ListItem(
-                        headlineContent = {
-                            Text(text = stringResource(R.string.downloading_to_device))
-                        },
-                        supportingContent = {
-                            Text(text = "${(downloadState.progress * 100).toInt()}%")
-                        },
-                        leadingContent = {
-                            CircularProgressIndicator(
-                                progress = { downloadState.progress },
-                                modifier = Modifier.size(24.dp),
-                                strokeWidth = 2.dp
-                            )
-                        },
-                        modifier = Modifier.clickable {
-                            downloadUtil.cancelMediaStoreDownload(song.id)
-                            onDismiss()
-                        }
-                    )
-                }
-                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED -> {
-                    val downloadState = mediaStoreDownload!!
-                    ListItem(
-                        headlineContent = {
-                            Text(
-                                text = stringResource(R.string.download_failed),
-                                color = MaterialTheme.colorScheme.error
-                            )
-                        },
-                        supportingContent = {
-                            Text(text = downloadState.error ?: "Unknown error")
-                        },
+                        headlineContent = { Text(text = stringResource(R.string.download_song)) },
                         leadingContent = {
                             Icon(
-                                painter = painterResource(R.drawable.info),
+                                painter = painterResource(R.drawable.download),
                                 contentDescription = null,
                             )
                         },
                         modifier = Modifier.clickable {
-                            downloadUtil.retryMediaStoreDownload(song.id)
-                            onDismiss()
+                            pendingVideoDownload = false
+                            if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                downloadUtil.downloadToMediaStore(song)
+                                // Don't dismiss - keep menu open
+                            } else {
+                                val permissions = PermissionHelper.getRequiredWritePermissions()
+                                permissionLauncher.launch(permissions)
+                            }
                         }
                     )
                 }
-                else -> {
-                    // Check if this is a video - if so, offer video download (unless videos are blocked)
-                    val isVideo = song.song.isVideo
+            }
 
-                    // Skip showing download option for videos when blocked
-                    if (isVideo && blockVideos) {
-                        null
-                    } else if (isLive && !blockVideos) {
-                        // For live performances, show both song and video download options
-                        Column {
-                            // Download as song option
-                            ListItem(
-                                headlineContent = {
-                                    Text(text = stringResource(R.string.download_song))
-                                },
-                                leadingContent = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null,
-                                    )
-                                },
-                                modifier = Modifier.clickable {
-                                    pendingVideoDownload = false
-                                    if (PermissionHelper.hasMediaStoreWritePermission(context)) {
-                                        downloadUtil.downloadToMediaStore(song)
-                                        // Don't dismiss - keep menu open to show download progress
-                                    } else {
-                                        permissionLauncher.launch(PermissionHelper.getRequiredWritePermissions())
-                                    }
-                                }
-                            )
-                            // Download as video option
-                            ListItem(
-                                headlineContent = {
-                                    Text(text = stringResource(R.string.download_video_to_device))
-                                },
-                                leadingContent = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.slow_motion_video),
-                                        contentDescription = null,
-                                    )
-                                },
-                                modifier = Modifier.clickable {
-                                    pendingVideoDownload = true
-                                    if (PermissionHelper.hasMediaStoreWritePermission(context)) {
-                                        downloadUtil.downloadVideoToMediaStore(song)
-                                        // Don't dismiss - keep menu open to show download progress
-                                    } else {
-                                        permissionLauncher.launch(PermissionHelper.getRequiredWritePermissions())
-                                    }
-                                }
-                            )
-                        }
-                    } else {
+            // Show "Download Video" option (video) - unless videos are blocked
+            if (!blockVideos) {
+                item {
+                    if (hasVideoDownload) {
                         ListItem(
                             headlineContent = {
-                                Text(text = if (isVideo)
-                                    stringResource(R.string.download_video_to_device)
-                                else
-                                    stringResource(R.string.download_to_device))
+                                Text(
+                                    text = stringResource(R.string.downloaded_to_device),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            },
+                            supportingContent = { Text("Video") },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.slow_motion_video),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                // Remove video download
+                                coroutineScope.launch {
+                                    downloadUtil.removeVideoDownload(song.id)
+                                }
+                            }
+                        )
+                    } else {
+                        ListItem(
+                            headlineContent = { Text(text = stringResource(R.string.download_video_to_device)) },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.slow_motion_video),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                pendingVideoDownload = true
+                                if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                    downloadUtil.downloadVideoToMediaStore(song)
+                                    // Don't dismiss - keep menu open
+                                } else {
+                                    val permissions = PermissionHelper.getRequiredWritePermissions()
+                                    permissionLauncher.launch(permissions)
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        } else {
+            // Standard download - single option based on content type
+            item {
+                when (mediaStoreDownload?.status) {
+                    com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> {
+                        ListItem(
+                            headlineContent = {
+                                Text(
+                                    text = stringResource(R.string.downloaded_to_device),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
                             },
                             leadingContent = {
                                 Icon(
@@ -808,21 +790,96 @@ fun SongMenu(
                                 )
                             },
                             modifier = Modifier.clickable {
-                                // Track the user's download choice for permission callback
-                                pendingVideoDownload = isVideo
-                                if (PermissionHelper.hasMediaStoreWritePermission(context)) {
-                                    if (isVideo) {
-                                        downloadUtil.downloadVideoToMediaStore(song)
-                                    } else {
-                                        downloadUtil.downloadToMediaStore(song)
-                                    }
-                                    // Don't dismiss - keep menu open to show download progress
-                                } else {
-                                    val permissions = PermissionHelper.getRequiredWritePermissions()
-                                    permissionLauncher.launch(permissions)
+                                // Remove download
+                                coroutineScope.launch {
+                                    downloadUtil.removeDownload(song.id)
                                 }
                             }
                         )
+                    }
+                    com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING,
+                    com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED -> {
+                        val downloadState = mediaStoreDownload!!
+                        ListItem(
+                            headlineContent = {
+                                Text(text = stringResource(R.string.downloading_to_device))
+                            },
+                            supportingContent = {
+                                Text(text = "${(downloadState.progress * 100).toInt()}%")
+                            },
+                            leadingContent = {
+                                CircularProgressIndicator(
+                                    progress = { downloadState.progress },
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                downloadUtil.cancelMediaStoreDownload(song.id)
+                            }
+                        )
+                    }
+                    com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED -> {
+                        val downloadState = mediaStoreDownload!!
+                        ListItem(
+                            headlineContent = {
+                                Text(
+                                    text = stringResource(R.string.download_failed),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            supportingContent = {
+                                Text(text = downloadState.error ?: "Unknown error")
+                            },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.info),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                downloadUtil.retryMediaStoreDownload(song.id)
+                            }
+                        )
+                    }
+                    else -> {
+                        // Check if this is a video - if so, offer video download (unless videos are blocked)
+                        val isVideo = song.song.isVideo
+
+                        // Skip showing download option for videos when blocked
+                        if (isVideo && blockVideos) {
+                            null
+                        } else {
+                            ListItem(
+                                headlineContent = {
+                                    Text(text = if (isVideo)
+                                        stringResource(R.string.download_video_to_device)
+                                    else
+                                        stringResource(R.string.download_to_device))
+                                },
+                                leadingContent = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.download),
+                                        contentDescription = null,
+                                    )
+                                },
+                                modifier = Modifier.clickable {
+                                    // Track the user's download choice for permission callback
+                                    pendingVideoDownload = isVideo
+                                    if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                        if (isVideo) {
+                                            downloadUtil.downloadVideoToMediaStore(song)
+                                        } else {
+                                            downloadUtil.downloadToMediaStore(song)
+                                        }
+                                        // Don't dismiss - keep menu open
+                                    } else {
+                                        val permissions = PermissionHelper.getRequiredWritePermissions()
+                                        permissionLauncher.launch(permissions)
+                                    }
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -107,6 +107,7 @@ fun YouTubeSongMenu(
     onDismiss: () -> Unit,
     onHistoryRemoved: () -> Unit = {},
     isVideo: Boolean = false,
+    isLive: Boolean = false, // For live performances, show both song and video download options
 ) {
     val context = LocalContext.current
     val auth = remember { FirebaseAuth.getInstance() }
@@ -651,6 +652,56 @@ fun YouTubeSongMenu(
                             // Skip showing download option for videos when blocked
                             if (isVideo && blockVideos) {
                                 null
+                            } else if (isLive && !blockVideos) {
+                                // For live performances, show both song and video download options
+                                Column {
+                                    // Download as song option
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(text = stringResource(R.string.download_song))
+                                        },
+                                        leadingContent = {
+                                            Icon(
+                                                painter = painterResource(R.drawable.download),
+                                                contentDescription = null,
+                                            )
+                                        },
+                                        modifier = Modifier.clickable {
+                                            coroutineScope.launch(Dispatchers.IO) {
+                                                val metadata = song.toMediaMetadata().copy(isVideo = false)
+                                                database.transaction {
+                                                    insert(metadata)
+                                                    setIsVideo(song.id, false)
+                                                }
+                                                val dbSong = database.song(song.id).first()
+                                                dbSong?.let { downloadUtil.downloadToMediaStore(it) }
+                                            }
+                                        }
+                                    )
+                                    // Download as video option
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(text = stringResource(R.string.download_video_to_device))
+                                        },
+                                        leadingContent = {
+                                            Icon(
+                                                painter = painterResource(R.drawable.slow_motion_video),
+                                                contentDescription = null,
+                                            )
+                                        },
+                                        modifier = Modifier.clickable {
+                                            coroutineScope.launch(Dispatchers.IO) {
+                                                val metadata = song.toMediaMetadata().copy(isVideo = true)
+                                                database.transaction {
+                                                    insert(metadata)
+                                                    setIsVideo(song.id, true)
+                                                }
+                                                val dbSong = database.song(song.id).first()
+                                                dbSong?.let { downloadUtil.downloadVideoToMediaStore(it) }
+                                            }
+                                        }
+                                    )
+                                }
                             } else {
                                 ListItem(
                                     headlineContent = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -1073,6 +1073,7 @@ fun BottomSheetPlayer(
                                         mediaMetadata = mediaMetadata,
                                         navController = navController,
                                         playerBottomSheetState = state,
+                                        isLive = mediaMetadata.isVideo, // Live performances can download both audio and video
                                         onShowDetailsDialog = {
                                             mediaMetadata.id.let {
                                                 bottomSheetPageState.show {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
@@ -366,6 +366,7 @@ fun Queue(
                                         mediaMetadata = mediaMetadata,
                                         navController = navController,
                                         playerBottomSheetState = playerBottomSheetState,
+                                        isLive = mediaMetadata?.isVideo == true, // Live performances can download both audio and video
                                         onShowDetailsDialog = {
                                             mediaMetadata?.id?.let {
                                                 bottomSheetPageState.show {
@@ -737,6 +738,7 @@ fun Queue(
                                                         navController = navController,
                                                         playerBottomSheetState = playerBottomSheetState,
                                                         isQueueTrigger = true,
+                                                        isLive = window.mediaItem.metadata?.isVideo == true, // Live performances can download both audio and video
                                                         onShowDetailsDialog = {
                                                             window.mediaItem.mediaId.let {
                                                                 bottomSheetPageState.show {
@@ -875,6 +877,7 @@ fun Queue(
                                                     navController = navController,
                                                     playerBottomSheetState = playerBottomSheetState,
                                                     isQueueTrigger = true,
+                                                    isLive = item.metadata?.isVideo == true, // Live performances can download both audio and video
                                                     onShowDetailsDialog = {
                                                         item.mediaId.let {
                                                             bottomSheetPageState.show {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -111,7 +111,10 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.screens.videoRoute
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TextButton
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.fadingEdge
 import com.jtech.zemer.ui.utils.resize
@@ -153,6 +156,11 @@ fun ArtistScreen(
     val lazyListState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
     var showLocal by rememberSaveable { mutableStateOf(false) }
+
+    // Live performance dialog state
+    var showLivePlaybackDialog by remember { mutableStateOf(false) }
+    var selectedLiveItem by remember { mutableStateOf<SongItem?>(null) }
+
     val density = LocalDensity.current
 
     // Calculate the offset value outside of the offset lambda
@@ -175,6 +183,97 @@ fun ArtistScreen(
     LaunchedEffect(artistPage, libraryArtist, showLocal) {
         if (artistPage != null || libraryArtist != null || showLocal) {
             firstFocus.requestFocus()
+        }
+    }
+
+    // Live performance playback type dialog
+    if (showLivePlaybackDialog && selectedLiveItem != null) {
+        DefaultDialog(
+            onDismiss = {
+                showLivePlaybackDialog = false
+                selectedLiveItem = null
+            },
+            title = { Text(stringResource(R.string.live_performance)) },
+            buttons = {
+                TextButton(onClick = {
+                    showLivePlaybackDialog = false
+                    selectedLiveItem = null
+                }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Play as song option
+                Surface(
+                    onClick = {
+                        selectedLiveItem?.let { item ->
+                            playerConnection.playQueue(
+                                YouTubeQueue(
+                                    WatchEndpoint(videoId = item.id),
+                                    item.toMediaMetadata(isLive = true),
+                                    database
+                                ),
+                            )
+                        }
+                        showLivePlaybackDialog = false
+                        selectedLiveItem = null
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.music_note),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(R.string.play_as_song),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+
+                // Play as video option
+                Surface(
+                    onClick = {
+                        selectedLiveItem?.let { item ->
+                            val artistDisplay = item.artists.joinToString(" • ") { it.name }
+                            navController.navigate(videoRoute(item.id, item.title, artistDisplay))
+                        }
+                        showLivePlaybackDialog = false
+                        selectedLiveItem = null
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.slow_motion_video),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(R.string.play_as_video),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -591,16 +690,18 @@ fun ArtistScreen(
                 } else {
                     artistPage?.sections?.fastForEach { section ->
                         val distinctItems = section.items.distinctBy { it.id }
+                        // Detect if this is a video or live section
                         val isVideoSection = section.title.contains("video", ignoreCase = true) ||
                             section.title.contains("short", ignoreCase = true)
+                        val isLiveSection = section.title.contains("live", ignoreCase = true)
 
-                        // Skip video sections entirely if videos are blocked
-                        if (isVideoSection && blockVideos) {
+                        // Skip video/live sections entirely if videos are blocked
+                        if ((isVideoSection || isLiveSection) && blockVideos) {
                             return@fastForEach
                         }
 
                         val visibleCount = visibleCounts.getOrPut(section.title) {
-                            if (isVideoSection) minOf(8, distinctItems.size) else distinctItems.size
+                            if (isVideoSection || isLiveSection) minOf(8, distinctItems.size) else distinctItems.size
                         }
                         val displayItems = distinctItems.take(visibleCount)
 
@@ -667,10 +768,14 @@ fun ArtistScreen(
                                     modifier = Modifier
                                         .combinedClickable(
                                             onClick = {
-                                                if (isVideoSection && !blockVideos) {
+                                                if (isLiveSection && !blockVideos) {
+                                                    // Show dialog to choose between song and video playback
+                                                    selectedLiveItem = song
+                                                    showLivePlaybackDialog = true
+                                                } else if (isVideoSection && !blockVideos) {
                                                     val artistDisplay = song.artists.joinToString(" • ") { it.name }
                                                     navController.navigate(videoRoute(song.id, song.title, artistDisplay))
-                                                } else if (!isVideoSection) {
+                                                } else if (!isVideoSection && !isLiveSection) {
                                                     if (song.id == mediaMetadata?.id) {
                                                         playerConnection.player.togglePlayPause()
                                                     } else {
@@ -691,6 +796,7 @@ fun ArtistScreen(
                                                         song = song,
                                                         navController = navController,
                                                         onDismiss = menuState::dismiss,
+                                                        isLive = isLiveSection,
                                                     )
                                                 }
                                             },
@@ -707,7 +813,7 @@ fun ArtistScreen(
                                         items = displayItems,
                                         key = { index, item -> "youtube_album_${item.id}_$index" },
                                     ) { index, item ->
-                                        if (isVideoSection && index >= displayItems.size - 3 && visibleCount < distinctItems.size) {
+                                        if ((isVideoSection || isLiveSection) && index >= displayItems.size - 3 && visibleCount < distinctItems.size) {
                                             visibleCounts[section.title] = minOf(visibleCount + 6, distinctItems.size)
                                         }
                                         YouTubeGridItem(
@@ -720,14 +826,18 @@ fun ArtistScreen(
                                             },
                                             isPlaying = isPlaying,
                                             coroutineScope = coroutineScope,
-                                            thumbnailRatio = if (isVideoSection) 1f else if (item is SongItem) 16f / 9 else 1f,
+                                            thumbnailRatio = if (isVideoSection || isLiveSection) 1f else if (item is SongItem) 16f / 9 else 1f,
                                             modifier = Modifier
                                                 .combinedClickable(
                                                     onClick = {
-                                                        if (isVideoSection && item is SongItem && !blockVideos) {
+                                                        if (isLiveSection && item is SongItem && !blockVideos) {
+                                                            // Show dialog to choose between song and video playback
+                                                            selectedLiveItem = item
+                                                            showLivePlaybackDialog = true
+                                                        } else if (isVideoSection && item is SongItem && !blockVideos) {
                                                             val artistDisplay = item.artists.joinToString(" • ") { it.name }
                                                             navController.navigate(videoRoute(item.id, item.title, artistDisplay))
-                                                        } else if (!isVideoSection) {
+                                                        } else if (!isVideoSection && !isLiveSection) {
                                                             when (item) {
                                                                 is SongItem -> {
                                                                     playerConnection.playQueue(
@@ -754,6 +864,7 @@ fun ArtistScreen(
                                                                         navController = navController,
                                                                         onDismiss = menuState::dismiss,
                                                                         isVideo = isVideoSection,
+                                                                        isLive = isLiveSection,
                                                                     )
 
                                                                 is AlbumItem ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <!-- MediaStore downloads -->
     <string name="download_to_device">Download</string>
     <string name="download_video_to_device">Download Video</string>
+    <string name="download_song">Download Song</string>
     <string name="downloading_to_device">Downloading</string>
     <string name="downloaded_to_device">Downloaded</string>
     <string name="download_failed">Download failed</string>
@@ -561,4 +562,9 @@
     <string name="widget_name">Zemer Music</string>
     <string name="widget_description">Control your music playback</string>
     <string name="widget_tap_to_open">Tap to open</string>
+
+    <!-- Live Performance -->
+    <string name="live_performance">Live Performance</string>
+    <string name="play_as_song">Play as song</string>
+    <string name="play_as_video">Play as video</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,8 +111,8 @@
 
     <!-- MediaStore downloads -->
     <string name="download_to_device">Download</string>
-    <string name="download_video_to_device">Download Video</string>
     <string name="download_song">Download Song</string>
+    <string name="download_video_to_device">Download Video</string>
     <string name="downloading_to_device">Downloading</string>
     <string name="downloaded_to_device">Downloaded</string>
     <string name="download_failed">Download failed</string>


### PR DESCRIPTION
## Summary
- Add `isLive` property to MediaMetadata for tracking live content
- Add live performance playback dialog on ArtistScreen (play as song or video)
- Detect live sections on artist pages alongside video sections
- Add `isLive` parameter to YouTubeSongMenu for context-aware menus

## Test plan
- [ ] Navigate to an artist with live performances section
- [ ] Tap on a live performance item
- [ ] Verify dialog appears with "Play as song" and "Play as video" options
- [ ] Test both playback options work correctly