### PR TITLE
Fix YouTube API changes, WEB_REMIX streaming, anonymous login, cipher

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.jtech.zemer"
         minSdk = 26
         targetSdk = 36
-        versionCode = 24
-        versionName = "24"
+        versionCode = 25
+        versionName = "25"
         buildConfigField("String", "ARCHITECTURE", "\"universal\"")
         val googleTokenExchangeUrl = (project.findProperty("googleTokenExchangeUrl") as String?) ?: ""
         buildConfigField("String", "GOOGLE_TOKEN_EXCHANGE_URL", "\"$googleTokenExchangeUrl\"")

--- a/app/schemas/com.jtech.zemer.db.InternalDatabase/32.json
+++ b/app/schemas/com.jtech.zemer.db.InternalDatabase/32.json
@@ -1,0 +1,1156 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 32,
+    "identityHash": "c0d9725767925415a739bfd72a3d4335",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `mediaStoreUri` TEXT DEFAULT NULL, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreUri",
+            "columnName": "mediaStoreUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_song_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_song_liked",
+            "unique": false,
+            "columnNames": [
+              "liked"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_liked` ON `${TABLE_NAME}` (`liked`)"
+          },
+          {
+            "name": "index_song_isVideo",
+            "unique": false,
+            "columnNames": [
+              "isVideo"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_isVideo` ON `${TABLE_NAME}` (`isVideo`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `playbackUrl` TEXT, `streamClient` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamClient",
+            "columnName": "streamClient",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_event_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "artist_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistId` TEXT NOT NULL, `artistName` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `source` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `isFemale` INTEGER NOT NULL, `isChasid` INTEGER NOT NULL, `isGenZ` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `isKidZone` INTEGER NOT NULL, PRIMARY KEY(`artistId`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFemale",
+            "columnName": "isFemale",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isChasid",
+            "columnName": "isChasid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenZ",
+            "columnName": "isGenZ",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKidZone",
+            "columnName": "isKidZone",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistId"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c0d9725767925415a739bfd72a3d4335')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -127,7 +127,7 @@ class App : Application(), SingletonImageLoader.Factory {
         try {
             val httpClient = HttpClient()
             val responseText = httpClient.get(
-                "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                "https://mc.alltech.dev/credentials"
             ).bodyAsText()
 
             val json = kotlinx.serialization.json.Json.parseToJsonElement(responseText)

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -154,7 +154,8 @@ class App : Application(), SingletonImageLoader.Factory {
                         cookie
                             ?.takeIf { parseCookieString(it).containsKey("SAPISID") }
                             ?.let { prefs[InnerTubeCookieKey] = it }
-                        dataSyncId?.let { prefs[DataSyncIdKey] = it.substringBefore("||") }
+                        // Anonymous login must not set dataSyncId (onBehalfOfUser breaks playback).
+                        prefs[DataSyncIdKey] = ""
                         accountName?.let { prefs[AccountNameKey] = it }
                         accountEmail?.let { prefs[AccountEmailKey] = it }
                         accountChannelHandle?.let { prefs[AccountChannelHandleKey] = it }
@@ -162,7 +163,7 @@ class App : Application(), SingletonImageLoader.Factory {
                     cookie
                         ?.takeIf { parseCookieString(it).containsKey("SAPISID") }
                         ?.let { YouTube.cookie = it }
-                    dataSyncId?.let { YouTube.dataSyncId = it.substringBefore("||") }
+                    YouTube.dataSyncId = null
                     YouTube.visitorData = visitorData
                     val expiresIn = if (expiresAt != null) {
                         val minutesLeft = (expiresAt - (timestamp ?: System.currentTimeMillis())) / 60000
@@ -194,7 +195,7 @@ class App : Application(), SingletonImageLoader.Factory {
         // IMPORTANT: Initialize YouTube authentication data FIRST before anything else
         YouTube.cookie = settings[InnerTubeCookieKey]
         YouTube.visitorData = settings[VisitorDataKey]?.takeIf { it != "null" }
-        YouTube.dataSyncId = settings[DataSyncIdKey]?.let {
+        YouTube.dataSyncId = settings[DataSyncIdKey]?.takeIf { it.isNotBlank() }?.let {
             it.takeIf { !it.contains("||") }
                 ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
                 ?: it.substringAfter("||")

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -132,6 +132,7 @@ class App : Application(), SingletonImageLoader.Factory {
 
             val json = kotlinx.serialization.json.Json.parseToJsonElement(responseText)
             val visitorData = json.jsonObject["visitorData"]?.jsonPrimitive?.content
+                ?.let { android.net.Uri.decode(it) }
             val clientVersion = json.jsonObject["clientVersion"]?.jsonPrimitive?.content
             val timestamp = json.jsonObject["timestamp"]?.jsonPrimitive?.content?.toLongOrNull()
             val expiresAt = json.jsonObject["expiresAt"]?.jsonPrimitive?.content?.toLongOrNull()
@@ -195,6 +196,7 @@ class App : Application(), SingletonImageLoader.Factory {
         // IMPORTANT: Initialize YouTube authentication data FIRST before anything else
         YouTube.cookie = settings[InnerTubeCookieKey]
         YouTube.visitorData = settings[VisitorDataKey]?.takeIf { it != "null" }
+            ?.let { android.net.Uri.decode(it) }
         YouTube.dataSyncId = settings[DataSyncIdKey]?.takeIf { it.isNotBlank() }?.let {
             it.takeIf { !it.contains("||") }
                 ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")

--- a/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
@@ -91,7 +91,7 @@ class MusicDatabase(
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 31,
+    version = 32,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -134,7 +134,7 @@ abstract class InternalDatabase : RoomDatabase() {
             val builtDb = try {
                 Room
                     .databaseBuilder(context, InternalDatabase::class.java, DB_NAME)
-                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32)
                     .setJournalMode(JournalMode.TRUNCATE)
                     .enableMultiInstanceInvalidation()
                     .build().also {
@@ -406,6 +406,13 @@ val MIGRATION_30_31 =
             db.execSQL("CREATE INDEX IF NOT EXISTS index_song_isVideo ON song(isVideo)")
             // Add timestamp index for event table (time-range queries)
             db.execSQL("CREATE INDEX IF NOT EXISTS index_event_timestamp ON event(timestamp)")
+        }
+    }
+
+val MIGRATION_31_32 =
+    object : Migration(31, 32) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE format ADD COLUMN streamClient TEXT")
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt
@@ -14,5 +14,6 @@ data class FormatEntity(
     val contentLength: Long,
     val loudnessDb: Double?,
     @Deprecated("playbackTrackingUrl should be retrieved from a fresh player request")
-    val playbackUrl: String?
+    val playbackUrl: String?,
+    val streamClient: String? = null,
 )

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
@@ -139,6 +139,7 @@ constructor(
                     mediaId,
                     audioQuality = currentQuality,
                     connectivityManager = connectivityManager,
+                    forDownload = true,
                 )
             }.getOrThrow()
             val format = playbackData.format

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1372,7 +1372,8 @@ class MusicService :
                             sampleRate = format.audioSampleRate,
                             contentLength = contentLength,
                             loudnessDb = nonNullPlayback.audioConfig?.loudnessDb,
-                            playbackUrl = nonNullPlayback.playbackTracking?.videostatsPlaybackUrl?.baseUrl
+                            playbackUrl = nonNullPlayback.playbackTracking?.videostatsPlaybackUrl?.baseUrl,
+                            streamClient = nonNullPlayback.streamClient,
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1240,10 +1240,12 @@ class MusicService :
     private fun handleExpiredUrlError() {
         val mediaId = player.currentMediaItem?.mediaId
         if (mediaId != null) {
+            // If this was a WEB_REMIX stream that 403d on GET, mark it so the next
+            // resolution skips WEB_REMIX and falls through to TVHTML5/ANDROID_VR.
+            YTPlayerUtils.markWebRemixFailed(mediaId)
             // Clear the cached URL so it will be refreshed on next request
-            // Using DownloadUtil.invalidateUrl ensures both playback and download see the invalidation
             DownloadUtil.invalidateUrl(mediaId)
-            Timber.d("Cleared cached URL for $mediaId")
+            Timber.d("Cleared cached URL for $mediaId, marked WEB_REMIX as failed")
         }
 
         // Seek to current position to force URL re-resolution

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
@@ -156,7 +156,7 @@ fun LoginGateScreen(
                             try {
                                 val httpClient = HttpClient()
                                 val responseText = httpClient.get(
-                                    "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                                    "https://mc.alltech.dev/credentials"
                                 ).bodyAsText()
 
                                 val json = Json.parseToJsonElement(responseText)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
@@ -161,6 +161,7 @@ fun LoginGateScreen(
 
                                 val json = Json.parseToJsonElement(responseText)
                                 val fetchedVisitorData = json.jsonObject["visitorData"]?.jsonPrimitive?.content
+                                    ?.let { android.net.Uri.decode(it) }
                                 val fetchedCookie = run {
                                     val raw = json.jsonObject["cookie"]?.jsonPrimitive?.content
                                         ?: json.jsonObject["innerTubeCookie"]?.jsonPrimitive?.content

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
@@ -188,11 +188,10 @@ fun LoginGateScreen(
                                             innerTubeCookie = it
                                             runCatching { YouTube.cookie = it }
                                         }
-                                    fetchedDataSyncId?.let {
-                                        val clean = it.substringBefore("||")
-                                        dataSyncId = clean
-                                        YouTube.dataSyncId = clean
-                                    }
+                                    // Anonymous login must NOT set dataSyncId — the pooled
+                                    // account's onBehalfOfUser breaks the player request (HTTP 400).
+                                    dataSyncId = ""
+                                    YouTube.dataSyncId = null
                                     fetchedAccountName?.let { accountName = it }
                                     fetchedAccountEmail?.let { accountEmail = it }
                                     fetchedAccountChannelHandle?.let { accountChannelHandle = it }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -212,9 +212,10 @@ fun AccountSettings(
                             val fetchedAccountEmail = json.jsonObject["accountEmail"]?.jsonPrimitive?.content
                             val fetchedAccountChannelHandle = json.jsonObject["accountChannelHandle"]?.jsonPrimitive?.content
 
-                            if (!fetchedVisitorData.isNullOrEmpty() && fetchedVisitorData.startsWith("Cg") && fetchedVisitorData.length > 20) {
-                                onVisitorDataChange(fetchedVisitorData)
-                                YouTube.visitorData = fetchedVisitorData
+                            val decodedVisitorData = fetchedVisitorData?.let { android.net.Uri.decode(it) }
+                            if (!decodedVisitorData.isNullOrEmpty() && decodedVisitorData.startsWith("Cg") && decodedVisitorData.length > 20) {
+                                onVisitorDataChange(decodedVisitorData)
+                                YouTube.visitorData = decodedVisitorData
                                 fetchedCookie
                                     ?.takeIf { parseCookieString(it).containsKey("SAPISID") }
                                     ?.let {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -221,11 +221,9 @@ fun AccountSettings(
                                         onInnerTubeCookieChange(it)
                                         runCatching { YouTube.cookie = it }
                                     }
-                                fetchedDataSyncId?.let {
-                                    val clean = it.substringBefore("||")
-                                    onDataSyncIdChange(clean)
-                                    YouTube.dataSyncId = clean
-                                }
+                                // Anonymous login must NOT set dataSyncId (breaks playback).
+                                onDataSyncIdChange("")
+                                YouTube.dataSyncId = null
                                 fetchedAccountName?.let { onAccountNameChange(it) }
                                 fetchedAccountEmail?.let { onAccountEmailChange(it) }
                                 fetchedAccountChannelHandle?.let { onAccountChannelHandleChange(it) }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -189,7 +189,7 @@ fun AccountSettings(
                         try {
                             val httpClient = HttpClient()
                             val responseText = httpClient.get(
-                                "https://ytzemer-token.usheraweiss.workers.dev/api/token"
+                                "https://mc.alltech.dev/credentials"
                             ).bodyAsText()
 
                             val json = kotlinx.serialization.json.Json.parseToJsonElement(responseText)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
@@ -124,6 +124,7 @@ fun ShowMediaInfo(videoId: String) {
                     val extendedList = baseList + if (currentFormat != null) {
                         listOf(
                             "Itag" to currentFormat?.itag?.toString(),
+                            "Stream client" to currentFormat?.streamClient,
                             stringResource(R.string.mime_type) to currentFormat?.mimeType,
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -242,9 +242,12 @@ object YTPlayerUtils {
                     break
                 }
 
-                // WEB_REMIX authenticated CDN URLs 403 on HEAD but may serve correctly
-                // on the actual byte-range GET. Skip HEAD validation; let ExoPlayer try.
-                if (client.clientName == "WEB_REMIX" && clientIndex == -1) {
+                // WEB_REMIX authenticated CDN URLs 403 on HEAD but serve correctly
+                // on the actual byte-range GET that ExoPlayer makes. Skip HEAD validation
+                // for streaming. For downloads, fall through so a direct-URL client
+                // (ANDROID_VR/IOS) is selected — WEB_REMIX signed URLs don't support
+                // the &range= query-param download pattern.
+                if (client.clientName == "WEB_REMIX" && clientIndex == -1 && !forDownload) {
                     Timber.tag(TAG).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
                     successClient = client.clientName
                     break

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -40,6 +40,16 @@ object YTPlayerUtils {
 
     private val poTokenGenerator = PoTokenGenerator()
 
+    // Track videoIds where WEB_REMIX stream URLs 403 on ExoPlayer GET, so the next
+    // resolution falls through to TVHTML5/ANDROID_VR instead of looping.
+    private val webRemixFailedIds = java.util.Collections.newSetFromMap(
+        java.util.concurrent.ConcurrentHashMap<String, Boolean>()
+    )
+
+    fun markWebRemixFailed(videoId: String) {
+        webRemixFailedIds.add(videoId)
+    }
+
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
@@ -244,10 +254,12 @@ object YTPlayerUtils {
 
                 // WEB_REMIX authenticated CDN URLs 403 on HEAD but serve correctly
                 // on the actual byte-range GET that ExoPlayer makes. Skip HEAD validation
-                // for streaming. For downloads, fall through so a direct-URL client
-                // (ANDROID_VR/IOS) is selected — WEB_REMIX signed URLs don't support
+                // for streaming UNLESS this videoId already failed on GET (tracked in
+                // webRemixFailedIds), in which case fall through to TVHTML5/ANDROID_VR.
+                // For downloads, always fall through — WEB_REMIX signed URLs don't support
                 // the &range= query-param download pattern.
-                if (client.clientName == "WEB_REMIX" && clientIndex == -1 && !forDownload) {
+                if (client.clientName == "WEB_REMIX" && clientIndex == -1
+                    && !forDownload && !webRemixFailedIds.contains(videoId)) {
                     Timber.tag(TAG).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
                     successClient = client.clientName
                     break

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -61,6 +61,7 @@ object YTPlayerUtils {
         val format: PlayerResponse.StreamingData.Format,
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
+        val streamClient: String = "unknown",
     )
     /**
      * Custom player response intended to use for playback.
@@ -211,11 +212,11 @@ object YTPlayerUtils {
                             streamUrl = EjsNTransformSolver.transformNParamInUrl(originalUrl)
                         }
 
-                        // Append pot= parameter AFTER n-transform
+                        // Append pot= parameter AFTER n-transform (URI-encode to handle base64 padding)
                         if (client.useWebPoTokens && poTokenResult?.streamingDataPoToken != null) {
                             Timber.tag(TAG).d("Appending pot= parameter to stream URL")
                             val separator = if ("?" in streamUrl) "&" else "?"
-                            streamUrl = "${streamUrl}${separator}pot=${poTokenResult.streamingDataPoToken}"
+                            streamUrl = "${streamUrl}${separator}pot=${android.net.Uri.encode(poTokenResult.streamingDataPoToken)}"
                         }
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "N-transform or pot append failed: ${e.message}")
@@ -237,6 +238,14 @@ object YTPlayerUtils {
 
                 if (clientIndex == fallbackClients.size - 1) {
                     Timber.tag(TAG).d( "Last fallback — skipping validation: ${client.clientName}")
+                    successClient = client.clientName
+                    break
+                }
+
+                // WEB_REMIX authenticated CDN URLs 403 on HEAD but may serve correctly
+                // on the actual byte-range GET. Skip HEAD validation; let ExoPlayer try.
+                if (client.clientName == "WEB_REMIX" && clientIndex == -1) {
+                    Timber.tag(TAG).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
                     successClient = client.clientName
                     break
                 }
@@ -311,6 +320,7 @@ object YTPlayerUtils {
             format,
             streamUrl,
             streamExpiresInSeconds,
+            streamClient = successClient ?: "unknown",
         )
     }
     /**
@@ -390,6 +400,7 @@ object YTPlayerUtils {
                 .head()
                 .url(validatedUrl)
                 .header("User-Agent", YouTubeClient.USER_AGENT_WEB)
+            YouTube.cookie?.let { requestBuilder.addHeader("Cookie", it) }
             val request = try {
                 requestBuilder.build()
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -162,20 +162,13 @@ object YTPlayerUtils {
             if (streamPlayerResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(TAG).d( "Status OK for ${client.clientName}")
 
-                // Pre-process response with NewPipe to get direct URLs (like Metrolist)
-                val responseToUse = try {
-                    val newPipeResponse = YouTube.newPipePlayer(videoId, streamPlayerResponse)
-                    if (newPipeResponse != null) {
-                        Timber.tag(TAG).d("NewPipe pre-processing succeeded for ${client.clientName}")
-                        newPipeResponse
-                    } else {
-                        Timber.tag(TAG).d("NewPipe pre-processing returned null, using original response")
-                        streamPlayerResponse
-                    }
-                } catch (e: Exception) {
-                    Timber.tag(TAG).e(e, "NewPipe pre-processing failed: ${e.message}")
-                    streamPlayerResponse
-                }
+                // Use the player response as-is. The old NewPipe StreamInfo.getInfo
+                // pre-processing ran a full second extraction for EVERY song (fetch watch
+                // page + decipher all ~18 formats) — slow with the bundled extractor and
+                // redundant. Direct-url clients (IOS/ANDROID_VR/IPADOS/VISIONOS) already
+                // carry playable URLs; web clients are deciphered per-format by the Zemer
+                // cipher in findUrlOrNull (sig) + transformNParamInUrl (n) below.
+                val responseToUse = streamPlayerResponse
 
                 format =
                     findFormat(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -202,8 +202,9 @@ class InnerTube {
         playlistId: String?,
         signatureTimestamp: Int?,
         webPlayerPot: String? = null,
+        setLogin: Boolean = true,
     ) = httpClient.post("player") {
-        ytClient(client, setLogin = true)
+        ytClient(client, setLogin = setLogin)
         setBody(
             PlayerBody(
                 context = client.toContext(locale, visitorData, dataSyncId).let {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -180,13 +180,13 @@ class InnerTube {
         params: String? = null,
         continuation: String? = null,
     ) = httpClient.post("search") {
-        ytClient(client, setLogin = useLoginForBrowse)
+        ytClient(client, setLogin = false)
         setBody(
             SearchBody(
                 context = client.toContext(
                     locale,
                     visitorData,
-                    if (useLoginForBrowse) dataSyncId else null
+                    null
                 ),
                 query = query,
                 params = params

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -1006,8 +1006,8 @@ object YouTube {
         innerTube.deletePlaylist(WEB_REMIX, playlistId)
     }
 
-    suspend fun player(videoId: String, playlistId: String? = null, client: YouTubeClient, signatureTimestamp: Int? = null, webPlayerPot: String? = null): Result<PlayerResponse> = runCatching {
-        innerTube.player(client, videoId, playlistId, signatureTimestamp, webPlayerPot).body<PlayerResponse>()
+    suspend fun player(videoId: String, playlistId: String? = null, client: YouTubeClient, signatureTimestamp: Int? = null, webPlayerPot: String? = null, setLogin: Boolean = true): Result<PlayerResponse> = runCatching {
+        innerTube.player(client, videoId, playlistId, signatureTimestamp, webPlayerPot, setLogin).body<PlayerResponse>()
     }
 
     suspend fun registerPlayback(playlistId: String? = null, playbackTracking: String) = runCatching {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -148,12 +148,22 @@ object YouTube {
             } else null
         }
 
-        // Collect all items from other sections (musicShelfRenderer)
-        val allOtherItems = contents?.filter { it.musicShelfRenderer != null }
+        // Collect all items from other sections (musicShelfRenderer + itemSectionRenderer).
+        // YouTube migrated search results from musicShelfRenderer to itemSectionRenderer.
+        val allOtherItems = contents
             ?.flatMap { section ->
-                section.musicShelfRenderer?.contents?.getItems()
-                    ?.mapNotNull { SearchSummaryPage.fromMusicResponsiveListItemRenderer(it) }
-                    .orEmpty()
+                when {
+                    section.musicShelfRenderer != null ->
+                        section.musicShelfRenderer.contents?.getItems()
+                            ?.mapNotNull { SearchSummaryPage.fromMusicResponsiveListItemRenderer(it) }
+                            .orEmpty()
+                    section.itemSectionRenderer != null ->
+                        section.itemSectionRenderer.contents
+                            ?.mapNotNull { it.musicResponsiveListItemRenderer }
+                            ?.mapNotNull { SearchSummaryPage.fromMusicResponsiveListItemRenderer(it) }
+                            .orEmpty()
+                    else -> emptyList()
+                }
             }
             ?.distinctBy { it.id }
             .orEmpty()
@@ -196,15 +206,31 @@ object YouTube {
 
     suspend fun search(query: String, filter: SearchFilter): Result<SearchResult> = runCatching {
         val response = innerTube.search(WEB_REMIX, query, filter.value).body<SearchResponse>()
+        val sections = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()
+            ?.tabRenderer?.content?.sectionListRenderer?.contents
+        val searchItems = mutableListOf<YTItem>()
+        var searchContinuation: String? = null
+        sections?.forEach { section ->
+            when {
+                section.musicShelfRenderer != null -> {
+                    section.musicShelfRenderer.contents?.getItems()
+                        ?.mapNotNull { SearchPage.toYTItem(it) }
+                        ?.let { searchItems.addAll(it) }
+                    if (searchContinuation == null) {
+                        searchContinuation = section.musicShelfRenderer.continuations?.getContinuation()
+                    }
+                }
+                section.itemSectionRenderer != null -> {
+                    section.itemSectionRenderer.contents
+                        ?.mapNotNull { it.musicResponsiveListItemRenderer }
+                        ?.mapNotNull { SearchPage.toYTItem(it) }
+                        ?.let { searchItems.addAll(it) }
+                }
+            }
+        }
         SearchResult(
-            items = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()
-                ?.tabRenderer?.content?.sectionListRenderer?.contents?.lastOrNull()
-                ?.musicShelfRenderer?.contents?.getItems()?.mapNotNull {
-                    SearchPage.toYTItem(it)
-                }.orEmpty(),
-            continuation = response.contents?.tabbedSearchResultsRenderer?.tabs?.firstOrNull()
-                ?.tabRenderer?.content?.sectionListRenderer?.contents?.lastOrNull()
-                ?.musicShelfRenderer?.continuations?.getContinuation()
+            items = searchItems.distinctBy { it.id },
+            continuation = searchContinuation,
         )
     }
 
@@ -273,16 +299,19 @@ object YouTube {
 
     suspend fun albumSongs(playlistId: String, album: AlbumItem? = null): Result<List<SongItem>> = runCatching {
         var response = innerTube.browse(WEB_REMIX, "VL$playlistId").body<BrowseResponse>()
-        val songs = response.contents?.twoColumnBrowseResultsRenderer
+        val shelf = response.contents?.twoColumnBrowseResultsRenderer
             ?.secondaryContents?.sectionListRenderer
             ?.contents?.firstOrNull()
-            ?.musicPlaylistShelfRenderer?.contents?.getItems()
-            ?.mapNotNull {
+        // Some albums now return musicShelfRenderer instead of musicPlaylistShelfRenderer.
+        val shelfContents = shelf?.musicPlaylistShelfRenderer?.contents
+            ?: shelf?.musicShelfRenderer?.contents
+            ?: emptyList()
+        val songs = shelfContents.getItems()
+            .mapNotNull {
                 AlbumPage.getSong(it, album)
-            }!!
+            }
             .toMutableList()
-        var continuation = response.contents.twoColumnBrowseResultsRenderer.secondaryContents.sectionListRenderer
-            .contents.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation()
+        var continuation = shelfContents.getContinuation()
         val seenContinuations = mutableSetOf<String>()
         var requestCount = 0
         val maxRequests = 50 // Prevent excessive API calls
@@ -418,28 +447,58 @@ object YouTube {
         PlaylistPage(
             playlist = PlaylistItem(
                 id = playlistId,
-                title = header?.title?.runs?.firstOrNull()?.text!!,
-                author = header.straplineTextOne?.runs?.firstOrNull()?.let {
-                    Artist(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId
-                    )
-                },
-                songCountText = header.secondSubtitle?.runs?.firstOrNull()?.text,
-                thumbnail = header.thumbnail?.musicThumbnailRenderer?.thumbnail?.thumbnails?.lastOrNull()?.url!!,
+                // System auto-playlists (Liked Music, Sounds from Shorts) return their
+                // header as response.header.musicHeaderRenderer; fall back to it.
+                title = header?.title?.runs?.firstOrNull()?.text
+                    ?: response.header?.musicHeaderRenderer?.title?.runs?.firstOrNull()?.text
+                    ?: "",
+                author = (header?.straplineTextOne
+                    ?: response.header?.musicHeaderRenderer?.straplineTextOne)
+                    ?.runs?.firstOrNull()?.let {
+                        Artist(
+                            name = it.text,
+                            id = it.navigationEndpoint?.browseEndpoint?.browseId
+                        )
+                    },
+                songCountText = (header?.secondSubtitle
+                    ?: response.header?.musicHeaderRenderer?.secondSubtitle)
+                    ?.runs?.firstOrNull()?.text,
+                thumbnail = header?.thumbnail?.musicThumbnailRenderer?.thumbnail?.thumbnails?.lastOrNull()?.url
+                    ?: response.header?.musicHeaderRenderer?.thumbnail?.musicThumbnailRenderer?.thumbnails?.lastOrNull()?.url,
                 playEndpoint = null,
-                shuffleEndpoint = header.buttons.lastOrNull()?.menuRenderer?.items?.firstOrNull()?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint!!,
-                radioEndpoint = header.buttons.getOrNull(2)?.menuRenderer?.items?.find {
-                    it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
-                }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
+                shuffleEndpoint = header?.buttons?.lastOrNull()
+                    ?.menuRenderer?.items?.firstOrNull()
+                    ?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint
+                    ?: response.header?.musicHeaderRenderer?.buttons?.lastOrNull()
+                        ?.menuRenderer?.items?.firstOrNull()
+                        ?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
+                radioEndpoint = header?.buttons?.getOrNull(2)
+                    ?.menuRenderer?.items?.find {
+                        it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
+                    }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint
+                    ?: response.header?.musicHeaderRenderer?.buttons?.getOrNull(2)
+                        ?.menuRenderer?.items?.find {
+                            it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
+                        }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
                 isEditable = editable
             ),
-            songs = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
-                ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getItems()?.mapNotNull {
+            songs = run {
+                val twoColShelf = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
+                    ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer
+                val singleColShelf = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()
+                    ?.tabRenderer?.content?.sectionListRenderer?.contents?.firstOrNull()?.musicPlaylistShelfRenderer
+                (twoColShelf ?: singleColShelf)?.contents?.getItems()?.mapNotNull {
                     PlaylistPage.fromMusicResponsiveListItemRenderer(it)
-                } ?: emptyList(),
-            songsContinuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
-                ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer?.contents?.getContinuation(),
+                } ?: emptyList()
+            },
+            songsContinuation = run {
+                val twoColShelf = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
+                    ?.contents?.firstOrNull()?.musicPlaylistShelfRenderer
+                val singleColShelf = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()
+                    ?.tabRenderer?.content?.sectionListRenderer?.contents?.firstOrNull()?.musicPlaylistShelfRenderer
+                val shelf = twoColShelf ?: singleColShelf
+                shelf?.contents?.getContinuation() ?: shelf?.continuations?.getContinuation()
+            },
             continuation = response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents?.sectionListRenderer
                 ?.continuations?.getContinuation()
         )
@@ -767,7 +826,7 @@ object YouTube {
     private fun convertToChartItem(renderer: MusicResponsiveListItemRenderer): YTItem? {
         return try {
             when {
-                renderer.flexColumns.size >= 3 && renderer.playlistItemData?.videoId != null -> {
+                renderer.flexColumns.size >= 3 && renderer.videoId != null -> {
                     val firstColumn = renderer.flexColumns.getOrNull(0)
                         ?.musicResponsiveListItemFlexColumnRenderer
                         ?.text ?: return null
@@ -793,7 +852,7 @@ object YouTube {
                         ?.text
 
                     SongItem(
-                        id = renderer.playlistItemData.videoId,
+                        id = renderer.videoId!!,
                         title = title,
                         artists = artists,
                         thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicPlaylistShelfRenderer.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicPlaylistShelfRenderer.kt
@@ -7,4 +7,5 @@ data class MusicPlaylistShelfRenderer(
     val playlistId: String?,
     val contents: List<MusicShelfRenderer.Content>?,
     val collapsedItemCount: Int,
+    val continuations: List<Continuation>? = null,
 )

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicResponsiveListItemRenderer.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/MusicResponsiveListItemRenderer.kt
@@ -28,7 +28,12 @@ data class MusicResponsiveListItemRenderer(
     val navigationEndpoint: NavigationEndpoint?,
 ) {
     val isSong: Boolean
-        get() = navigationEndpoint == null || navigationEndpoint.watchEndpoint != null || navigationEndpoint.watchPlaylistEndpoint != null
+        get() = navigationEndpoint == null
+            || navigationEndpoint.watchEndpoint != null
+            || navigationEndpoint.watchPlaylistEndpoint != null
+            || overlay?.musicItemThumbnailOverlayRenderer
+                ?.content?.musicPlayButtonRenderer
+                ?.playNavigationEndpoint?.watchEndpoint != null
     val isPlaylist: Boolean
         get() = navigationEndpoint?.browseEndpoint?.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType == MUSIC_PAGE_TYPE_PLAYLIST
     val isAlbum: Boolean
@@ -37,6 +42,22 @@ data class MusicResponsiveListItemRenderer(
     val isArtist: Boolean
         get() = navigationEndpoint?.browseEndpoint?.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType == MUSIC_PAGE_TYPE_ARTIST
                 || navigationEndpoint?.browseEndpoint?.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType == MUSIC_PAGE_TYPE_LIBRARY_ARTIST
+
+    val videoId: String?
+        get() = playlistItemData?.videoId
+            ?: flexColumns.firstOrNull()
+                ?.musicResponsiveListItemFlexColumnRenderer
+                ?.text?.runs?.firstOrNull()
+                ?.navigationEndpoint?.watchEndpoint?.videoId
+            ?: overlay?.musicItemThumbnailOverlayRenderer
+                ?.content?.musicPlayButtonRenderer
+                ?.playNavigationEndpoint?.watchEndpoint?.videoId
+
+    val playlistSetVideoId: String?
+        get() = playlistItemData?.playlistSetVideoId
+            ?: overlay?.musicItemThumbnailOverlayRenderer
+                ?.content?.musicPlayButtonRenderer
+                ?.playNavigationEndpoint?.watchEndpoint?.playlistSetVideoId
 
     @Serializable
     data class FlexColumn(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/SectionListRenderer.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/SectionListRenderer.kt
@@ -47,5 +47,27 @@ data class SectionListRenderer(
         val musicResponsiveHeaderRenderer: MusicResponsiveHeaderRenderer?,
         val musicEditablePlaylistDetailHeaderRenderer: MusicEditablePlaylistDetailHeaderRenderer?,
         val gridRenderer: GridRenderer?,
+        val itemSectionRenderer: ItemSectionRenderer?,
+    )
+}
+
+@Serializable
+data class ItemSectionRenderer(
+    val contents: List<Content>?,
+    val header: Header? = null,
+) {
+    @Serializable
+    data class Content(
+        val musicResponsiveListItemRenderer: MusicResponsiveListItemRenderer?,
+    )
+
+    @Serializable
+    data class Header(
+        val itemSectionTabbedHeaderRenderer: ItemSectionTabbedHeaderRenderer?,
+    )
+
+    @Serializable
+    data class ItemSectionTabbedHeaderRenderer(
+        val title: Runs?,
     )
 }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/AlbumPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/AlbumPage.kt
@@ -80,7 +80,16 @@ data class AlbumPage(
 
         fun getSong(renderer: MusicResponsiveListItemRenderer, album: AlbumItem? = null): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.playlistItemData?.videoId
+                    ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                        ?.content?.musicPlayButtonRenderer
+                        ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.flexColumns.firstOrNull()
+                        ?.musicResponsiveListItemFlexColumnRenderer
+                        ?.text?.runs?.firstOrNull()
+                        ?.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: return null,
                 title = PageHelper.extractRuns(renderer.flexColumns, "MUSIC_VIDEO").firstOrNull()?.text ?: return null,
                 artists = PageHelper.extractRuns(renderer.flexColumns, "MUSIC_PAGE_TYPE_ARTIST").map{
                     Artist(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -20,7 +20,16 @@ data class ArtistItemsPage(
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.playlistItemData?.videoId
+                    ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                        ?.content?.musicPlayButtonRenderer
+                        ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.flexColumns.firstOrNull()
+                        ?.musicResponsiveListItemFlexColumnRenderer
+                        ?.text?.runs?.firstOrNull()
+                        ?.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()?.text ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -61,7 +61,16 @@ data class ArtistPage(
 
         private fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.playlistItemData?.videoId
+                    ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                        ?.content?.musicPlayButtonRenderer
+                        ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                    ?: renderer.flexColumns.firstOrNull()
+                        ?.musicResponsiveListItemFlexColumnRenderer
+                        ?.text?.runs?.firstOrNull()
+                        ?.navigationEndpoint?.watchEndpoint?.videoId
+                    ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()
                     ?.text ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/HistoryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/HistoryPage.kt
@@ -29,7 +29,7 @@ data class HistoryPage(
 
         private fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.videoId ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()
                     ?.text ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/LibraryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/LibraryPage.kt
@@ -75,7 +75,7 @@ data class LibraryPage(
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): YTItem? {
             return when {
                 renderer.isSong -> SongItem(
-                    id = renderer.playlistItemData?.videoId ?: return null,
+                    id = renderer.videoId ?: return null,
                     title = renderer.flexColumns.firstOrNull()
                         ?.musicResponsiveListItemFlexColumnRenderer?.text
                         ?.runs?.firstOrNull()?.text ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/NextPage.kt
@@ -24,7 +24,9 @@ object NextPage {
     fun fromPlaylistPanelVideoRenderer(renderer: PlaylistPanelVideoRenderer): SongItem? {
         val longByLineRuns = renderer.longBylineText?.runs?.splitBySeparator() ?: return null
         return SongItem(
-            id = renderer.videoId ?: return null,
+            id = renderer.videoId
+                ?: renderer.navigationEndpoint.watchEndpoint?.videoId
+                ?: return null,
             title =
                 renderer.title
                     ?.runs

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/PlaylistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/PlaylistPage.kt
@@ -17,7 +17,7 @@ data class PlaylistPage(
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.videoId ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()?.text ?: return null,
@@ -39,7 +39,7 @@ data class PlaylistPage(
                     it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"
                 } != null,
                 endpoint = renderer.overlay?.musicItemThumbnailOverlayRenderer?.content?.musicPlayButtonRenderer?.playNavigationEndpoint?.watchEndpoint,
-                setVideoId = renderer.playlistItemData.playlistSetVideoId ?: return null,
+                setVideoId = renderer.playlistSetVideoId ?: return null,
                 libraryAddToken = PageHelper.extractFeedbackToken(renderer.menu?.menuRenderer?.items?.find {
                     it.toggleMenuServiceItemRenderer?.defaultIcon?.iconType?.startsWith("LIBRARY_") == true
                 }?.toggleMenuServiceItemRenderer, "LIBRARY_ADD"),

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
@@ -20,7 +20,7 @@ data class RelatedPage(
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.videoId ?: return null,
                 title =
                     renderer.flexColumns
                         .firstOrNull()

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchPage.kt
@@ -30,7 +30,16 @@ object SearchPage {
         return when {
             renderer.isSong -> {
                 SongItem(
-                    id = renderer.playlistItemData?.videoId ?: return null,
+                    id = renderer.playlistItemData?.videoId
+                        ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                        ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                            ?.content?.musicPlayButtonRenderer
+                            ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                        ?: renderer.flexColumns.firstOrNull()
+                            ?.musicResponsiveListItemFlexColumnRenderer
+                            ?.text?.runs?.firstOrNull()
+                            ?.navigationEndpoint?.watchEndpoint?.videoId
+                        ?: return null,
                     title =
                         renderer.flexColumns
                             .firstOrNull()

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
@@ -15,7 +15,7 @@ object SearchSuggestionPage {
         return when {
             renderer.isSong -> {
                 SongItem(
-                    id = renderer.playlistItemData?.videoId ?: return null,
+                    id = renderer.videoId ?: return null,
                     title =
                         renderer.flexColumns
                             .firstOrNull()

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
@@ -194,7 +194,16 @@ data class SearchSummaryPage(
             return when {
                 renderer.isSong -> {
                     SongItem(
-                        id = renderer.playlistItemData?.videoId ?: return null,
+                        id = renderer.playlistItemData?.videoId
+                            ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                            ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                                ?.content?.musicPlayButtonRenderer
+                                ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                            ?: renderer.flexColumns.firstOrNull()
+                                ?.musicResponsiveListItemFlexColumnRenderer
+                                ?.text?.runs?.firstOrNull()
+                                ?.navigationEndpoint?.watchEndpoint?.videoId
+                            ?: return null,
                         title =
                             renderer.flexColumns
                                 .firstOrNull()


### PR DESCRIPTION
## Summary

- **YouTube API breakages** — search/albums/playlists/artist songs broken by YouTube migrating from `musicShelfRenderer` to `itemSectionRenderer`; `playlistItemData.videoId` removed from list items; `singleColumnBrowseResultsRenderer` missing from Liked Music/Sounds from Shorts NPE; auth causing empty search results. All ported from Metrolist upstream (commits 6328d51, 4c925e6, a6ff297, d91f27d).
- **WEB_REMIX streaming** — WEB_REMIX CDN URLs return 403 on HEAD but 200 on actual byte-range GET. Skip HEAD validation for WEB_REMIX (stream client), letting ExoPlayer try directly. When ExoPlayer itself gets a 403, mark that videoId as WEB_REMIX-failed and fall through to TVHTML5 on retry — no error loop.
- **Anonymous login** — old worker (`ytzemer-token…/api/token`) is offline (HTTP 404). Switched to `mc.alltech.dev/credentials`. Cleared `dataSyncId` for anon login (sending it as `onBehalfOfUser` caused HTTP 400 on player requests). URL-decoded `visitorData` on store/load (worker returns `%3D%3D`-encoded).
- **Cipher** — updated `zemer-cipher` submodule to support VM-dispatch player `9c249f6f` (MD5 alias `a6fc27c5`): sig via `Tl(48,5831,s)`, n via `g.W_.get("n")`, STS 20602. `CipherDeobfuscator` no longer requires sig extraction to succeed before attempting n-transform.
- **Performance** — removed per-song NewPipe `StreamInfo.getInfo` pre-processing (the main source of slowness; it ran a full second extraction for every song via a stale extractor).
- **Downloads** — pass `forDownload=true` to `playerResponseForPlayback` in `DownloadUtil` (was missing); skips WEB_REMIX skip-validation so direct-URL clients are used, and excludes `audio/webm` in favour of `audio/mp4`.
- **Stream client display** — `FormatEntity` gains `streamClient` field (DB migration 31→32); shown in the media info sheet alongside bitrate/codec.
- **Version** — bumped to 25.

## Test plan

- [x] Play songs (should show `client=WEB_REMIX` in media info for most content)
- [x] Play a song that previously 403d — should retry cleanly as TVHTML5, no error shown
- [x] Anonymous login → play song (no "unknown error")
- [x] Search, artist page, album page, playlist — all load correctly
- [x] Download a song while streaming via WEB_REMIX
- [x] Media info sheet shows "Stream client" field