### PR TITLE
fix: handle null artist IDs by matching artist name

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -1264,6 +1264,9 @@ interface DatabaseDao {
     @Query("SELECT * FROM artist WHERE artist.name = :name")
     fun artistByName(name: String): ArtistEntity?
 
+    @Query("SELECT * FROM artist WHERE artist.id IN (SELECT artistId FROM artist_whitelist) AND INSTR(:combinedName, artist.name) > 0 LIMIT 1")
+    fun whitelistedArtistByPartialName(combinedName: String): ArtistEntity?
+
     @Query("SELECT * FROM artist WHERE artist.id = :id LIMIT 1")
     fun getArtistById(id: String): ArtistEntity?
 
@@ -1319,7 +1322,7 @@ interface DatabaseDao {
 
         // Always create artist mappings (uses IGNORE so duplicates are fine)
         mediaMetadata.artists.forEachIndexed { index, artist ->
-            val artistId = artist.id ?: artistByName(artist.name)?.id ?: ArtistEntity.generateArtistId()
+            val artistId = artist.id ?: artistByName(artist.name)?.id ?: whitelistedArtistByPartialName(artist.name)?.id ?: ArtistEntity.generateArtistId()
 
             insert(
                 ArtistEntity(
@@ -1372,6 +1375,7 @@ interface DatabaseDao {
             ?.map { artist ->
                 ArtistEntity(
                     id = artist.id ?: artistByName(artist.name)?.id
+                    ?: whitelistedArtistByPartialName(artist.name)?.id
                     ?: ArtistEntity.generateArtistId(),
                     name = artist.name,
                 )
@@ -1403,7 +1407,7 @@ interface DatabaseDao {
         )
         songArtistMap(song.id).forEach(::delete)
         mediaMetadata.artists.forEachIndexed { index, artist ->
-            val artistId = artist.id ?: artistByName(artist.name)?.id ?: ArtistEntity.generateArtistId()
+            val artistId = artist.id ?: artistByName(artist.name)?.id ?: whitelistedArtistByPartialName(artist.name)?.id ?: ArtistEntity.generateArtistId()
             
             insert(
                 ArtistEntity(

--- a/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt
@@ -36,6 +36,19 @@ private object WhitelistEntryCache {
     }
 }
 
+private fun matchArtistByName(
+    artistName: String,
+    allowedEntries: List<ArtistWhitelistEntity>,
+    config: ContentFilterConfig,
+): ArtistWhitelistEntity? {
+    return allowedEntries.firstOrNull { entry ->
+        if (config.filtersEnabled && !config.allowFemaleSingers && entry.isFemale) {
+            return@firstOrNull false
+        }
+        artistName.contains(entry.artistName, ignoreCase = true)
+    }
+}
+
 private suspend fun SongItem.isWhitelisted(
     database: MusicDatabase,
     allowedIds: Set<String>?,
@@ -56,7 +69,17 @@ private suspend fun SongItem.isWhitelisted(
     var allAllowed = true
     var isChasidish = false
     for (artist in artists) {
-        val artistId = artist.id ?: continue
+        val artistId = artist.id
+        if (artistId == null) {
+            val matchedEntry = matchArtistByName(artist.name, WhitelistCache.allowedEntries(config), config)
+            if (matchedEntry != null) {
+                anyAllowed = true
+                if (matchedEntry.isChasid) isChasidish = true
+            } else {
+                allAllowed = false
+            }
+            continue
+        }
         val decision = database.artistMatchesFilters(artistId, allowedIds, artistCache, config)
         if (decision.allowed) {
             anyAllowed = true
@@ -97,7 +120,17 @@ private suspend fun AlbumItem.isWhitelisted(
     var allAllowed = true
     var isChasidish = false
     for (artist in albumArtists) {
-        val artistId = artist.id ?: continue
+        val artistId = artist.id
+        if (artistId == null) {
+            val matchedEntry = matchArtistByName(artist.name, WhitelistCache.allowedEntries(config), config)
+            if (matchedEntry != null) {
+                anyAllowed = true
+                if (matchedEntry.isChasid) isChasidish = true
+            } else {
+                allAllowed = false
+            }
+            continue
+        }
         val decision = database.artistMatchesFilters(artistId, allowedIds, artistCache, config)
         if (decision.allowed) {
             anyAllowed = true


### PR DESCRIPTION
When YouTube Music returns artists with null IDs (e.g., combined artists like "Dovy Meisels & Pinky Weber"), fall back to name-based matching against the whitelist instead of skipping them entirely.