### PR TITLE
fix: unify anonymous and Google login stream validation

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -269,21 +269,9 @@ object YTPlayerUtils {
                     continue
                 }
 
-                // Skip validation for: last fallback client, or WEB_REMIX with anon login
-                // (anon login HEAD requests return 403 but actual playback works)
-                val skipValidation = when {
-                    clientIndex == fallbackClients.size - 1 -> {
-                        Timber.tag(TAG).d("Last fallback — skipping validation: ${client.clientName}")
-                        true
-                    }
-                    client.clientName == "WEB_REMIX" && YouTube.isAnonLogin -> {
-                        Timber.tag(TAG).d("WEB_REMIX + anon login — skipping validation (HEAD returns 403 but playback works)")
-                        true
-                    }
-                    else -> false
-                }
-
-                if (skipValidation) {
+                // Skip validation only for last fallback client (no more options to try)
+                if (clientIndex == fallbackClients.size - 1) {
+                    Timber.tag(TAG).d("Last fallback — skipping validation: ${client.clientName}")
                     successClient = client.clientName
                     break
                 }


### PR DESCRIPTION
## Summary
- Remove special case that skipped URL validation for anonymous login
- Both login types now follow the same code path for stream validation
- Fixes download issues with anonymous login

## Changes
- Proactive n-transform applied for all logins
- HEAD validation runs for all logins
- N-transform retry on validation failure
- Only skip validation on last fallback client

## Test plan
- [ ] Test playback with anonymous login
- [ ] Test downloads with anonymous login
- [ ] Test playback with Google login
- [ ] Test downloads with Google login