### PR TITLE
feat: anonymous login improvements and local-to-YouTube sync

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -127,7 +127,7 @@ class App : Application(), SingletonImageLoader.Factory {
         try {
             val httpClient = HttpClient()
             val responseText = httpClient.get(
-                "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                "https://mc.alltech.dev/credentials?refresh=1"
             ).bodyAsText()
 
             val json = kotlinx.serialization.json.Json.parseToJsonElement(responseText)
@@ -209,7 +209,7 @@ class App : Application(), SingletonImageLoader.Factory {
                 try {
                     val httpClient = HttpClient()
                     val responseText = httpClient.get(
-                        "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                        "https://mc.alltech.dev/credentials?refresh=1"
                     ).bodyAsText()
                     httpClient.close()
 

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -202,6 +202,12 @@ class App : Application(), SingletonImageLoader.Factory {
 
         // Migration: Detect login method for existing users who don't have it set
         val loginMethod = settings[LoginMethodKey]
+
+        // Restore isAnonLogin flag from persisted login method
+        if (loginMethod == "anonymous") {
+            YouTube.isAnonLogin = true
+        }
+
         val userCookie = settings[InnerTubeCookieKey]
         if (loginMethod.isNullOrEmpty() && !userCookie.isNullOrEmpty() && "SAPISID" in parseCookieString(userCookie)) {
             // User is logged in but doesn't have login method set - detect by comparing with anonymous token
@@ -432,6 +438,7 @@ class App : Application(), SingletonImageLoader.Factory {
             YouTube.cookie = null
             YouTube.visitorData = null
             YouTube.dataSyncId = null
+            YouTube.isAnonLogin = false
 
             Log.d("App", "Account forgotten - cookies cleared for new account login")
         }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1720,17 +1720,32 @@ class MusicService :
         bypassCacheForQualityChange.add(mediaId)
         Timber.tag("QualitySwitch").i("Set bypass cache flag for $mediaId")
 
-        // Stop and restart from current position
-        // Position is preserved since different streams have same time-to-byte mapping
-        Timber.tag("QualitySwitch").i("Stopping player, restarting from position=$currentPosition, wasPlaying=$wasPlaying")
+        // Completely kill and restart the player to force fresh URL fetch
+        // Simply calling stop()/prepare() may not re-fetch the URL if media item is cached internally
+        Timber.tag("QualitySwitch").i("Killing player, will restart from position=$currentPosition, wasPlaying=$wasPlaying")
+
+        // Get the current media item to re-add it
+        val currentMediaItem = player.currentMediaItem
+        if (currentMediaItem == null) {
+            Timber.tag("QualitySwitch").e("No current media item to reload!")
+            return
+        }
+
+        // Stop the player completely
         player.stop()
-        player.seekTo(currentIndex, currentPosition)
-        Timber.tag("QualitySwitch").i("Calling prepare() - this should trigger ResolvingDataSource")
+
+        // Remove and re-add the media item to force ExoPlayer to re-resolve the URL
+        player.removeMediaItem(currentIndex)
+        player.addMediaItem(currentIndex, currentMediaItem)
+
+        // Prepare and seek to saved position
         player.prepare()
+        player.seekTo(currentIndex, currentPosition)
+
         if (wasPlaying) {
             player.play()
         }
-        Timber.tag("QualitySwitch").i("=== RELOAD END === mediaId=$mediaId")
+        Timber.tag("QualitySwitch").i("=== RELOAD END === mediaId=$mediaId, restarting at position=$currentPosition")
     }
 
     override fun onDestroy() {

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -475,6 +475,45 @@ class MusicService :
                 }
         }
 
+        // Observe visitor data changes
+        scope.launch {
+            dataStore.data
+                .map { it[com.jtech.zemer.constants.VisitorDataKey] }
+                .distinctUntilChanged()
+                .collect { visitorData ->
+                    YouTube.visitorData = visitorData?.takeIf { it != "null" }
+                    songUrlCache.clear()
+                    android.util.Log.d("MusicService", "Visitor data changed: ${visitorData?.take(20)}...")
+                }
+        }
+
+        // Observe data sync ID changes
+        scope.launch {
+            dataStore.data
+                .map { it[com.jtech.zemer.constants.DataSyncIdKey] }
+                .distinctUntilChanged()
+                .collect { dataSyncId ->
+                    YouTube.dataSyncId = dataSyncId?.let {
+                        it.takeIf { !it.contains("||") }
+                            ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
+                            ?: it.substringAfter("||")
+                    }
+                    android.util.Log.d("MusicService", "DataSyncId changed")
+                }
+        }
+
+        // Observe login method changes to update isAnonLogin flag
+        scope.launch {
+            dataStore.data
+                .map { it[com.jtech.zemer.constants.LoginMethodKey] }
+                .distinctUntilChanged()
+                .collect { loginMethod ->
+                    YouTube.isAnonLogin = loginMethod == "anonymous"
+                    songUrlCache.clear()
+                    android.util.Log.d("MusicService", "Login method changed: $loginMethod, isAnonLogin=${YouTube.isAnonLogin}")
+                }
+        }
+
         if (dataStore.get(PersistentQueueKey, true)) {
             runCatching {
                 filesDir.resolve(PERSISTENT_QUEUE_FILE).inputStream().use { fis ->

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -801,27 +801,29 @@ class MusicService :
             ?: (playbackData?.videoDetails ?: YTPlayerUtils.playerResponseForMetadata(mediaId)
                 .getOrNull()?.videoDetails)?.lengthSeconds?.toInt()
             ?: -1
-        database.query {
-            if (song == null) insert(mediaMetadata.copy(duration = duration))
-            else if (song.song.duration == -1) update(song.song.copy(duration = duration))
-        }
-        if (!database.hasRelatedSongs(mediaId)) {
+
+        // Fetch related songs data outside of transaction
+        val relatedSongsToInsert = if (!database.hasRelatedSongs(mediaId)) {
             val relatedEndpoint =
                 YouTube.next(WatchEndpoint(videoId = mediaId)).getOrNull()?.relatedEndpoint
-                    ?: return
-            val relatedPage = YouTube.related(relatedEndpoint).getOrNull() ?: return
-            val filteredSongs = relatedPage.songs.filterWhitelisted(database).filterIsInstance<SongItem>()
-            database.query {
-                filteredSongs
-                    .map(SongItem::toMediaMetadata)
-                    .onEach(::insert)
-                    .map {
-                        RelatedSongMap(
-                            songId = mediaId,
-                            relatedSongId = it.id
-                        )
-                    }
-                    .forEach(::insert)
+            val relatedPage = relatedEndpoint?.let { YouTube.related(it).getOrNull() }
+            relatedPage?.songs?.filterWhitelisted(database)?.filterIsInstance<SongItem>()
+                ?.map(SongItem::toMediaMetadata)
+        } else null
+
+        // Do ALL inserts in a single transaction to avoid foreign key issues
+        database.query {
+            // First ensure the main song exists
+            if (song == null) insert(mediaMetadata.copy(duration = duration))
+            else if (song.song.duration == -1) update(song.song.copy(duration = duration))
+
+            // Then insert related songs and their mappings
+            relatedSongsToInsert?.forEach { relatedMetadata ->
+                insert(relatedMetadata)
+                insert(RelatedSongMap(
+                    songId = mediaId,
+                    relatedSongId = relatedMetadata.id
+                ))
             }
         }
     }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -334,58 +334,42 @@ class MusicService :
             ?: throw IllegalStateException("ConnectivityManager not available on this device")
         connectivityObserver = NetworkConnectivityObserver(this)
 
-        // Initialize audioQuality from preference and reload on change
+        // Combine all quality-related settings and debounce to prevent multiple reloads
+        // when user changes both bitrate and client at once
         scope.launch {
             var isFirstEmit = true
-            audioQualityFlow.collect { quality ->
+            combine(
+                audioQualityFlow,
+                audioBitrateFlow,
+                preferredClientFlow
+            ) { quality, bitrate, client ->
+                Triple(quality, bitrate, client)
+            }.debounce(100) // Wait 100ms to batch rapid changes
+            .collect { (quality, bitrate, client) ->
                 val previousQuality = audioQuality
-                audioQuality = quality
-                Timber.tag("QualitySwitch").i("*** QUALITY CHANGED: $previousQuality -> $quality (isFirstEmit=$isFirstEmit, hasMediaItem=${player.currentMediaItem != null})")
-
-                // Reload current song if quality changed (skip first emit which is initialization)
-                if (!isFirstEmit && previousQuality != quality && player.currentMediaItem != null) {
-                    Timber.tag("QualitySwitch").i("Triggering reload for quality change")
-                    reloadCurrentSong("quality changed to $quality")
-                } else {
-                    Timber.tag("QualitySwitch").i("NOT reloading: isFirstEmit=$isFirstEmit, sameQuality=${previousQuality == quality}")
-                }
-                isFirstEmit = false
-            }
-        }
-
-        // Initialize audioBitrate from preference and reload on change
-        scope.launch {
-            var isFirstEmit = true
-            audioBitrateFlow.collect { bitrate ->
                 val previousBitrate = audioBitrate
-                audioBitrate = bitrate
-                Timber.tag("QualitySwitch").i("*** BITRATE CHANGED: ${previousBitrate}kbps -> ${bitrate}kbps (isFirstEmit=$isFirstEmit)")
-
-                // Reload current song if bitrate changed (skip first emit which is initialization)
-                if (!isFirstEmit && previousBitrate != bitrate && player.currentMediaItem != null) {
-                    Timber.tag("QualitySwitch").i("Triggering reload for bitrate change")
-                    reloadCurrentSong("bitrate changed to ${bitrate}kbps")
-                } else {
-                    Timber.tag("QualitySwitch").i("NOT reloading: isFirstEmit=$isFirstEmit, sameBitrate=${previousBitrate == bitrate}")
-                }
-                isFirstEmit = false
-            }
-        }
-
-        // Initialize preferredClient from preference and reload on change
-        scope.launch {
-            var isFirstEmit = true
-            preferredClientFlow.collect { client ->
                 val previousClient = preferredClient
-                preferredClient = client
-                Timber.tag("QualitySwitch").i("*** CLIENT CHANGED: $previousClient -> $client (isFirstEmit=$isFirstEmit)")
 
-                // Reload current song if client changed (skip first emit which is initialization)
-                if (!isFirstEmit && previousClient != client && player.currentMediaItem != null) {
-                    Timber.tag("QualitySwitch").i("Triggering reload for client change")
-                    reloadCurrentSong("client changed to $client")
-                } else {
-                    Timber.tag("QualitySwitch").i("NOT reloading: isFirstEmit=$isFirstEmit, sameClient=${previousClient == client}")
+                audioQuality = quality
+                audioBitrate = bitrate
+                preferredClient = client
+
+                val qualityChanged = previousQuality != quality
+                val bitrateChanged = previousBitrate != bitrate
+                val clientChanged = previousClient != client
+                val anyChanged = qualityChanged || bitrateChanged || clientChanged
+
+                Timber.tag("QualitySwitch").i("*** SETTINGS: quality=$quality, bitrate=${bitrate}kbps, client=$client (isFirstEmit=$isFirstEmit, changed=$anyChanged)")
+
+                // Reload current song if any setting changed (skip first emit which is initialization)
+                if (!isFirstEmit && anyChanged && player.currentMediaItem != null) {
+                    val reasons = listOfNotNull(
+                        if (qualityChanged) "quality=$quality" else null,
+                        if (bitrateChanged) "bitrate=${bitrate}kbps" else null,
+                        if (clientChanged) "client=$client" else null
+                    ).joinToString(", ")
+                    Timber.tag("QualitySwitch").i("Triggering reload: $reasons")
+                    reloadCurrentSong(reasons)
                 }
                 isFirstEmit = false
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -351,13 +351,13 @@ fun BottomSheetPlayer(
     val loginMethod by remember {
         context.dataStore.data.map { it[LoginMethodKey] ?: "" }
     }.collectAsState(initial = "")
-    // Google login: all clients, Anonymous: only VR
-    val availableClients = if (loginMethod == "anonymous") {
-        listOf(PreferredClient.AUTO, PreferredClient.ANDROID_VR)
-    } else {
-        // "google" or empty (legacy users default to full access)
-        listOf(PreferredClient.AUTO, PreferredClient.WEB_REMIX, PreferredClient.TVHTML5, PreferredClient.ANDROID_VR)
-    }
+    // All clients available for both Google and Anonymous login
+    val availableClients = listOf(
+        PreferredClient.AUTO,
+        PreferredClient.WEB_REMIX,
+        PreferredClient.TVHTML5,
+        PreferredClient.ANDROID_VR
+    )
     val (audioBitrate, onAudioBitrateChange) = rememberPreference(AudioBitrateKey, defaultValue = 0)
     val (preferredClient, onPreferredClientChange) = rememberEnumPreference(PreferredClientKey, defaultValue = PreferredClient.AUTO)
     val qualityCoroutineScope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -544,6 +544,7 @@ fun BottomSheetPlayer(
                                     onPreferredClientChange(client)
                                     val videoId = mediaMetadata?.id
                                     if (videoId != null) {
+                                        availableFormats = emptyList() // Clear to show loading indicator
                                         isLoadingFormats = true
                                         qualityCoroutineScope.launch {
                                             val result = withContext(Dispatchers.IO) {
@@ -569,6 +570,7 @@ fun BottomSheetPlayer(
                                     onPreferredClientChange(client)
                                     val videoId = mediaMetadata?.id
                                     if (videoId != null) {
+                                        availableFormats = emptyList() // Clear to show loading indicator
                                         isLoadingFormats = true
                                         qualityCoroutineScope.launch {
                                             val result = withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -478,11 +478,14 @@ fun BottomSheetPlayer(
                     // Format options - show what's actually playing based on currentFormat
                     // Convert current format bitrate from bps to kbps for comparison
                     val actualPlayingBitrateKbps = currentFormat?.bitrate?.div(1000) ?: 0
+                    // Find the closest matching format to avoid selecting multiple
+                    val closestFormat = if (actualPlayingBitrateKbps > 0 && availableFormats.isNotEmpty()) {
+                        availableFormats.minByOrNull { kotlin.math.abs(it.bitrateKbps - actualPlayingBitrateKbps) }
+                    } else null
                     if (availableFormats.isNotEmpty()) {
                         availableFormats.forEach { format ->
-                            // Check if this format is actually playing (within 10% tolerance for rounding)
-                            val isActuallyPlaying = actualPlayingBitrateKbps > 0 &&
-                                kotlin.math.abs(actualPlayingBitrateKbps - format.bitrateKbps) < (format.bitrateKbps * 0.1)
+                            // Only select the single closest matching format
+                            val isActuallyPlaying = format == closestFormat
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -225,6 +225,7 @@ fun BottomSheetPlayer(
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    val currentFormat by playerConnection.currentFormat.collectAsState(initial = null)
     val automix by playerConnection.service.automixItems.collectAsState()
     val repeatMode by playerConnection.repeatMode.collectAsState()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
@@ -474,9 +475,14 @@ fun BottomSheetPlayer(
                         )
                     }
 
-                    // Format options
+                    // Format options - show what's actually playing based on currentFormat
+                    // Convert current format bitrate from bps to kbps for comparison
+                    val actualPlayingBitrateKbps = currentFormat?.bitrate?.div(1000) ?: 0
                     if (availableFormats.isNotEmpty()) {
                         availableFormats.forEach { format ->
+                            // Check if this format is actually playing (within 10% tolerance for rounding)
+                            val isActuallyPlaying = actualPlayingBitrateKbps > 0 &&
+                                kotlin.math.abs(actualPlayingBitrateKbps - format.bitrateKbps) < (format.bitrateKbps * 0.1)
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -488,7 +494,7 @@ fun BottomSheetPlayer(
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 RadioButton(
-                                    selected = audioBitrate == format.bitrateKbps,
+                                    selected = isActuallyPlaying,
                                     onClick = {
                                         onAudioBitrateChange(format.bitrateKbps)
                                         showQualityDialog = false
@@ -1003,8 +1009,10 @@ fun BottomSheetPlayer(
                                     color = iconButtonColor
                                 )
                             } else {
+                                // Show actual playing bitrate, not just the preference
+                                val actualBitrateKbps = currentFormat?.bitrate?.div(1000) ?: 0
                                 Text(
-                                    text = if (audioBitrate > 0) "${audioBitrate}k" else stringResource(R.string.audio_quality),
+                                    text = if (actualBitrateKbps > 0) "${actualBitrateKbps}k" else stringResource(R.string.audio_quality),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = iconButtonColor
                                 )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
@@ -156,7 +156,7 @@ fun LoginGateScreen(
                             try {
                                 val httpClient = HttpClient()
                                 val responseText = httpClient.get(
-                                    "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                                    "https://mc.alltech.dev/credentials?refresh=1"
                                 ).bodyAsText()
 
                                 val json = Json.parseToJsonElement(responseText)
@@ -196,6 +196,9 @@ fun LoginGateScreen(
                                     fetchedAccountName?.let { accountName = it }
                                     fetchedAccountEmail?.let { accountEmail = it }
                                     fetchedAccountChannelHandle?.let { accountChannelHandle = it }
+
+                                    // Enable anon login mode for stream validation skip
+                                    YouTube.isAnonLogin = true
 
                                     // Small delay to let preferences propagate before navigating
                                     kotlinx.coroutines.delay(100)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -413,8 +413,9 @@ fun AccountSettings(
                     .background(MaterialTheme.colorScheme.surface)
             )
 
-            // Only show sync options for non-anonymous logged in users (use persisted loginMethod, not static flag)
-            if (loginMethod != "anonymous") {
+            // Only show sync options for non-anonymous logged in users
+            // Check both: static flag (immediate effect during session) AND persisted preference (after restart)
+            if (loginMethod != "anonymous" && !YouTube.isAnonLogin) {
                 Spacer(Modifier.height(4.dp))
 
                 SwitchPreference(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -76,6 +76,7 @@ import com.jtech.zemer.utils.Updater
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.AccountSettingsViewModel
 import com.jtech.zemer.viewmodels.HomeViewModel
+import com.jtech.zemer.LocalSyncUtils
 import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.innertube.YouTube
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
@@ -115,6 +116,11 @@ fun AccountSettings(
     var tokenTestResult by remember { mutableStateOf<String?>(null) }
     var showLogoutDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+
+    // Sync local to YouTube
+    val syncUtils = LocalSyncUtils.current
+    val isPushingToRemote by syncUtils.isPushingToRemote.collectAsState()
+    var pushSyncResult by remember { mutableStateOf<String?>(null) }
 
     Column(
         modifier = Modifier
@@ -419,6 +425,47 @@ fun AccountSettings(
                     .clip(RoundedCornerShape(16.dp))
                     .background(MaterialTheme.colorScheme.surface)
             )
+
+            // Only show for non-anonymous logged in users
+            if (!YouTube.isAnonLogin) {
+                Spacer(Modifier.height(4.dp))
+
+                PreferenceEntry(
+                    title = {
+                        Text(
+                            if (isPushingToRemote) stringResource(R.string.syncing)
+                            else stringResource(R.string.sync_local_to_youtube)
+                        )
+                    },
+                    description = pushSyncResult ?: stringResource(R.string.sync_local_to_youtube_desc),
+                    icon = {
+                        if (isPushingToRemote) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(painterResource(R.drawable.backup), null)
+                        }
+                    },
+                    onClick = {
+                        if (!isPushingToRemote) {
+                            scope.launch {
+                                pushSyncResult = null
+                                syncUtils.pushLocalToYouTube().onSuccess { count ->
+                                    pushSyncResult = "Synced $count items"
+                                }.onFailure { e ->
+                                    pushSyncResult = "Failed: ${e.message}"
+                                }
+                            }
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surface)
+                )
+            }
         }
 
         Spacer(Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -191,7 +191,7 @@ fun AccountSettings(
                         try {
                             val httpClient = HttpClient()
                             val responseText = httpClient.get(
-                                "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                                "https://mc.alltech.dev/credentials?refresh=1"
                             ).bodyAsText()
 
                             val json = kotlinx.serialization.json.Json.parseToJsonElement(responseText)
@@ -232,8 +232,10 @@ fun AccountSettings(
                                 fetchedAccountEmail?.let { onAccountEmailChange(it) }
                                 fetchedAccountChannelHandle?.let { onAccountChannelHandleChange(it) }
                                 onLoginMethodChange("anonymous")
+                                // Enable anon login mode for stream validation skip
+                                YouTube.isAnonLogin = true
                                 tokenTestResult = "success"
-                                android.util.Log.i("TokenTest", "✓ Anonymous token valid!")
+                                android.util.Log.i("TokenTest", "✓ Anonymous token valid! isAnonLogin=${YouTube.isAnonLogin}")
                                 Toast.makeText(
                                     context,
                                     context.getString(R.string.login_success_restart),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -96,7 +96,7 @@ fun AccountSettings(
     val (innerTubeCookie, onInnerTubeCookieChange) = rememberPreference(InnerTubeCookieKey, "")
     val (visitorData, onVisitorDataChange) = rememberPreference(VisitorDataKey, "")
     val (dataSyncId, onDataSyncIdChange) = rememberPreference(DataSyncIdKey, "")
-    val (_, onLoginMethodChange) = rememberPreference(LoginMethodKey, "")
+    val (loginMethod, onLoginMethodChange) = rememberPreference(LoginMethodKey, "")
 
     val isLoggedIn = remember(innerTubeCookie) {
         "SAPISID" in parseCookieString(innerTubeCookie)
@@ -413,21 +413,21 @@ fun AccountSettings(
                     .background(MaterialTheme.colorScheme.surface)
             )
 
-            Spacer(Modifier.height(4.dp))
+            // Only show sync options for non-anonymous logged in users (use persisted loginMethod, not static flag)
+            if (loginMethod != "anonymous") {
+                Spacer(Modifier.height(4.dp))
 
-            SwitchPreference(
-                title = { Text(stringResource(R.string.yt_sync)) },
-                icon = { Icon(painterResource(R.drawable.cached), null) },
-                checked = ytmSync,
-                onCheckedChange = onYtmSyncChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(MaterialTheme.colorScheme.surface)
-            )
+                SwitchPreference(
+                    title = { Text(stringResource(R.string.yt_sync)) },
+                    icon = { Icon(painterResource(R.drawable.cached), null) },
+                    checked = ytmSync,
+                    onCheckedChange = onYtmSyncChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surface)
+                )
 
-            // Only show for non-anonymous logged in users
-            if (!YouTube.isAnonLogin) {
                 Spacer(Modifier.height(4.dp))
 
                 PreferenceEntry(

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -85,6 +85,45 @@ class SyncUtils @Inject constructor(
         }
     }
 
+    private val _isPushingToRemote = MutableStateFlow(false)
+    val isPushingToRemote: StateFlow<Boolean> = _isPushingToRemote.asStateFlow()
+
+    /**
+     * Push local data to YouTube account.
+     * For users who were previously logged in anonymously.
+     */
+    suspend fun pushLocalToYouTube(): Result<Int> = withContext(Dispatchers.IO) {
+        if (_isPushingToRemote.value) return@withContext Result.failure(Exception("Sync in progress"))
+        if (YouTube.isAnonLogin) return@withContext Result.failure(Exception("Login required"))
+
+        _isPushingToRemote.value = true
+        var count = 0
+
+        try {
+            // Push liked songs
+            database.likedSongsByNameAsc().first().forEach { song ->
+                YouTube.likeVideo(song.id, true).onSuccess { count++ }
+            }
+
+            // Push subscribed artists
+            database.artistsBookmarkedByNameAsc().first().forEach { artist ->
+                val channelId = artist.artist.channelId ?: YouTube.getChannelId(artist.id).takeIf { it.isNotEmpty() }
+                channelId?.let { YouTube.subscribeChannel(it, true).onSuccess { count++ } }
+            }
+
+            // Push liked albums
+            database.albumsLikedByNameAsc().first().forEach { album ->
+                album.album.playlistId?.let { YouTube.likePlaylist(it, true).onSuccess { count++ } }
+            }
+
+            Result.success(count)
+        } catch (e: Exception) {
+            Result.failure(e)
+        } finally {
+            _isPushingToRemote.value = false
+        }
+    }
+
     suspend fun syncLikedSongs() {
         if (isSyncingLikedSongs.value) return
         isSyncingLikedSongs.value = true

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -269,8 +269,21 @@ object YTPlayerUtils {
                     continue
                 }
 
-                if (clientIndex == fallbackClients.size - 1) {
-                    Timber.tag(TAG).d( "Last fallback — skipping validation: ${client.clientName}")
+                // Skip validation for: last fallback client, or WEB_REMIX with anon login
+                // (anon login HEAD requests return 403 but actual playback works)
+                val skipValidation = when {
+                    clientIndex == fallbackClients.size - 1 -> {
+                        Timber.tag(TAG).d("Last fallback — skipping validation: ${client.clientName}")
+                        true
+                    }
+                    client.clientName == "WEB_REMIX" && YouTube.isAnonLogin -> {
+                        Timber.tag(TAG).d("WEB_REMIX + anon login — skipping validation (HEAD returns 403 but playback works)")
+                        true
+                    }
+                    else -> false
+                }
+
+                if (skipValidation) {
                     successClient = client.clientName
                     break
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -675,8 +675,10 @@ object YTPlayerUtils {
             webPlayerPot = if (client.useWebPoTokens) poTokenResult?.playerRequestPoToken else null
         ).getOrThrow()
 
+        // Only include formats that have a URL (direct or via signatureCipher)
+        // This filters out unusable formats without restricting by login type
         val formats = response.streamingData?.adaptiveFormats
-            ?.filter { it.isAudio && it.isOriginal }
+            ?.filter { it.isAudio && it.isOriginal && (it.url != null || it.signatureCipher != null) }
             ?.map { format ->
                 val codec = when {
                     format.mimeType.contains("opus") -> "opus"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -561,4 +561,9 @@
     <string name="widget_name">Zemer Music</string>
     <string name="widget_description">Control your music playback</string>
     <string name="widget_tap_to_open">Tap to open</string>
+
+    <!-- Sync local to YouTube -->
+    <string name="sync_local_to_youtube">Sync local library to YouTube</string>
+    <string name="sync_local_to_youtube_desc">For users who were previously logged in anonymously</string>
+    <string name="syncing">Syncing…</string>
 </resources>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -81,6 +81,10 @@ class InnerTube {
 
     var useLoginForBrowse: Boolean = false
 
+    // Anonymous login state
+    var isAnonLogin: Boolean = false
+    var appVisitorData: String? = null
+
     @OptIn(ExperimentalSerializationApi::class)
     private fun createClient() = HttpClient(OkHttp) {
         expectSuccess = true

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -122,6 +122,24 @@ object YouTube {
             innerTube.appVisitorData = value
         }
 
+    /**
+     * Exception thrown when an account-related operation is attempted while in anonymous mode.
+     * Anonymous users can still use local features, but remote account sync is disabled.
+     */
+    class AccountOperationDisabledException : Exception("Account operation disabled in anonymous mode")
+
+    /**
+     * Helper to guard account-related operations.
+     * Returns failure with AccountOperationDisabledException when in anonymous mode.
+     */
+    private inline fun <T> requireAccount(block: () -> T): Result<T> {
+        return if (isAnonLogin) {
+            Result.failure(AccountOperationDisabledException())
+        } else {
+            runCatching { block() }
+        }
+    }
+
     suspend fun searchSuggestions(query: String): Result<SearchSuggestions> = runCatching {
         val response = innerTube.getSearchSuggestions(WEB_REMIX, query).body<GetSearchSuggestionsResponse>()
         SearchSuggestions(
@@ -600,7 +618,7 @@ object YouTube {
         )
     }
 
-    suspend fun library(browseId: String, tabIndex: Int = 0) = runCatching {
+    suspend fun library(browseId: String, tabIndex: Int = 0) = requireAccount {
         val response = innerTube.browse(
             client = WEB_REMIX,
             browseId = browseId,
@@ -637,7 +655,7 @@ object YouTube {
         }
     }
 
-    suspend fun libraryContinuation(continuation: String) = runCatching {
+    suspend fun libraryContinuation(continuation: String) = requireAccount {
         val response = innerTube.browse(
             client = WEB_REMIX,
             continuation = continuation,
@@ -667,7 +685,7 @@ object YouTube {
         }
     }
 
-    suspend fun libraryRecentActivity(): Result<LibraryPage> = runCatching {
+    suspend fun libraryRecentActivity(): Result<LibraryPage> = requireAccount {
         val continuation = LibraryFilter.FILTER_RECENT_ACTIVITY.value
 
         val response = innerTube.browse(
@@ -870,7 +888,7 @@ object YouTube {
         }
     }
 
-    suspend fun musicHistory() = runCatching {
+    suspend fun musicHistory() = requireAccount {
         val response = innerTube.browse(
             client = WEB_REMIX,
             browseId = "FEmusic_history",
@@ -888,21 +906,21 @@ object YouTube {
         )
     }
 
-    suspend fun likeVideo(videoId: String, like: Boolean) = runCatching {
+    suspend fun likeVideo(videoId: String, like: Boolean) = requireAccount {
         if (like)
             innerTube.likeVideo(WEB_REMIX, videoId)
         else
             innerTube.unlikeVideo(WEB_REMIX, videoId)
     }
 
-    suspend fun likePlaylist(playlistId: String, like: Boolean) = runCatching {
+    suspend fun likePlaylist(playlistId: String, like: Boolean) = requireAccount {
         if (like)
             innerTube.likePlaylist(WEB_REMIX, playlistId)
         else
             innerTube.unlikePlaylist(WEB_REMIX, playlistId)
     }
 
-    suspend fun subscribeChannel(channelId: String, subscribe: Boolean) = runCatching {
+    suspend fun subscribeChannel(channelId: String, subscribe: Boolean) = requireAccount {
         if (subscribe)
             innerTube.subscribeChannel(WEB_REMIX, channelId)
         else
@@ -916,19 +934,19 @@ object YouTube {
         return ""
     }
 
-    suspend fun addToPlaylist(playlistId: String, videoId: String) = runCatching {
+    suspend fun addToPlaylist(playlistId: String, videoId: String) = requireAccount {
         innerTube.addToPlaylist(WEB_REMIX, playlistId, videoId)
     }
 
-    suspend fun addPlaylistToPlaylist(playlistId: String, addPlaylistId: String) = runCatching {
+    suspend fun addPlaylistToPlaylist(playlistId: String, addPlaylistId: String) = requireAccount {
         innerTube.addPlaylistToPlaylist(WEB_REMIX, playlistId, addPlaylistId)
     }
 
-    suspend fun removeFromPlaylist(playlistId: String, videoId: String, setVideoId: String) = runCatching {
+    suspend fun removeFromPlaylist(playlistId: String, videoId: String, setVideoId: String) = requireAccount {
         innerTube.removeFromPlaylist(WEB_REMIX, playlistId, videoId, setVideoId)
     }
 
-    suspend fun moveSongPlaylist(playlistId: String, setVideoId: String, successorSetVideoId: String?) = runCatching {
+    suspend fun moveSongPlaylist(playlistId: String, setVideoId: String, successorSetVideoId: String?) = requireAccount {
         innerTube.moveSongPlaylist(WEB_REMIX, playlistId, setVideoId, successorSetVideoId)
     }
 
@@ -936,7 +954,7 @@ object YouTube {
         innerTube.createPlaylist(WEB_REMIX, title).body<CreatePlaylistResponse>().playlistId
     }
 
-    suspend fun renamePlaylist(playlistId: String, name: String) = runCatching {
+    suspend fun renamePlaylist(playlistId: String, name: String) = requireAccount {
         innerTube.renamePlaylist(WEB_REMIX, playlistId, name)
     }
 
@@ -951,11 +969,11 @@ object YouTube {
         innerTube.setThumbnailPlaylist(WEB_REMIX, playlistId, blobId).body<EditPlaylistResponse>().newHeader?.musicEditablePlaylistDetailHeaderRenderer?.header?.musicResponsiveHeaderRenderer?.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl()
     }
 
-    suspend fun removeThumbnailPlaylist(playlistId: String) = runCatching {
+    suspend fun removeThumbnailPlaylist(playlistId: String) = requireAccount {
         innerTube.removeThumbnailPlaylist(WEB_REMIX, playlistId).body<EditPlaylistResponse>().newHeader?.musicEditablePlaylistDetailHeaderRenderer?.header?.musicResponsiveHeaderRenderer?.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl()
     }
 
-    suspend fun deletePlaylist(playlistId: String) = runCatching {
+    suspend fun deletePlaylist(playlistId: String) = requireAccount {
         innerTube.deletePlaylist(WEB_REMIX, playlistId)
     }
 
@@ -1100,14 +1118,14 @@ object YouTube {
 //    }
 // --Commented out by Inspection STOP (12/1/25, 12:23 PM)
 
-    suspend fun accountInfo(): Result<AccountInfo> = runCatching {
+    suspend fun accountInfo(): Result<AccountInfo> = requireAccount {
         innerTube.accountMenu(WEB_REMIX).body<AccountMenuResponse>()
             .actions[0].openPopupAction.popup.multiPageMenuRenderer
             .header?.activeAccountHeaderRenderer
             ?.toAccountInfo()!!
     }
 
-    suspend fun feedback(tokens: List<String>): Result<Boolean> = runCatching {
+    suspend fun feedback(tokens: List<String>): Result<Boolean> = requireAccount {
         innerTube.feedback(WEB_REMIX, tokens).body<FeedbackResponse>().feedbackResponses.all { it.isProcessed }
     }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -110,6 +110,18 @@ object YouTube {
             innerTube.useLoginForBrowse = value
         }
 
+    // Anonymous login state
+    var isAnonLogin: Boolean
+        get() = innerTube.isAnonLogin
+        set(value) {
+            innerTube.isAnonLogin = value
+        }
+    var appVisitorData: String?
+        get() = innerTube.appVisitorData
+        set(value) {
+            innerTube.appVisitorData = value
+        }
+
     suspend fun searchSuggestions(query: String): Result<SearchSuggestions> = runCatching {
         val response = innerTube.getSearchSuggestions(WEB_REMIX, query).body<GetSearchSuggestionsResponse>()
         SearchSuggestions(


### PR DESCRIPTION
## Summary
- Improve stream handling for anonymous login users
- Disable remote account operations (likes, subscriptions, playlists) when logged in anonymously while keeping all local features working
- Add "Sync local library to YouTube" setting for users who were previously logged in anonymously to push their local data to their YouTube account

## Test plan
- [ ] Login anonymously and verify streaming works
- [ ] Verify local features (local playlists, local likes) still work in anonymous mode
- [ ] Verify remote operations show appropriate behavior in anonymous mode
- [ ] Login with full account and use "Sync local to YouTube" to push local library