### PR TITLE
Pre-warm player.js and HTTP connections at startup

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -95,6 +95,30 @@ class App : Application(), SingletonImageLoader.Factory {
                 IsraeliArtistRegistry.ensureLoaded()
                 Timber.d("App: IsraeliArtistRegistry pre-loaded")
             }
+            // Pre-warm for faster first playback: fetch player.js and warm HTTP connections
+            launch(Dispatchers.IO) {
+                try {
+                    // Pre-fetch player.js (used for cipher/signature operations)
+                    com.zemer.cipher.PlayerJsFetcher.getPlayerJs()
+                    Timber.d("App: Player.js pre-fetched")
+                } catch (e: Exception) {
+                    Timber.e(e, "App: Player.js warmup failed")
+                }
+            }
+            launch(Dispatchers.IO) {
+                // Pre-warm HTTP connections to YouTube
+                try {
+                    val client = okhttp3.OkHttpClient.Builder().build()
+                    listOf("https://www.youtube.com/", "https://music.youtube.com/").forEach { url ->
+                        runCatching {
+                            client.newCall(okhttp3.Request.Builder().url(url).head().build()).execute().close()
+                        }
+                    }
+                    Timber.d("App: HTTP connections pre-warmed")
+                } catch (e: Exception) {
+                    Timber.d("App: HTTP warmup failed: ${e.message}")
+                }
+            }
             // Removed auto-fetch of anonymous token; user must trigger login manually.
         }
     }


### PR DESCRIPTION
## Summary
- Pre-fetch player.js in background at app startup
- Pre-warm HTTP/TLS connections to youtube.com and music.youtube.com
- Reduces first playback latency by having cipher resources ready before user plays

## Test plan
- [ ] Cold start app, play a song - should be faster than before
- [ ] Check logs for "Player.js pre-fetched" and "HTTP connections pre-warmed"