### PR TITLE
test: terminal streaming harness + investigation runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,12 @@ output-metadata.json
 google-services.json
 *.jks
 *.keystore
+
+# Local credentials / secrets — never commit
+innertube_cookie.txt
+*.cookie.txt
+po_token.json
+potoken.json
+
+# Node test harness deps
+tests/node_modules/

--- a/tests/INVESTIGATION.md
+++ b/tests/INVESTIGATION.md
@@ -1,0 +1,269 @@
+# Streaming investigation & runbook
+
+How we diagnosed the WEB_REMIX playback hiccups with hard data, and — more importantly —
+**how to do it again** when YouTube changes something and streaming breaks. This is the
+reference to reach for when songs start dropping, seeking fails, a player rotates, or poTokens
+stop working.
+
+Companion to [`README.md`](./README.md) (quick reference + the headline result). This file is
+the deep version: methodology, the full story, and a symptom-indexed runbook.
+
+---
+
+## 0. Principles (why the harness exists)
+
+1. **Hard data only.** Every claim is an HTTP status at a specific byte offset against the live
+   googlevideo CDN, with the real logged-in cookie. No reasoning from convention — YouTube's
+   behaviour changes faster than any blog/yt-dlp/NewPipe lore, and the lore was *wrong* here
+   (the stream URL wants a **videoId**-bound poToken, not the conventional visitorData one).
+2. **Reproduce the app's EXACT path**, not an approximation. Same `/player` request as
+   `InnerTube.kt`, same sig+n cipher as the `cipher` submodule (run in jsdom instead of an
+   Android WebView, byte-identical output), same two poTokens as `PoTokenGenerator`. A test that
+   diverges from the app proves nothing about the app.
+3. **Isolate one variable at a time.** The binding matrix (`pot-probe.mjs`) holds the request
+   constant and varies only the URL pot; the client survey (`client-fulldownload.mjs`) holds the
+   video constant and varies only the client. That's how you turn "it's broken" into "byte
+   1,048,576 returns 403 unless pot is bound to the videoId."
+
+---
+
+## 1. How the harness mirrors the app
+
+The test scripts are deliberate ports of specific app code. When the app changes, the mirror
+must change too (see §6). The mapping:
+
+| App (Kotlin) | Harness (Node) | What it reproduces |
+|---|---|---|
+| `YouTube.cookie` / `visitorData` (session) | `cred.mjs` | the logged-in session, from `innertube_cookie.txt` |
+| `InnerTube.kt` `player()` + `ytClient()` | `web-remix-stream.mjs` / `pot-probe.mjs` `playerRequest()` | the `/player` POST: context, `X-Goog-*` headers, `SAPISIDHASH`, `signatureTimestamp`, `serviceIntegrityDimensions.poToken` |
+| `models/YouTubeClient.kt` | `clients.mjs` | client name/version/id/UA/flags (WEB_REMIX id 67, IOS id 5, …) |
+| `cipher/.../PlayerJsFetcher.kt` | `cipher.mjs` `fetchPlayerJs()` | iframe_api → `player_ias.vflset/en_GB/base.js`, STS |
+| `cipher/.../FunctionNameExtractor.kt` `KNOWN_PLAYER_CONFIGS` | `cipher.mjs` `KNOWN_PLAYER_CONFIGS` | per-player sig expression (`Tl(48,5831,…)` / `Qp(25,37,…)`) + n-trick (`g.W_`/`g.W1`) + STS |
+| `cipher/.../CipherWebView.kt` (Android WebView) | `cipher.mjs` (jsdom) | injects exports into the IIFE `})(_yt_player);`, runs base.js, calls `_cipherSigFunc` / `_nTransformFunc` |
+| `cipher/.../CipherDeobfuscator.kt` | `cipher.mjs` `deobfuscateStreamUrl` / `transformNParamInUrl` | parse `s/sp/url`, apply sig, replace `n=`, append `&pot=` |
+| `cipher/.../potoken/PoTokenGenerator.kt` + `PoTokenWebView.kt` | `potoken.mjs` (bgutils-js) | BotGuard mint: streaming pot ← visitorData, player pot ← videoId, request key `O43z0dpjhgX20SCx4KAo` |
+| `YTPlayerUtils.playerResponseForPlayback()` | `web-remix-stream.mjs` `resolveAppUrl()` | full resolve: player → findFormat → sig → n → pot |
+| `YTPlayerUtils.findFormat()` | `findFormat()` in the scripts | `adaptiveFormats.filter(isAudio && isOriginal).maxBy(bitrate + webm bias)` → itag 251 opus |
+| ExoPlayer `DefaultHttpDataSource` + `RetryOn403DataSource` | `fetchRange()` / `drainWhole()` | range GETs on fresh connections; seek = range at a far offset |
+
+> The Node cipher is **not** an approximation. It downloads the same `base.js` and runs it; only
+> the JS host differs (jsdom vs Android WebView). Confirmed identical: the n-transform probe
+> `KdrqFlzJXl9EcCwlmEy → -_L5LE0VOwTkzf` matches on both, and the bgutils pot and the WebView pot
+> both unlock the same URL.
+
+---
+
+## 2. Setup
+
+1. **Cookie.** Put the dumped logged-in session at the repo root as `innertube_cookie.txt`
+   (gitignored — never commit it). Format in [`README.md` §1](./README.md). `cred.mjs` parses it.
+   - To refresh: re-dump from the app/account (the values are `HSID/SAPISID/SID/__Secure-*PSID/…`
+     cookies + `VISITOR DATA`). A stale cookie shows up as `playability != OK`.
+2. **Deps** are vendored in `tests/node_modules` (`bgutils-js`, `jsdom`, `youtubei.js`). Node ≥ 20.
+3. **Test video:** default `JTF9fLJvniI` (330 s — long enough to cross the 1 MiB wall). Override with
+   argv[1] or `VIDEO_ID`.
+
+Env knobs: `URL_POT=streaming|player|none`, `PLAYER_HASH=<hash>` (pin a player), `CHUNK`,
+`COVER_SECONDS`, `YT_COOKIE`/`YT_VISITOR_DATA` (override the file).
+
+---
+
+## 3. The investigation (what we actually did)
+
+The story, so the *method* is repeatable even if the specifics change.
+
+1. **Reproduce, don't trust HEAD.** The old probe checked `Range: bytes=0-1` (2 bytes) and
+   declared clients "streamable". That's meaningless for full playback. We instead drove the URL
+   like ExoPlayer: sequential range chunks on fresh connections until something 403s.
+   → `web-remix-stream.mjs` found the first failure at **byte 1,048,576 (1 MiB)**, ~the reported
+   "45 s drop". Seek (range at 75 %) also 403'd. Both symptoms = the same wall.
+2. **The free window is universal.** Even the IOS direct URL (no pot) 403'd past 1 MiB. So this
+   is a googlevideo rule, not WEB_REMIX-specific.
+3. **Isolate the gate.** The pot-variant probe at the failing offset: `no pot → 403`,
+   `visitorData pot → 403`, `videoId pot → 206`. The URL wants a **videoId-bound** pot.
+4. **Kill the alternatives.** `pot-probe.mjs` ran the full matrix (request-pot × url-pot ×
+   {none/videoId/visitorData-raw/visitorData-enc}) across two player versions. Only url-pot=videoId
+   served past 1 MiB → full file. visitorData encoding ruled out; request-pot irrelevant.
+5. **Find the bug in the app.** `PoTokenGenerator.getWebClientPoToken` returned
+   `PoTokenResult(playerPot=generate(videoId), streamingPot=generate(visitorData))`, and
+   `YTPlayerUtils` appends `streamingDataPoToken` (visitorData) to the URL → always 403 past 1 MiB.
+   The bindings were swapped relative to what the CDN enforces.
+6. **Fix + verify on-device.** Swapped the mapping in the cipher. Rebuilt, logged the full resolved
+   URL on device, curled it from a terminal: **206 at every range, HEAD 200, query-range 200, whole
+   file** — including from a different IP. All three songs then played on WEB_REMIX with no fallback.
+
+The fix is one mapping swap. Everything else here is the apparatus that proved it.
+
+---
+
+## 4. Running each test (and reading the output)
+
+```bash
+cd tests   # or run with tests/ prefix from repo root
+```
+
+### `cipher.mjs` — is the cipher alive on the current player?
+```bash
+node cipher.mjs
+```
+Prints the live player hash, STS, and whether sig + n work (`nProbe.changed: true`). **Run this
+first whenever streaming breaks** — if it throws "no hardcoded cipher config", YouTube rotated to
+a player neither the app nor the harness knows yet (see §5 Runbook A).
+
+### `potoken.mjs` — does BotGuard still mint?
+```bash
+node potoken.mjs JTF9fLJvniI
+```
+Prints the two tokens + lengths. If it errors, bgutils/BotGuard changed (Runbook D).
+
+### `web-remix-stream.mjs` — reproduce drop/seek; verify a fix
+```bash
+node web-remix-stream.mjs                 # URL_POT=streaming (app default) — reproduces the bug
+URL_POT=player node web-remix-stream.mjs  # videoId pot — should serve clean past the window
+```
+Read the `B/B2/C/D` lines: `B continuation` should be "no drop"; `C seek` should be 206; `D one
+open GET` should deliver the whole file. The `P pot-variant probe` shows which binding the CDN
+wants *right now*.
+
+### `pot-probe.mjs` — the definitive binding matrix
+```bash
+node pot-probe.mjs
+```
+The source of truth for "which pot does the URL want". If the answer ever stops being "videoId",
+this is what tells you the new answer (Runbook B).
+
+### `client-fulldownload.mjs` — which clients deliver a whole song
+```bash
+node client-fulldownload.mjs              # uses the live player
+PLAYER_HASH=4f38b487 node client-fulldownload.mjs   # pin a known player for determinism
+```
+Drains the entire file per client. Use it to re-pick the fallback order when a client breaks
+(Runbook C).
+
+---
+
+## 5. Runbook — "streaming broke again, now what?"
+
+Work top-down. `cipher.mjs` and `potoken.mjs` are the two health checks; run them first.
+
+### A. `cipher.mjs` throws `no hardcoded cipher config for live player (hashes: XXXX, YYYY)`
+YouTube rotated to a new `player_ias` and neither the app's `FunctionNameExtractor` nor
+`cipher.mjs` has its sig/n recipe. This is the **most common** future break (the app has an hourly
+hash monitor for exactly this).
+
+- **To keep testing immediately:** pin a still-served known player —
+  `PLAYER_HASH=4f38b487 node web-remix-stream.mjs`. The STS you send in the `/player` request makes
+  YouTube return a signatureCipher compatible with that base.js, so decipher stays valid even if it
+  isn't the "current" rotated player. (Verified: pinning 4f38b487 worked while the live player was
+  the unconfigured `0006d355`.)
+- **To actually support the new player:** add an entry to **both**
+  `cipher/library/.../FunctionNameExtractor.kt` `KNOWN_PLAYER_CONFIGS` (app, the real fix) and
+  `tests/cipher.mjs` `KNOWN_PLAYER_CONFIGS` (harness mirror), keyed by both the URL hash and the
+  MD5-of-first-10000-bytes alias. Each entry needs:
+  - `sigExpr`: the VM-dispatch expression that transforms `s`, e.g. `Tl(48,5831,INPUT)` (player
+    4f38b487/9c249f6f) or `Qp(25,37,INPUT)` (5cabb421). Derive by reversing the new base.js: find
+    the function that consumes `decodeURIComponent(...s)` and note the global dispatch name + its two
+    integer constants.
+  - `nExpr`: the URL-parser trick — `new g.W_('…?n='+n,true).get('n')` (the class name `W_`/`W1`
+    changes per player; it's the player's internal URL parser).
+  - `sts`: from `signatureTimestamp:(\d+)` in base.js.
+  - Confirm with `node cipher.mjs` → `sig=true n=true`, n probe `changed:true`.
+
+### B. Songs drop after N seconds / 403 mid-playback / seek fails
+The throttle/pot rule changed. Re-derive it empirically:
+1. `node web-remix-stream.mjs` → note the `B continuation` first-failure byte offset (the new "free
+   window"; was 1,048,576).
+2. `node pot-probe.mjs` → read which `url pot=` column serves past that offset. If it's no longer
+   `videoId`, that's the new required binding.
+3. Apply it in `cipher/.../PoTokenGenerator.kt` (which token goes to `streamingDataPoToken`) and
+   re-verify with `URL_POT=… node web-remix-stream.mjs`. Mirror any token-binding change into
+   `potoken.mjs`.
+4. If *no* pot works, the gate moved elsewhere — check `c=` client, the `n` transform (wrong n →
+   throttle/403), or a new required URL param.
+
+### C. A client that used to work now 403s (e.g. IOS broke)
+`node client-fulldownload.mjs` (pin a player for a clean comparison). It shows, per client,
+whether the whole song downloads. Re-rank `STREAM_FALLBACK_CLIENTS` in `YTPlayerUtils.kt` toward
+whatever still returns "WHOLE SONG" (as of this writing: ANDROID_VR with no pot; WEB_REMIX with the
+videoId pot; IOS/IPADOS were broken past 1 MiB).
+
+### D. `potoken.mjs` errors / poToken rejected (`UNPLAYABLE` even with pot)
+BotGuard/`bgutils-js` drift, or the web request key changed.
+- Update `bgutils-js` (`tests/package.json`).
+- Confirm the request key still matches the app: `O43z0dpjhgX20SCx4KAo` in both
+  `potoken.mjs` (`WEB_REQUEST_KEY`) and `PoTokenWebView.kt` (`REQUEST_KEY`).
+- Remember the harness mints via bgutils while the app mints via an Android WebView — both have
+  worked interchangeably, but if only one breaks, suspect that path specifically.
+
+### E. `playability != OK` (`LOGIN_REQUIRED` / `UNPLAYABLE` / HTTP 400)
+- Cookie expired → refresh `innertube_cookie.txt`.
+- Client version stale → bump in `clients.mjs` *and* `YouTubeClient.kt` (compare against a fresh
+  `music.youtube.com` to get the current `clientVersion`).
+- HTTP 400 on a logged-in request → check you're not sending `onBehalfOfUser`/`dataSyncId` where it
+  isn't wanted (historically broke WEB_REMIX; session id must be `visitorData`).
+
+### F. On-device disagrees with the harness
+Capture the app's real URL and curl it from the **same network** (the URL has `ip=` in `sparams`;
+test from the phone via termux, or a box on the same NAT):
+1. Temporarily log the full URL in `YTPlayerUtils` after the pot append
+   (`android.util.Log.i(TAG, "ZURL … :: \$streamUrl")`), rebuild.
+2. `U=$(adb logcat -d | grep 'ZURL' | tail -1 | sed 's/^.*:: //')`
+3. `curl -s -o /dev/null -w "%{http_code}\n" -r 1048576-1310719 "$U"` (and HEAD, and `&range=`).
+4. Remove the temp log before committing.
+
+---
+
+## 6. Keeping the harness in sync with the app
+
+The Node mirror duplicates app constants on purpose. When these app files change, update the mirror:
+
+| App change | Update in harness |
+|---|---|
+| `YouTubeClient.kt` client versions/UAs | `clients.mjs` |
+| `FunctionNameExtractor.kt` `KNOWN_PLAYER_CONFIGS` (new player) | `cipher.mjs` `KNOWN_PLAYER_CONFIGS` |
+| `PoTokenGenerator.kt` token bindings | `potoken.mjs` `mintWebPoTokens` + the `URL_POT` mapping in `web-remix-stream.mjs` |
+| `PoTokenWebView.kt` `REQUEST_KEY` | `potoken.mjs` `WEB_REQUEST_KEY` |
+| `YTPlayerUtils.findFormat()` selection | `findFormat()` in the scripts |
+| `PlayerJsFetcher` base.js URL (locale path) | `cipher.mjs` `PLAYER_JS_URL` |
+
+A quick `node cipher.mjs && node potoken.mjs && URL_POT=player node web-remix-stream.mjs` after any
+of these confirms the harness still resolves a playable stream.
+
+---
+
+## 7. Reference facts (as of 2026-06-04)
+
+- **Free window:** googlevideo serves the first **1,048,576 bytes (1 MiB)** of a stream without a
+  valid content pot; past that, every new connection 403s.
+- **Required pot binding:** stream URL `&pot=` must be bound to the **videoId**; the `/player`
+  request pot is bound to the **session (visitorData)**. (Opposite of the common convention.)
+- **Player rotation:** iframe_api rotates `player_ias` hashes frequently (saw `4f38b487` STS 20602,
+  `5cabb421` STS 20606, and a fresh unconfigured `0006d355` within one session). The MD5-of-first-
+  10000-bytes alias matters because some players have no self-referencing URL inside the JS.
+- **Chosen format:** itag 251 (opus, webm) — `findFormat` adds a +10240 webm bias.
+- **Request key (web BotGuard):** `O43z0dpjhgX20SCx4KAo`.
+- **base.js:** `https://www.youtube.com/s/player/<hash>/player_ias.vflset/en_GB/base.js`, hash from
+  `https://www.youtube.com/iframe_api`.
+- **Full-song delivery (this date):** ANDROID_VR ✅ (no pot/cipher), WEB_REMIX ✅ (with videoId pot),
+  IOS/IPADOS ❌ (403 past 1 MiB).
+
+## 8. Gotchas (things that wasted time, so they don't again)
+
+- **2-byte checks lie.** `Range: bytes=0-1` returning 206 says nothing about full playback — the
+  1 MiB gate is past it. Always drain or range past the window.
+- **visitorData encoding.** Stored URL-encoded (`…%3D%3D`). Decode once and use the same string for
+  the request header *and* the pot binding. Both raw `==` and encoded `%3D%3D` were tested — neither
+  visitorData binding works on the URL; only videoId does (so encoding wasn't the cause).
+- **`ip=` in `sparams` is not strictly enforced.** The on-device URL served 206 from a different
+  IP. Don't assume IP-lock; but for an apples-to-apples on-device check, still curl from the same
+  network (Runbook F).
+- **HEAD validation is a false-negative trap.** `YTPlayerUtils.validateStatus` does a HEAD; it has
+  historically 403'd on URLs that GET fine. With the pot fixed, HEAD now returns 200 — but the
+  `webRemixFailedIds` + HEAD path can still spuriously demote WEB_REMIX after one transient failure.
+  Candidate for removal now that the pot is correct.
+- **logcat truncates** long lines (~4 kB) and **duplicates** under `su -c logcat` — a ~1.8 kB
+  stream URL fits, but grep/tail for the latest.
+- **Signed URLs expire** ~6 h (`expire=` / "Expires in: 21540s"). Re-resolve if a curl suddenly
+  403s everywhere — it may just be stale.
+- **Don't trust convention over the matrix.** yt-dlp/NewPipe say streaming=visitorData; the CDN
+  said videoId. `pot-probe.mjs` is the arbiter.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,154 @@
+# tests/ — YouTube Music streaming harness (terminal, hard data)
+
+Node scripts that reproduce the app's streaming pipeline **exactly** (same `/player` request,
+same cipher, same poTokens) so playback behaviour can be measured against the live CDN without
+building the APK. Source of truth is the terminal output, not guesses.
+
+All scripts run from the repo root or `tests/`. Node ≥ 20. Deps (`bgutils-js`, `jsdom`,
+`youtubei.js`) are vendored in `tests/node_modules`.
+
+> **When streaming breaks again** (player rotation, pot scheme change, a client stops working),
+> see **[`INVESTIGATION.md`](./INVESTIGATION.md)** — the full methodology + a symptom-indexed
+> runbook ("songs drop after N seconds → run X", "cipher throws no-config → do Y", etc.).
+
+---
+
+## Setup
+
+### 1. Credentials — `innertube_cookie.txt` (gitignored)
+
+Drop the dumped session at the repo root as `innertube_cookie.txt`:
+
+```
+***INNERTUBE COOKIE*** =HSID=...; SAPISID=...; SID=...; __Secure-1PSID=...; ...
+***VISITOR DATA*** =<your-visitor-data, e.g. Cgs...%3D%3D>
+***DATASYNC ID*** =
+***ACCOUNT NAME*** =
+***ACCOUNT EMAIL*** =
+***ACCOUNT CHANNEL HANDLE*** =
+```
+
+`cred.mjs` parses this. It is **gitignored** (`innertube_cookie.txt`, `*.cookie.txt`,
+`po_token.json`, `potoken.json`) — these are live Google account cookies, never commit them.
+
+Overrides (take precedence over the file): `YT_COOKIE`, `YT_VISITOR_DATA`, `YT_DATASYNC_ID`,
+`COOKIE_FILE`, or `CRED_URL` (remote worker, only used if nothing local is found).
+
+### 2. Test song
+
+Default video is `JTF9fLJvniI` (a 330s track — long enough to cross the 1-MiB pot wall). Pass a
+different id as the first CLI arg or via `VIDEO_ID`.
+
+---
+
+## Scripts
+
+| script | what it does |
+|---|---|
+| `cred.mjs` | Loads cookie/visitorData/dataSyncId from `innertube_cookie.txt` (+ env overrides). |
+| `cipher.mjs` | Faithful Node port of the app's **Zemer cipher** (sig deobfuscation + n-transform + STS). Fetches the **same** `base.js` (iframe_api → `player_ias.vflset/en_GB/base.js`), injects the **same** VM-dispatch expressions (`Tl(48,5831,sig)` / `Qp(25,37,sig)`, `g.W_`/`g.W1` n-trick) into the IIFE, and runs it in jsdom. Byte-identical to `CipherWebView`. |
+| `potoken.mjs` | BotGuard **poToken** minter (`bgutils-js` + jsdom), request key `O43z0dpjhgX20SCx4KAo`. Mirrors the app's `PoTokenGenerator`: **streaming token bound to visitorData** (minted first), **player token bound to videoId**. |
+| `web-remix-stream.mjs` | Reproduces the WEB_REMIX **45s-drop + seek** bug via the app's exact resolve path, then exercises the URL like ExoPlayer (sequential range chunks on fresh connections, seek, one open GET, re-resolve, pot-variant probe) + an IOS control. |
+| `pot-probe.mjs` | The **definitive poToken-binding matrix**: request-pot × url-pot × {none/videoId/visitorData-raw/visitorData-enc}, fetched past the 1-MiB window. |
+| `client-fulldownload.mjs` | Drains the **whole** file per client to show which clients actually deliver a full song right now (vs the old 2-byte check). |
+| `run.mjs`, `full-stream.mjs`, `retest-web.mjs`, `clients.mjs` | Older player-endpoint probes / client matrix (kept for reference). |
+
+### Run them
+
+```bash
+node tests/cipher.mjs                 # self-test: live player hash, STS, sig/n working?
+node tests/potoken.mjs JTF9fLJvniI    # mint the token pair, print bindings/lengths
+node tests/web-remix-stream.mjs                      # reproduce the bug (URL_POT=streaming, default)
+URL_POT=player node tests/web-remix-stream.mjs       # verify the fix (videoId-bound pot)
+node tests/pot-probe.mjs                             # the binding matrix
+node tests/client-fulldownload.mjs                   # per-client whole-song delivery
+```
+
+Useful env: `URL_POT=streaming|player|none`, `CHUNK=262144`, `COVER_SECONDS=90`,
+`PLAYER_HASH=4f38b487` (pin a known-configured player so a freshly-rotated player can't break the
+cipher mid-test — the matching STS is sent in the `/player` request, keeping decipher valid).
+
+> When YouTube rotates to a player hash not in `cipher.mjs`'s `KNOWN_PLAYER_CONFIGS` (mirrors the
+> app's `FunctionNameExtractor.KNOWN_PLAYER_CONFIGS`), `cipher.mjs` throws — the app would also
+> need a new config (its hourly hash monitor exists for this). Pin a known hash to keep testing.
+
+---
+
+## Results — the WEB_REMIX hiccup (2026-06-04, video `JTF9fLJvniI`, logged-in cookie)
+
+### Reproduced
+
+The app's exact WEB_REMIX path resolves fine (`playability=OK`, itag 251 opus, sig+n applied,
+`pot=` appended). The CDN URL is `clen=5,878,798` bytes / 330s (≈17.8 KB/s).
+
+```
+A initial   bytes=0-262143               -> 206
+B continuation (fresh conn / chunk)      -> 403 at byte 1,048,576  (= 1 MiB ≈ 59s)
+C seek @75%                              -> 403 (header AND query range)
+D one open GET bytes=0-                  -> 403, 0 bytes delivered
+```
+
+- **45s drop** = the CDN serves the first **1 MiB** then 403s every *new connection* (next chunk).
+- **Seek → fallback** = a seek is just a new connection at a far offset; same 403.
+
+Both are the same failure: any connection past the 1-MiB free window is rejected.
+
+### Root cause — the appended poToken is bound to the wrong thing
+
+`pot-probe.mjs`, holding everything else constant and fetching past 1 MiB:
+
+```
+                       @1 MiB   @2 MiB
+url pot = none          403      403
+url pot = videoId       206      206   ✓  → full file 5,878,798 B downloads
+url pot = visitorData    403      403       (raw "==" AND url-encoded "%3D%3D" both fail)
+```
+
+- Independent of what's sent in the `/player` request, and reproduced across two player versions
+  (`4f38b487` STS 20602 and `5cabb421` STS 20606). visitorData encoding ruled out.
+- **The stream URL's `pot=` must be bound to the videoId.**
+
+The app does the opposite. `PoTokenGenerator.getWebClientPoToken(videoId, sessionId)` returns
+`PoTokenResult(playerPot = generate(videoId), streamingPot = generate(visitorData))`, and
+`YTPlayerUtils` appends `streamingDataPoToken` (= `streamingPot` = **visitorData-bound**) to the
+URL while sending `playerRequestPoToken` (= **videoId-bound**) in the request. The two are swapped
+relative to what googlevideo enforces, so every WEB_REMIX stream 403s at 1 MiB → fallback restart.
+
+### Fix — verified end to end
+
+Append the **videoId-bound** token to the stream URL (`URL_POT=player`):
+
+```
+A initial                     -> 206
+B  continuation (header)      -> all 206 through 132.5s — no drop
+B2 continuation (query)       -> all 206 through 132.5s — no drop
+C  seek @75%                  -> 206 / 200
+D  one open GET               -> 206, whole file 5741KB/5741KB (330s)
+```
+
+Code fix options (pick one):
+- **App side (smallest):** in `YTPlayerUtils.playerResponseForPlayback`, append
+  `poTokenResult.playerRequestPoToken` (videoId-bound) to `streamUrl` instead of
+  `streamingDataPoToken`.
+- **Cipher side (clearer names):** in `PoTokenGenerator.getWebClientPoToken`, swap the bindings so
+  `streamingDataPoToken` is `generate(videoId)` and `playerRequestPoToken` is `generate(visitorData)`.
+
+### Which clients deliver a WHOLE song right now
+
+`client-fulldownload.mjs` (full drain, not a 2-byte check):
+
+| client | full song? | needs |
+|---|---|---|
+| **ANDROID_VR_1_43_32 / _NO_AUTH / _1_61_48** | ✅ whole song | nothing — anon, direct url, no pot/cipher/BotGuard |
+| **WEB_REMIX** | ✅ **only with the videoId-pot fix** | poToken (videoId-bound) + sig/n cipher |
+| **IOS / IPADOS** | ❌ 403 (hits the 1-MiB wall, no pot) | — no longer reliable for full playback |
+
+Implications for `STREAM_FALLBACK_CLIENTS` (currently `TVHTML5, ANDROID_VR_1_43_32, IOS, IPADOS, …`):
+- **ANDROID_VR is the reliable no-pot path** — fastest (one anonymous request, no BotGuard, no
+  decipher) and delivers the whole song. Strong candidate to rank first, or to be the stream client.
+- **IOS/IPADOS 403 past 1 MiB** — they would re-trigger the same hiccup if reached; deprioritise.
+- **TVHTML5** is a web/pot client and hits the same 1-MiB rule — it needs the same videoId-pot fix.
+
+> Note: the earlier "Findings (2026-06-02)" in this file concluded IOS/ANDROID_VR "stream in one
+> request". That was based on `Range: bytes=0-1` (first 2 bytes) and does **not** hold for full
+> playback — IOS 403s past 1 MiB. Use `client-fulldownload.mjs` for the real picture.

--- a/tests/analyze-player.mjs
+++ b/tests/analyze-player.mjs
@@ -1,0 +1,53 @@
+// Reverse-engineer the live player JS: locate the signature-decipher and n-transform
+// functions and their call sites, so the cipher's FunctionNameExtractor regexes can be
+// updated. Run against the variant the cipher fetches (player_ias).
+//
+//   PLAYER_JS=/tmp/player_ias.js node tests/analyze-player.mjs
+import fs from "node:fs";
+
+const js = fs.readFileSync(process.env.PLAYER_JS || "/tmp/player_ias.js", "utf8");
+console.log(`player.js: ${js.length} bytes\n`);
+
+function show(re, label, before = 80, after = 200, max = 4) {
+  const g = new RegExp(re.source, re.flags.includes("g") ? re.flags : re.flags + "g");
+  let m, n = 0;
+  console.log(`### ${label}`);
+  while ((m = g.exec(js)) && n < max) {
+    n++;
+    console.log(`  @${m.index}: ...${js.slice(Math.max(0, m.index - before), m.index + after).replace(/\s+/g, " ")}...`);
+  }
+  if (n === 0) console.log("  (no match)");
+  console.log();
+}
+
+// ---- signature decipher ----
+// classic call site: X.set("signature"|sp, FUNC(decodeURIComponent(...)))  OR  m=FUNC(decodeURIComponent(...))
+show(/[a-zA-Z0-9_$]+\(decodeURIComponent\(/, "X(decodeURIComponent( — sig call candidates", 50, 70, 8);
+// the decipher fn itself: NAME=function(a){a=a.split("");...;return a.join("")}
+show(/[a-zA-Z0-9_$]{1,4}=function\([a-z]\)\{[a-z]=[a-z]\.split\(""\)/, "split/join decipher fn defs", 5, 180, 4);
+show(/\.set\((?:"signature"|"sig"|[a-z]\.sp\b|[a-z]\.sp\|\|)/, ".set(signature|sig|sp)", 90, 90, 4);
+
+// ---- n-transform ----
+show(/\.get\("n"\)/, 'get("n") sites', 90, 160, 6);
+// modern n-name forms: ...=NFUNC[idx](X)  guarded by get("n")  /  fromCharCode(110)
+show(/b=String\.fromCharCode\(110\)/, "String.fromCharCode(110) (='n')", 30, 160, 3);
+// n function def shape: NAME=function(a){var b=a.split(...)
+show(/[a-zA-Z0-9_$]{1,4}=function\([a-z]\)\{var [a-z]=[a-z]\.split\(/, "n-style function defs (var b=a.split)", 5, 120, 4);
+
+// ---- try a couple of yt-dlp-style name regexes ----
+const sigYt = [
+  /\b[a-zA-Z0-9$]{2,}&&\([a-zA-Z0-9$]=([a-zA-Z0-9$]{2,})\(decodeURIComponent\(/,
+  /([a-zA-Z0-9$]{2,})\(decodeURIComponent\([a-zA-Z0-9$.]+\)\)/,
+  /\.set\([^,]+,encodeURIComponent\(([a-zA-Z0-9$]+)\(/,
+];
+console.log("### yt-dlp-style SIG name probes");
+sigYt.forEach((re, i) => { const m = js.match(re); console.log(`  [${i}] ${m ? "name=" + m[1] : "no match"}`); });
+console.log();
+
+const nYt = [
+  /\.get\("n"\)\)&&\([a-z]=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\([a-z]\)/,
+  /[a-zA-Z0-9$]+=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\([a-z]\)(?:,[a-zA-Z0-9$]+\.set\("n"?,)/,
+  /([a-zA-Z0-9$]+)(?:\[(\d+)\])?\([a-z]\),[a-zA-Z0-9$]+\.set\("n"/,
+];
+console.log("### yt-dlp-style N name probes");
+nYt.forEach((re, i) => { const m = js.match(re); console.log(`  [${i}] ${m ? "nfunc=" + m[1] + " idx=" + (m[2] ?? "-") : "no match"}`); });

--- a/tests/cipher-check.mjs
+++ b/tests/cipher-check.mjs
@@ -1,0 +1,67 @@
+// Hard-data check: run zemer-cipher's FunctionNameExtractor regexes (ported verbatim
+// from FunctionNameExtractor.kt) against the live player JS to see whether the cipher
+// can actually extract the signature + n-transform functions for the CURRENT player.
+//
+//   node tests/cipher-check.mjs            (expects /tmp/player_base.js)
+import fs from "node:fs";
+
+const PATH = process.env.PLAYER_JS || "/tmp/player_base.js";
+const js = fs.readFileSync(PATH, "utf8");
+console.log(`player.js: ${js.length} bytes (${PATH})\n`);
+
+// --- Q-array obfuscation (the thing the cipher was updated for, on player 74edf1a3) ---
+const Q_ARRAY = /var\s+Q\s*=\s*"[^"]+"\s*\.\s*split\s*\(\s*"\}"\s*\)/;
+const qMatch = js.match(Q_ARRAY);
+console.log(`Q-array obfuscation: ${qMatch ? "YES" : "no"}`);
+console.log(`"enhanced_except_" present: ${/enhanced_except_/.test(js)}`);
+console.log(`'.get("n")' present: ${/\.get\("n"\)/.test(js)}\n`);
+
+// --- SIG function patterns (verbatim from FunctionNameExtractor.SIG_FUNCTION_PATTERNS) ---
+const SIG = [
+  /&&\s*\(\s*[a-zA-Z0-9$]+\s*=\s*([a-zA-Z0-9$]+)\s*\(\s*(\d+)\s*,\s*decodeURIComponent\s*\(\s*[a-zA-Z0-9$]+\s*\)/,
+  /\b[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*encodeURIComponent\(([a-zA-Z0-9$]+)\(/,
+  /\b[a-zA-Z0-9]+\s*&&\s*[a-zA-Z0-9]+\.set\([^,]+\s*,\s*encodeURIComponent\(([a-zA-Z0-9$]+)\(/,
+  /\bm=([a-zA-Z0-9$]{2,})\(decodeURIComponent\(h\.s\)\)/,
+  /\bc\s*&&\s*d\.set\([^,]+\s*,\s*(?:encodeURIComponent\s*\()([a-zA-Z0-9$]+)\(/,
+  /\bc\s*&&\s*[a-z]\.set\([^,]+\s*,\s*encodeURIComponent\(([a-zA-Z0-9$]+)\(/,
+];
+console.log("--- SIG function patterns ---");
+let sigName = null;
+SIG.forEach((re, i) => {
+  const m = js.match(re);
+  if (m && !sigName) sigName = m[1];
+  console.log(`  [${i}] ${m ? `MATCH name=${m[1]} arg=${m[2] ?? "-"}` : "no match"}`);
+});
+console.log(`SIG extracted: ${sigName ? `YES (${sigName})` : "NO"}\n`);
+
+// --- N function patterns (verbatim from N_FUNCTION_PATTERNS) ---
+const N = [
+  /\.get\("n"\)\)&&\(b=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(([a-zA-Z0-9])\)/,
+  /\.get\("n"\)\)\s*&&\s*\(([a-zA-Z0-9$]+)\s*=\s*([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(\1\)/,
+  /\(\s*([a-zA-Z0-9$]+)\s*=\s*String\.fromCharCode\(110\)/,
+  /([a-zA-Z0-9$]+)\s*=\s*function\([a-zA-Z0-9]\)\s*\{[^}]*?enhanced_except_/,
+];
+console.log("--- N function patterns ---");
+let nName = null;
+N.forEach((re, i) => {
+  const m = js.match(re);
+  if (m && !nName) nName = m[1];
+  console.log(`  [${i}] ${m ? `MATCH groups=${JSON.stringify(m.slice(1))}` : "no match"}`);
+});
+console.log(`N extracted: ${nName ? `YES (${nName})` : "NO"}\n`);
+
+// --- signatureTimestamp ---
+const STS = [/signatureTimestamp['":\s]+(\d+)/, /sts['":\s]+(\d+)/, /"signatureTimestamp"\s*:\s*(\d+)/];
+let sts = null;
+for (const re of STS) { const m = js.match(re); if (m) { sts = m[1]; break; } }
+console.log(`signatureTimestamp: ${sts ?? "NOT FOUND"}`);
+
+// --- hardcoded fallback availability ---
+const playerVer = "9c249f6f";
+const KNOWN = ["74edf1a3"];
+console.log(`\nhardcoded config for live player ${playerVer}: ${KNOWN.includes(playerVer) ? "yes" : "NO (only " + KNOWN.join(",") + ")"}`);
+
+console.log("\n=== VERDICT ===");
+const ok = sigName && nName;
+if (ok) console.log(`Cipher CAN extract on ${playerVer}: sig=${sigName}, n=${nName}, sts=${sts}`);
+else console.log(`Cipher CANNOT fully extract on ${playerVer}: sig=${sigName ? "ok" : "FAIL"}, n=${nName ? "ok" : "FAIL"} — and no hardcoded fallback → web clients will fail deciphering, falling back to direct-url clients.`);

--- a/tests/cipher.mjs
+++ b/tests/cipher.mjs
@@ -1,0 +1,205 @@
+// Faithful Node port of the app's Zemer cipher (sig deobfuscation + n-transform + STS).
+//
+// It does EXACTLY what cipher/library/.../CipherWebView.kt does, just in jsdom instead of
+// an Android WebView:
+//   1. fetch the SAME base.js (iframe_api -> hash -> player_ias.vflset/en_GB/base.js)
+//   2. inject the SAME exports into the IIFE closure ("})(_yt_player);"):
+//        window._cipherSigFunc  = function(sig){ try { return <sigExpr> } catch(e){ return null } }
+//        window._nTransformFunc = function(n)  { try { return <nExpr>  } catch(e){ return n } }
+//      using the SAME hardcoded VM-dispatch expressions (Tl(48,5831,sig) / Qp(25,37,sig),
+//      and the g.W_/g.W1 ".get('n')" URL-param trick) keyed by player hash.
+//   3. run base.js, then call those two functions.
+//   4. assemble the URL the SAME way: url + "&{sp}=" + enc(sig), then replace n=, then &pot=.
+//
+// Because it's the same base.js and the same expressions, the resulting URL is byte-identical
+// to what YTPlayerUtils.findUrlOrNull + transformNParamInUrl produce on-device.
+
+import crypto from "node:crypto";
+import { JSDOM } from "jsdom";
+
+const IFRAME_API_URL = "https://www.youtube.com/iframe_api";
+const PLAYER_JS_URL = (hash) =>
+  `https://www.youtube.com/s/player/${hash}/player_ias.vflset/en_GB/base.js`;
+
+// Ported from FunctionNameExtractor.KNOWN_PLAYER_CONFIGS (expression-based, current players).
+// Keyed by BOTH the URL hash and the MD5-of-first-10000 fallback alias.
+const KNOWN_PLAYER_CONFIGS = {
+  // 9c249f6f / a6fc27c5 (2026-05-31)
+  "9c249f6f": { sigExpr: "Tl(48,5831,INPUT)", nExpr: nTrick("W_"), sts: 20602 },
+  "a6fc27c5": { sigExpr: "Tl(48,5831,INPUT)", nExpr: nTrick("W_"), sts: 20602 },
+  // 4f38b487 / 1215646b (2026-06-03)
+  "4f38b487": { sigExpr: "Tl(48,5831,INPUT)", nExpr: nTrick("W_"), sts: 20602 },
+  "1215646b": { sigExpr: "Tl(48,5831,INPUT)", nExpr: nTrick("W_"), sts: 20602 },
+  // 5cabb421 / 94f9ca52 (2026-06-03, TVHTML5 Q-array)
+  "5cabb421": { sigExpr: "Qp(25,37,INPUT)", nExpr: nTrick("W1"), sts: 20606 },
+  "94f9ca52": { sigExpr: "Qp(25,37,INPUT)", nExpr: nTrick("W1"), sts: 20606 },
+};
+
+function nTrick(urlClass) {
+  // The app's nJsExpression: parse a fake googlevideo URL with the player's own URL class and
+  // read back the VM-transformed "n" query param.
+  return `(function(n){try{var u=new g.${urlClass}('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)`;
+}
+
+const SIG_TS_PATTERNS = [/signatureTimestamp['":\s]+(\d+)/, /\bsts['":\s]+(\d+)/];
+
+function md5hash4(s) {
+  return crypto.createHash("md5").update(Buffer.from(s.slice(0, 10000), "utf8")).digest("hex").slice(0, 8);
+}
+
+function extractHashesFromJs(playerJs) {
+  const out = [];
+  const pats = [
+    /jsUrl['":\s]+[^"']*?\/player\/([a-f0-9]{8})\//,
+    /player_ias\.vflset\/[^/]+\/([a-f0-9]{8})\//,
+    /\/s\/player\/([a-f0-9]{8})\//,
+  ];
+  for (const p of pats) { const m = playerJs.match(p); if (m) out.push(m[1]); }
+  out.push(md5hash4(playerJs));
+  return [...new Set(out)];
+}
+
+export function extractSignatureTimestamp(playerJs, hashes = []) {
+  for (const p of SIG_TS_PATTERNS) { const m = playerJs.match(p); if (m) return Number(m[1]); }
+  for (const h of hashes) if (KNOWN_PLAYER_CONFIGS[h]) return KNOWN_PLAYER_CONFIGS[h].sts;
+  return null;
+}
+
+export async function fetchPlayerJs() {
+  // PLAYER_HASH pins a specific player (e.g. a known-configured one) instead of whatever
+  // iframe_api currently rotates to — makes tests deterministic. The matching STS is sent in
+  // the /player request, so the returned signatureCipher stays compatible with this base.js.
+  let urlHash = process.env.PLAYER_HASH;
+  if (!urlHash) {
+    const iframe = await (await fetch(IFRAME_API_URL, { headers: { "User-Agent": "Mozilla/5.0" } })).text();
+    // iframe_api JSON-escapes its slashes: \/s\/player\/HASH\/ — tolerate optional backslashes.
+    const m = iframe.match(/\\?\/s\\?\/player\\?\/([a-zA-Z0-9_-]+)\\?\//);
+    if (!m) throw new Error("could not extract player hash from iframe_api");
+    urlHash = m[1];
+  }
+  const playerJs = await (await fetch(PLAYER_JS_URL(urlHash), { headers: { "User-Agent": "Mozilla/5.0" } })).text();
+  return { playerJs, urlHash };
+}
+
+/**
+ * Build a cipher bound to the live base.js. Returns:
+ *   { hash, sts, sigAvailable, nAvailable, deobfuscateSignature, transformN,
+ *     deobfuscateStreamUrl, transformNParamInUrl }
+ */
+export async function createCipher({ verbose = false } = {}) {
+  const { playerJs, urlHash } = await fetchPlayerJs();
+  const hashes = [urlHash, ...extractHashesFromJs(playerJs)];
+  const uniq = [...new Set(hashes)];
+  const cfgKey = uniq.find((h) => KNOWN_PLAYER_CONFIGS[h]);
+  const cfg = cfgKey ? KNOWN_PLAYER_CONFIGS[cfgKey] : null;
+  const sts = extractSignatureTimestamp(playerJs, uniq);
+
+  if (verbose) {
+    console.error(`cipher: urlHash=${urlHash} hashes=[${uniq.join(",")}] cfg=${cfgKey || "NONE"} sts=${sts}`);
+  }
+  if (!cfg) {
+    throw new Error(
+      `no hardcoded cipher config for live player (hashes: ${uniq.join(", ")}). ` +
+      `The app would also need a new config for this player — update KNOWN_PLAYER_CONFIGS.`,
+    );
+  }
+
+  // Inject the exports into the IIFE closure, exactly like CipherWebView.loadPlayerJsFromFile().
+  const sigStmt = `window._cipherSigFunc = function(sig){ try { return ${cfg.sigExpr.replace("INPUT", "sig")}; } catch(e){ return null; } };`;
+  const nStmt = `window._nTransformFunc = function(n){ try { return ${cfg.nExpr.replace("INPUT", "n")}; } catch(e){ return n; } };`;
+  const exportCode = `; ${sigStmt} ${nStmt} `;
+  let modified = playerJs.replace("})(_yt_player);", `${exportCode}})(_yt_player);`);
+  if (modified === playerJs) {
+    if (verbose) console.error("cipher: injection point '})(_yt_player);' not found — appending");
+    modified = `${playerJs}\n${exportCode}`;
+  }
+
+  // Run base.js in a browser-ish env (jsdom). outside-only lets us window.eval our script
+  // while NOT auto-running any <script> tags.
+  const dom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>", {
+    url: "https://www.youtube.com/",
+    pretendToBeVisual: true,
+    runScripts: "outside-only",
+  });
+  const win = dom.window;
+  win._yt_player = {}; // the IIFE arg `g`
+  // A couple of stubs base.js may poke at during init that jsdom lacks.
+  if (!win.TextEncoder) win.TextEncoder = TextEncoder;
+  if (!win.TextDecoder) win.TextDecoder = TextDecoder;
+
+  let initError = null;
+  try {
+    win.eval(modified);
+  } catch (e) {
+    initError = e;
+    if (verbose) console.error(`cipher: base.js eval threw: ${e.message}`);
+  }
+
+  const sigFn = win._cipherSigFunc;
+  const nFn = win._nTransformFunc;
+  const sigAvailable = typeof sigFn === "function";
+  const nAvailable = typeof nFn === "function";
+
+  // Validate n function with the same probe the app uses.
+  let nProbe = null;
+  if (nAvailable) {
+    try {
+      const probeIn = "KdrqFlzJXl9EcCwlmEy";
+      const probeOut = nFn(probeIn);
+      nProbe = { in: probeIn, out: probeOut, changed: probeOut && probeOut !== probeIn };
+    } catch (e) { nProbe = { error: e.message }; }
+  }
+
+  function deobfuscateSignature(obfuscatedSig) {
+    if (!sigAvailable) throw new Error("sig function not available");
+    const r = sigFn(obfuscatedSig);
+    if (r == null) throw new Error("sig function returned null");
+    return String(r);
+  }
+  function transformN(nValue) {
+    if (!nAvailable) return nValue;
+    const r = nFn(nValue);
+    return r == null ? nValue : String(r);
+  }
+
+  // url + "&{sp}=" + enc(sig) — matches CipherDeobfuscator.deobfuscateInternal.
+  function deobfuscateStreamUrl(signatureCipher) {
+    const params = {};
+    for (const pair of signatureCipher.split("&")) {
+      const i = pair.indexOf("=");
+      if (i > 0) params[decodeURIComponent(pair.slice(0, i))] = decodeURIComponent(pair.slice(i + 1));
+    }
+    const s = params["s"], sp = params["sp"] || "signature", baseUrl = params["url"];
+    if (s == null || baseUrl == null) throw new Error("signatureCipher missing s/url");
+    const sig = deobfuscateSignature(s);
+    const sep = baseUrl.includes("?") ? "&" : "?";
+    return `${baseUrl}${sep}${sp}=${encodeURIComponent(sig)}`;
+  }
+
+  // replace n= with transform(n) — matches CipherDeobfuscator.transformNInternal.
+  function transformNParamInUrl(url) {
+    const m = url.match(/[?&]n=([^&]+)/);
+    if (!m) return url;
+    const nValue = decodeURIComponent(m[1]);
+    const transformed = transformN(nValue);
+    return url.replace(/([?&])n=[^&]+/, `$1n=${encodeURIComponent(transformed)}`);
+  }
+
+  return {
+    hash: cfgKey, urlHash, sts, sigAvailable, nAvailable, nProbe, initError: initError?.message || null,
+    deobfuscateSignature, transformN, deobfuscateStreamUrl, transformNParamInUrl,
+    _close: () => dom.window.close(),
+  };
+}
+
+// ---- CLI self-test ----
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const c = await createCipher({ verbose: true });
+  console.log(JSON.stringify({
+    hash: c.hash, urlHash: c.urlHash, sts: c.sts,
+    sigAvailable: c.sigAvailable, nAvailable: c.nAvailable, nProbe: c.nProbe, initError: c.initError,
+  }, null, 2));
+  if (c.nAvailable && c.nProbe?.changed) console.error("n-transform WORKS ✓");
+  else console.error("n-transform did NOT transform ✗");
+  process.exit(0);
+}

--- a/tests/client-fulldownload.mjs
+++ b/tests/client-fulldownload.mjs
@@ -1,0 +1,104 @@
+// Does each client actually deliver a WHOLE song right now? The old probe only checked
+// `Range: bytes=0-1` (first 2 bytes), which says nothing about the 1-MiB pot wall. This
+// resolves the best audio URL per client the app's way and drains the ENTIRE file on one
+// open-ended GET, reporting how many bytes/seconds actually arrive before any 403.
+//
+//   node tests/client-fulldownload.mjs            # JTF9fLJvniI
+//   node tests/client-fulldownload.mjs <videoId>
+
+import crypto from "node:crypto";
+import { CLIENTS, ORIGIN, PLAYER_URL } from "./clients.mjs";
+import { getCred, describeCred } from "./cred.mjs";
+import { createCipher } from "./cipher.mjs";
+import { createMinter } from "./potoken.mjs";
+
+const VIDEO_ID = process.argv[2] || process.env.VIDEO_ID || "JTF9fLJvniI";
+const dec = (s) => { try { return s && /%[0-9A-Fa-f]{2}/.test(s) ? decodeURIComponent(s) : s; } catch { return s; } };
+const kb = (n) => `${(n / 1024).toFixed(0)}KB`;
+// Clients to test for full delivery: WEB_REMIX (with fix), plus the direct-url fallbacks.
+const TEST = ["WEB_REMIX", "IOS", "IPADOS", "ANDROID_VR_1_43_32", "ANDROID_VR_NO_AUTH", "ANDROID_VR_1_61_48"];
+
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/); if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  return `SAPISIDHASH ${ts}_${crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex")}`;
+}
+async function playerRequest(c, visitorData, dataSyncId, cookie, { sts, poToken, auth }) {
+  const client = { clientName: c.clientName, clientVersion: c.clientVersion, hl: "en", gl: "US" };
+  if (visitorData) client.visitorData = visitorData;
+  for (const k of ["osName", "osVersion", "deviceMake", "deviceModel", "androidSdkVersion"]) if (c[k]) client[k] = c[k];
+  const body = { context: { client }, videoId: VIDEO_ID, contentCheckOk: true, racyCheckOk: true };
+  if (c.loginSupported && dataSyncId) body.context.user = { onBehalfOfUser: dataSyncId };
+  if (c.useSignatureTimestamp && sts) body.playbackContext = { contentPlaybackContext: { signatureTimestamp: Number(sts) } };
+  if (poToken) body.serviceIntegrityDimensions = { poToken };
+  const h = {
+    "Content-Type": "application/json", "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": c.clientId, "X-YouTube-Client-Version": c.clientVersion,
+    "X-Origin": ORIGIN, Referer: ORIGIN + "/", "User-Agent": c.userAgent,
+  };
+  if (visitorData) h["X-Goog-Visitor-Id"] = visitorData;
+  if (auth && cookie && c.loginSupported) { h.cookie = cookie; const a = sapisidHash(cookie); if (a) h.Authorization = a; }
+  const res = await fetch(PLAYER_URL, { method: "POST", headers: h, body: JSON.stringify(body) });
+  let j = {}; try { j = JSON.parse(await res.text()); } catch {}
+  return { http: res.status, j };
+}
+const isAudio = (f) => f.width == null;
+const isOriginal = (f) => !f.audioTrack || f.audioTrack.isAutoDubbed == null;
+const findFormat = (j) => (j?.streamingData?.adaptiveFormats || []).filter((f) => isAudio(f) && isOriginal(f))
+  .sort((a, b) => (b.bitrate + ((b.mimeType || "").startsWith("audio/webm") ? 10240 : 0)) -
+                  (a.bitrate + ((a.mimeType || "").startsWith("audio/webm") ? 10240 : 0)))[0] || null;
+
+async function drainWhole(url, ua, cap) {
+  const t0 = performance.now();
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": ua, Range: "bytes=0-" } });
+    if (r.status !== 200 && r.status !== 206) return { status: r.status, read: 0, ms: performance.now() - t0 };
+    let read = 0; const rd = r.body.getReader();
+    for (;;) { const { done, value } = await rd.read(); if (done) break; read += value.length; if (cap && read >= cap) { await rd.cancel(); break; } }
+    return { status: r.status, read, ms: performance.now() - t0 };
+  } catch (e) { return { status: "ERR", error: e.message, read: 0, ms: performance.now() - t0 }; }
+}
+
+(async () => {
+  const cred = await getCred();
+  const visitorData = dec(cred.visitorData);
+  console.log(describeCred(cred));
+  console.log(`video=${VIDEO_ID}\n`);
+  const cipher = await createCipher({});
+  const minter = await createMinter(visitorData);
+  const potVideo = await minter.mint(VIDEO_ID);       // videoId-bound (the one the URL needs)
+  const potVisitor = await minter.mint(visitorData);  // visitorData-bound (player request)
+
+  console.log("client".padEnd(20), "http".padEnd(5), "play".padEnd(5), "itag".padEnd(5), "clen".padEnd(9), "delivered".padEnd(12), "secs".padEnd(7), "result");
+  for (const key of TEST) {
+    const c = CLIENTS.find((x) => x.key === key);
+    if (!c) continue;
+    try {
+      const isWeb = c.useWebPoTokens;
+      const { http, j } = await playerRequest(c, visitorData, cred.dataSyncId, cred.cookie, {
+        sts: c.useSignatureTimestamp ? cipher.sts : null,
+        poToken: isWeb ? potVisitor : null,   // player-request pot (session)
+        auth: !!c.loginSupported,
+      });
+      const ps = j?.playabilityStatus?.status || "-";
+      const fmt = findFormat(j);
+      if (!fmt) { console.log(key.padEnd(20), String(http).padEnd(5), ps.padEnd(5), "-".padEnd(5), "-".padEnd(9), "-".padEnd(12), "-".padEnd(7), "no format"); continue; }
+      let url = fmt.url || cipher.deobfuscateStreamUrl(fmt.signatureCipher);
+      if (isWeb) { url = cipher.transformNParamInUrl(url); url += `${url.includes("?") ? "&" : "?"}pot=${encodeURIComponent(potVideo)}`; } // FIX: videoId pot
+      const clen = fmt.contentLength ? Number(fmt.contentLength) : null;
+      const durMs = fmt.approxDurationMs ? Number(fmt.approxDurationMs) : null;
+      const d = await drainWhole(url, c.userAgent, clen ? clen + 1 : 50 * 1048576);
+      const secs = clen && durMs ? ((d.read / clen) * (durMs / 1000)).toFixed(0) + "s" : "?";
+      const whole = clen && d.read >= clen;
+      console.log(
+        key.padEnd(20), String(http).padEnd(5), ps.padEnd(5), String(fmt.itag).padEnd(5),
+        String(clen ?? "?").padEnd(9), kb(d.read).padEnd(12), String(secs).padEnd(7),
+        whole ? "✓ WHOLE SONG" : `✗ ${d.status} after ${kb(d.read)}`,
+      );
+    } catch (e) {
+      console.log(key.padEnd(20), "ERR", String(e.message).slice(0, 50));
+    }
+  }
+  cipher._close?.();
+  process.exit(0);
+})();

--- a/tests/clients.mjs
+++ b/tests/clients.mjs
@@ -1,0 +1,69 @@
+// YouTube client definitions — mirrors
+// innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
+// Keep in sync with that file.
+
+export const USER_AGENT_WEB =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
+
+export const CLIENTS = [
+  { key: "WEB", clientName: "WEB", clientVersion: "2.20260213.00.00", clientId: "1",
+    userAgent: USER_AGENT_WEB, loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "WEB_REMIX", clientName: "WEB_REMIX", clientVersion: "1.20260213.01.00", clientId: "67",
+    userAgent: USER_AGENT_WEB, loginSupported: true, useSignatureTimestamp: true, useWebPoTokens: true },
+
+  { key: "WEB_CREATOR", clientName: "WEB_CREATOR", clientVersion: "1.20260213.00.00", clientId: "62",
+    userAgent: USER_AGENT_WEB, loginSupported: true, loginRequired: true, useSignatureTimestamp: true },
+
+  { key: "TVHTML5", clientName: "TVHTML5", clientVersion: "7.20260213.00.00", clientId: "7",
+    userAgent: "Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 (KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15",
+    loginSupported: true, loginRequired: true, useSignatureTimestamp: true, useWebPoTokens: true },
+
+  { key: "TVHTML5_SIMPLY_EMBEDDED_PLAYER", clientName: "TVHTML5_SIMPLY_EMBEDDED_PLAYER", clientVersion: "2.0", clientId: "85",
+    userAgent: "Mozilla/5.0 (PlayStation; PlayStation 4/12.02) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
+    loginSupported: true, useSignatureTimestamp: true, isEmbedded: true },
+
+  { key: "IOS", clientName: "IOS", clientVersion: "21.03.1", clientId: "5",
+    userAgent: "com.google.ios.youtube/21.03.1 (iPhone16,2; U; CPU iOS 18_2 like Mac OS X;)",
+    osVersion: "18.2.22C152", loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "ANDROID", clientName: "ANDROID", clientVersion: "21.03.38", clientId: "3",
+    userAgent: "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
+    loginSupported: true, useSignatureTimestamp: true },
+
+  { key: "ANDROID_NO_SDK", clientName: "ANDROID", clientVersion: "21.03.38", clientId: "3",
+    userAgent: "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
+    loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "ANDROID_VR_NO_AUTH", clientName: "ANDROID_VR", clientVersion: "1.61.48", clientId: "28",
+    userAgent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Oculus Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+    loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "ANDROID_VR_1_61_48", clientName: "ANDROID_VR", clientVersion: "1.61.48", clientId: "28",
+    userAgent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+    osName: "Android", osVersion: "12", deviceMake: "Oculus", deviceModel: "Quest 3", androidSdkVersion: "32",
+    loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "ANDROID_VR_1_43_32", clientName: "ANDROID_VR", clientVersion: "1.43.32", clientId: "28",
+    userAgent: "com.google.android.apps.youtube.vr.oculus/1.43.32 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/107.0.5284.2)",
+    osName: "Android", osVersion: "12", deviceMake: "Oculus", deviceModel: "Quest 3", androidSdkVersion: "32",
+    loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "ANDROID_CREATOR", clientName: "ANDROID_CREATOR", clientVersion: "25.03.101", clientId: "14",
+    userAgent: "com.google.android.apps.youtube.creator/25.03.101 (Linux; U; Android 15; en_US; Pixel 9 Pro Fold; Build/AP3A.241005.015.A2; Cronet/132.0.6779.0)",
+    osName: "Android", osVersion: "15", deviceMake: "Google", deviceModel: "Pixel 9 Pro Fold", androidSdkVersion: "35",
+    loginSupported: true, useSignatureTimestamp: true },
+
+  { key: "VISIONOS", clientName: "VISIONOS", clientVersion: "0.1", clientId: "101",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+    osName: "visionOS", osVersion: "1.3.21O771", deviceMake: "Apple", deviceModel: "RealityDevice14,1",
+    loginSupported: false, useSignatureTimestamp: false },
+
+  { key: "IPADOS", clientName: "IOS", clientVersion: "21.03.3", clientId: "5",
+    userAgent: "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)",
+    osName: "iPadOS", osVersion: "17.7.10.21H450", deviceMake: "Apple", deviceModel: "iPad7,6",
+    loginSupported: false, useSignatureTimestamp: false },
+];
+
+export const ORIGIN = "https://music.youtube.com";
+export const PLAYER_URL = ORIGIN + "/youtubei/v1/player?prettyPrint=false";

--- a/tests/cred.mjs
+++ b/tests/cred.mjs
@@ -1,0 +1,82 @@
+// Credential loader. Reads the local innertube_cookie.txt (the dumped
+// "***INNERTUBE COOKIE*** =..." format) so the test scripts use the same
+// logged-in session the app uses, without hitting a remote credential worker.
+//
+// Resolution order for each field:
+//   1. env override  (YT_COOKIE / YT_VISITOR_DATA / YT_DATASYNC_ID)
+//   2. file          (COOKIE_FILE env, else ../innertube_cookie.txt)
+//   3. CRED_URL       remote worker, only if nothing local is found
+//
+// Returns { cookie, visitorData, dataSyncId, source }.
+
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_FILE = path.join(HERE, "..", "innertube_cookie.txt");
+
+// Map the dumped "***LABEL*** =value" lines to our field names.
+const LABELS = {
+  "INNERTUBE COOKIE": "cookie",
+  "VISITOR DATA": "visitorData",
+  "DATASYNC ID": "dataSyncId",
+  "ACCOUNT NAME": "accountName",
+  "ACCOUNT EMAIL": "accountEmail",
+  "ACCOUNT CHANNEL HANDLE": "accountHandle",
+};
+
+export function parseCookieFile(text) {
+  const out = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^\*\*\*\s*(.+?)\s*\*\*\*\s*=(.*)$/);
+    if (!m) continue;
+    const field = LABELS[m[1].trim().toUpperCase()];
+    if (field) out[field] = m[2].trim();
+  }
+  return out;
+}
+
+export async function getCred() {
+  const file = process.env.COOKIE_FILE || DEFAULT_FILE;
+  let fromFile = {};
+  let source = "env";
+  if (fs.existsSync(file)) {
+    try {
+      fromFile = parseCookieFile(fs.readFileSync(file, "utf8"));
+      source = file;
+    } catch (e) {
+      console.warn(`cred: failed to read ${file}: ${e.message}`);
+    }
+  }
+
+  let cookie = process.env.YT_COOKIE || fromFile.cookie || "";
+  let visitorData = process.env.YT_VISITOR_DATA || fromFile.visitorData || "";
+  let dataSyncId = process.env.YT_DATASYNC_ID || fromFile.dataSyncId || "";
+
+  // Fall back to the remote credential worker only if we have nothing local.
+  if (!cookie && !visitorData && process.env.CRED_URL) {
+    try {
+      const j = await (await fetch(process.env.CRED_URL)).json();
+      cookie = j.cookie || "";
+      visitorData = j.visitorData || "";
+      dataSyncId = j.dataSyncId || "";
+      source = process.env.CRED_URL;
+    } catch (e) {
+      console.warn(`cred: CRED_URL fetch failed: ${e.message}`);
+    }
+  }
+
+  return { cookie, visitorData, dataSyncId, source };
+}
+
+// Print a one-line summary safe for logs (no secrets).
+export function describeCred(c) {
+  const has = (s) => (s ? "yes" : "NO");
+  return (
+    `cookie=${has(c.cookie)} SAPISID=${/SAPISID=/.test(c.cookie) ? "yes" : "NO"} ` +
+    `visitorData=${(c.visitorData || "").slice(0, 14)}${c.visitorData ? "…" : ""} ` +
+    `dataSyncId=${c.dataSyncId ? c.dataSyncId.slice(0, 8) + "…" : "(none)"} ` +
+    `[${c.source}]`
+  );
+}

--- a/tests/full-stream.mjs
+++ b/tests/full-stream.mjs
@@ -1,0 +1,87 @@
+// Full end-to-end stream resolution "as if the app": generate a BotGuard poToken,
+// run the player request, decipher signature + n, and validate the stream — per client,
+// with timing for each stage. Shows where the per-song time actually goes and how the
+// web (poToken+decipher) path compares to the direct-URL (iOS/ANDROID) path.
+//
+//   node tests/full-stream.mjs
+//   VIDEO_IDS=a,b CRED_URL=... node tests/full-stream.mjs
+//
+// Uses youtubei.js (full InnerTube + decipher) + bgutils-js (poToken). This is pure-JVM-
+// equivalent (Rhino-style) decipher in-process — i.e. the path Metrolist uses — NOT the
+// app's Android WebView path, so the timings are the floor the app *should* hit.
+
+import { Innertube } from "youtubei.js";
+import { BG } from "bgutils-js";
+import { JSDOM } from "jsdom";
+
+const VIDEO_IDS = (process.env.VIDEO_IDS || "dQw4w9WgXcQ,kJQP7kiw5Fk").split(",");
+const CRED_URL = process.env.CRED_URL || "https://mc.alltech.dev/credentials";
+const WEB_REQUEST_KEY = "O43z0dpjhgX20SCx4KAo"; // YouTube web BotGuard request key (constant)
+const ms = (a, b) => `${(b - a).toFixed(0)}ms`.padStart(7);
+
+async function getCred() {
+  try { return await (await fetch(CRED_URL)).json(); } catch { return {}; }
+}
+
+async function genPoToken(visitorData) {
+  const dom = new JSDOM();
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  const bgConfig = { fetch: (u, o) => fetch(u, o), globalObj: globalThis, identifier: visitorData, requestKey: WEB_REQUEST_KEY };
+  const challenge = await BG.Challenge.create(bgConfig);
+  if (!challenge) throw new Error("no challenge");
+  const interpreterJs = challenge.interpreterJavascript?.privateDoNotAccessOrElseSafeScriptWrappedValue;
+  if (!interpreterJs) throw new Error("no interpreter");
+  new Function(interpreterJs)();
+  const res = await BG.PoToken.generate({ program: challenge.program, globalName: challenge.globalName, bgConfig });
+  return res.poToken;
+}
+
+(async () => {
+  const cred = await getCred();
+  const visitorData = cred.visitorData || undefined;
+  console.log(`cred: cookie=${cred.cookie ? "yes" : "no"} visitorData=${(visitorData || "").slice(0, 14)}…\n`);
+
+  let t = performance.now();
+  let poToken;
+  try { poToken = await genPoToken(visitorData); console.log(`poToken gen        ${ms(t, performance.now())}  ${poToken.slice(0, 22)}…  (one-time)`); }
+  catch (e) { console.log(`poToken gen        FAILED (${e.message}) — web clients will be throttled/unplayable`); }
+
+  t = performance.now();
+  const yt = await Innertube.create({ po_token: poToken, visitor_data: visitorData, cookie: cred.cookie, retrieve_player: true });
+  console.log(`Innertube.create   ${ms(t, performance.now())}  (downloads+parses base.js, one-time)\n`);
+
+  const CLIENTS = ["YTMUSIC", "WEB", "iOS", "ANDROID", "TV"];
+  for (const videoId of VIDEO_IDS) {
+    console.log(`=== ${videoId} ===`);
+    console.log("client".padEnd(9), "status".padEnd(13), "getInfo".padEnd(9), "decipher".padEnd(9), "stream", "itag");
+    for (const client of CLIENTS) {
+      try {
+        const t0 = performance.now();
+        const info = await yt.getInfo(videoId, client);
+        const t1 = performance.now();
+        let url = null, ciphered = false;
+        const fmt = info.chooseFormat({ type: "audio", quality: "best" });
+        try {
+          if (fmt?.url) { url = fmt.url; }
+          else { url = fmt?.decipher(yt.session.player); ciphered = true; }
+        } catch { url = null; }
+        const t2 = performance.now();
+        let stream = "-";
+        if (url) { try { const r = await fetch(url, { headers: { Range: "bytes=0-1" } }); r.body?.cancel?.(); stream = String(r.status); } catch { stream = "ERR"; } }
+        console.log(
+          client.padEnd(9),
+          String(info.playability_status?.status || "-").padEnd(13),
+          ms(t0, t1).padEnd(9),
+          (ciphered ? ms(t1, t2) : "direct").padEnd(9),
+          String(stream).padEnd(6),
+          fmt?.itag ?? "-",
+        );
+      } catch (e) {
+        console.log(client.padEnd(9), "ERROR", String(e.message).slice(0, 60));
+      }
+    }
+    console.log();
+  }
+  process.exit(0);
+})();

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,554 @@
+{
+  "name": "tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "bgutils-js": "^3.2.0",
+        "jsdom": "^29.1.1",
+        "youtubei.js": "^17.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bgutils-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/bgutils-js/-/bgutils-js-3.2.0.tgz",
+      "integrity": "sha512-CacO15JvxbclbLeCAAm9DETGlLuisRGWpPigoRvNsccSCPEC4pwYwA2g2x/pv7Om/sk79d4ib35V5HHmxPBpDg==",
+      "funding": [
+        "https://github.com/sponsors/LuanRT"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
+    "node_modules/youtubei.js": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-17.0.1.tgz",
+      "integrity": "sha512-1lO4b8UqMDzE0oh2qEGzbBOd4UYRdxn/4PdpRM7BGTHxM6ddsEsKZTu90jp8V9FHVgC2h1UirQyqoqLiKwl+Zg==",
+      "funding": [
+        "https://github.com/sponsors/LuanRT"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "meriyah": "^6.1.4"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "bgutils-js": "^3.2.0",
+    "jsdom": "^29.1.1",
+    "youtubei.js": "^17.0.1"
+  }
+}

--- a/tests/pot-probe.mjs
+++ b/tests/pot-probe.mjs
@@ -1,0 +1,139 @@
+// Definitive poToken-binding matrix for the WEB_REMIX 1-MiB / seek 403.
+//
+// Question: which poToken makes a googlevideo stream URL serve PAST the 1 MiB free window
+// (i.e. the whole song)? Tests every combination of:
+//   - request pot  : the token sent in the /player serviceIntegrityDimensions (videoId vs visitorData)
+//   - url pot       : the &pot= appended to the media URL (none / videoId / visitorData-raw / visitorData-enc)
+// For each cell it fetches a fresh connection at 1 MiB and 2 MiB (past the free window) and,
+// for any cell that passes, drains the whole file to confirm full download.
+//
+// "visitorData-raw" = decoded (…==).  "visitorData-enc" = as stored in the cookie dump (…%3D%3D).
+// This rules out a visitorData URL-encoding artifact as the cause.
+//
+//   node tests/pot-probe.mjs            # JTF9fLJvniI
+//   node tests/pot-probe.mjs <videoId>
+
+import crypto from "node:crypto";
+import { CLIENTS, ORIGIN, PLAYER_URL, USER_AGENT_WEB } from "./clients.mjs";
+import { getCred, describeCred } from "./cred.mjs";
+import { createCipher } from "./cipher.mjs";
+import { createMinter } from "./potoken.mjs";
+
+const VIDEO_ID = process.argv[2] || process.env.VIDEO_ID || "JTF9fLJvniI";
+const WEB_REMIX = CLIENTS.find((c) => c.key === "WEB_REMIX");
+const dec = (s) => { try { return s && /%[0-9A-Fa-f]{2}/.test(s) ? decodeURIComponent(s) : s; } catch { return s; } };
+const kb = (n) => `${(n / 1024).toFixed(0)}KB`;
+
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  return `SAPISIDHASH ${ts}_${crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex")}`;
+}
+async function playerRequest(c, visitorData, cookie, { sts, poToken }) {
+  const client = { clientName: c.clientName, clientVersion: c.clientVersion, hl: "en", gl: "US", visitorData };
+  const body = { context: { client }, videoId: VIDEO_ID, contentCheckOk: true, racyCheckOk: true };
+  if (c.useSignatureTimestamp && sts) body.playbackContext = { contentPlaybackContext: { signatureTimestamp: Number(sts) } };
+  if (poToken) body.serviceIntegrityDimensions = { poToken };
+  const h = {
+    "Content-Type": "application/json", "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": c.clientId, "X-YouTube-Client-Version": c.clientVersion,
+    "X-Origin": ORIGIN, Referer: ORIGIN + "/", "User-Agent": c.userAgent, "X-Goog-Visitor-Id": visitorData,
+  };
+  if (cookie) { h.cookie = cookie; const a = sapisidHash(cookie); if (a) h.Authorization = a; }
+  const res = await fetch(PLAYER_URL, { method: "POST", headers: h, body: JSON.stringify(body) });
+  let j = {}; try { j = JSON.parse(await res.text()); } catch {}
+  return { http: res.status, j };
+}
+const isAudio = (f) => f.width == null;
+const isOriginal = (f) => !f.audioTrack || f.audioTrack.isAutoDubbed == null;
+function findFormat(j) {
+  return (j?.streamingData?.adaptiveFormats || []).filter((f) => isAudio(f) && isOriginal(f))
+    .sort((a, b) => (b.bitrate + ((b.mimeType || "").startsWith("audio/webm") ? 10240 : 0)) -
+                    (a.bitrate + ((a.mimeType || "").startsWith("audio/webm") ? 10240 : 0)))[0] || null;
+}
+async function resolveBaseUrl(cipher, visitorData, cookie, requestPot) {
+  const { http, j } = await playerRequest(WEB_REMIX, visitorData, cookie, { sts: cipher.sts, poToken: requestPot });
+  const ps = j?.playabilityStatus?.status;
+  const fmt = findFormat(j);
+  if (!fmt) return { http, ps, url: null, fmt: null };
+  let url = fmt.url || cipher.deobfuscateStreamUrl(fmt.signatureCipher);
+  url = cipher.transformNParamInUrl(url); // n-transform, NO pot appended
+  return { http, ps, url, fmt };
+}
+function withPot(url, pot) {
+  const base = url.replace(/([?&])pot=[^&]*/, "$1").replace(/[?&]$/, "");
+  return pot ? `${base}${base.includes("?") ? "&" : "?"}pot=${encodeURIComponent(pot)}` : base;
+}
+async function status(url, start, end) {
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": USER_AGENT_WEB, Range: `bytes=${start}-${end}`, Connection: "close" } });
+    r.body?.cancel?.();
+    return r.status;
+  } catch (e) { return "ERR"; }
+}
+async function drainWhole(url, cap) {
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": USER_AGENT_WEB, Range: "bytes=0-" } });
+    if (r.status !== 200 && r.status !== 206) return { status: r.status, read: 0 };
+    let read = 0; const rd = r.body.getReader();
+    for (;;) { const { done, value } = await rd.read(); if (done) break; read += value.length; if (cap && read >= cap) { await rd.cancel(); break; } }
+    return { status: r.status, read };
+  } catch (e) { return { status: "ERR", read: 0 }; }
+}
+
+const MIB = 1048576;
+
+(async () => {
+  const cred = await getCred();
+  const visRaw = dec(cred.visitorData);          // decoded …==
+  const visEnc = cred.visitorData;               // as stored …%3D%3D
+  console.log(describeCred(cred));
+  console.log(`video=${VIDEO_ID}`);
+
+  const cipher = await createCipher({ verbose: true });
+  console.log(`cipher hash=${cipher.hash} sts=${cipher.sts}`);
+
+  // Mint all tokens from ONE BotGuard run (session identifier = decoded visitorData).
+  const minter = await createMinter(visRaw);
+  const potVideo = await minter.mint(VIDEO_ID);
+  const potVisRaw = await minter.mint(visRaw);
+  const potVisEnc = await minter.mint(visEnc);
+  console.log(`minted: video(${potVideo.length}) visRaw(${potVisRaw.length}) visEnc(${potVisEnc.length})\n`);
+
+  const urlPots = {
+    none: null,
+    "video    ": potVideo,
+    "visRaw   ": potVisRaw,
+    "visEnc   ": potVisEnc,
+  };
+  const requestPots = { "req=video": potVideo, "req=visRaw": potVisRaw };
+
+  let best = null;
+  for (const [rname, rpot] of Object.entries(requestPots)) {
+    const base = await resolveBaseUrl(cipher, visRaw, cred.cookie, rpot);
+    console.log(`[${rname}] player http=${base.http} playability=${base.ps} itag=${base.fmt?.itag} clen=${base.fmt?.contentLength}`);
+    if (!base.url) { console.log("   no url\n"); continue; }
+    const clen = Number(base.fmt.contentLength);
+    for (const [uname, upot] of Object.entries(urlPots)) {
+      const u = withPot(base.url, upot);
+      const s1 = await status(u, MIB, MIB + 262143);          // 1 MiB
+      const s2 = await status(u, 2 * MIB, 2 * MIB + 262143);  // 2 MiB
+      const pass = (s1 === 200 || s1 === 206) && (s2 === 200 || s2 === 206);
+      console.log(`   url pot=${uname}  @1MiB=${s1}  @2MiB=${s2}  ${pass ? "✓ PAST FREE WINDOW" : ""}`);
+      if (pass && !best) best = { rname, uname: uname.trim(), url: u, clen };
+    }
+    console.log();
+  }
+
+  if (best) {
+    console.log(`Confirming full download for [${best.rname}] url pot=${best.uname} ...`);
+    const d = await drainWhole(best.url, best.clen + 1);
+    const ok = d.read >= best.clen;
+    console.log(`   -> ${d.status} delivered ${kb(d.read)} / ${kb(best.clen)}  ${ok ? "✓ WHOLE FILE" : "✗ stopped early"}`);
+  } else {
+    console.log("No pot combination served past the 1 MiB free window.");
+  }
+  cipher._close?.();
+  process.exit(0);
+})();

--- a/tests/potoken.mjs
+++ b/tests/potoken.mjs
@@ -1,0 +1,132 @@
+// Reusable BotGuard poToken generator (web client), built on bgutils-js + jsdom.
+//
+// YouTube web clients (WEB / WEB_REMIX / TVHTML5) need a poToken in two places.
+// Bindings verified against the app's PoTokenGenerator.getWebClientPoToken(videoId, sessionId):
+//   - streamingDataPoToken : appended to the media URL as &pot=...
+//                            content binding = the SESSION id (visitorData). Minted FIRST, once.
+//   - playerRequestPoToken : sent in serviceIntegrityDimensions.poToken on the /player request.
+//                            content binding = the VIDEO ID. Minted after the streaming token.
+// (PoTokenResult(playerPot, streamingPot) = PoTokenResult(generate(videoId), generate(visitorData)).)
+// Session id is ALWAYS visitorData — dataSyncId is rejected by BotGuard as a session context.
+//
+// Run directly to mint + print tokens (uses ../innertube_cookie.txt for visitorData):
+//   node tests/potoken.mjs                 # session token bound to visitorData
+//   node tests/potoken.mjs <videoId>       # also mint the streaming token bound to <videoId>
+//
+// Import:
+//   import { mintWebPoTokens, generatePoToken } from "./potoken.mjs";
+
+import { BG } from "bgutils-js";
+import { JSDOM } from "jsdom";
+
+// Constant request key for YouTube web BotGuard (same value NewPipe/yt-dlp/youtubei.js use).
+export const WEB_REQUEST_KEY = "O43z0dpjhgX20SCx4KAo";
+
+let domReady = false;
+function ensureDom() {
+  if (domReady) return;
+  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+    url: "https://music.youtube.com/",
+  });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.location = dom.window.location;
+  domReady = true;
+}
+
+/**
+ * Build a BotGuard integrity-token "minter" with ONE BotGuard run, then mint as
+ * many poTokens as needed for different content bindings. This matches how the
+ * app mints both the player token (binding=visitorData) and the streaming token
+ * (binding=videoId) from a single attestation.
+ *
+ * @param {string} sessionIdentifier  visitorData (or dataSyncId)
+ */
+export async function createMinter(sessionIdentifier) {
+  ensureDom();
+  const bgConfig = {
+    fetch: (url, opts) => fetch(url, opts),
+    globalObj: globalThis,
+    identifier: sessionIdentifier,
+    requestKey: WEB_REQUEST_KEY,
+  };
+
+  const challenge = await BG.Challenge.create(bgConfig);
+  if (!challenge) throw new Error("BotGuard: Challenge.create returned nothing");
+
+  const interpreterJs =
+    challenge.interpreterJavascript?.privateDoNotAccessOrElseSafeScriptWrappedValue;
+  if (!interpreterJs) throw new Error("BotGuard: no interpreter javascript in challenge");
+  // Evaluate the BotGuard VM into the (jsdom) global scope.
+  new Function(interpreterJs)();
+
+  return {
+    bgConfig,
+    program: challenge.program,
+    globalName: challenge.globalName,
+    /** Mint a poToken for a given content binding (visitorData or videoId). */
+    async mint(contentBinding) {
+      const res = await BG.PoToken.generate({
+        program: challenge.program,
+        globalName: challenge.globalName,
+        bgConfig: { ...bgConfig, identifier: contentBinding },
+      });
+      const tok = res?.poToken;
+      if (!tok) throw new Error(`poToken mint returned empty for binding=${contentBinding}`);
+      return tok;
+    },
+  };
+}
+
+/** One-shot: mint a single poToken bound to `identifier`. */
+export async function generatePoToken(identifier) {
+  const minter = await createMinter(identifier);
+  return minter.mint(identifier);
+}
+
+/**
+ * Mint the pair the web player path needs.
+ * @returns {{ playerRequestPoToken: string, streamingDataPoToken: string|null }}
+ */
+export async function mintWebPoTokens({ visitorData, videoId }) {
+  if (!visitorData) throw new Error("mintWebPoTokens: visitorData is required");
+  const minter = await createMinter(visitorData);
+  // App order/bindings (PoTokenGenerator): the streaming poToken (bound to the
+  // session = visitorData) is minted exactly once, BEFORE the player token.
+  const streamingDataPoToken = await minter.mint(visitorData);
+  // The player-request poToken is bound to the videoId.
+  const playerRequestPoToken = videoId ? await minter.mint(videoId) : null;
+  return { playerRequestPoToken, streamingDataPoToken };
+}
+
+// ---- CLI ----
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { getCred, describeCred } = await import("./cred.mjs");
+  const videoId = process.argv[2] || null;
+  const cred = await getCred();
+  console.error(describeCred(cred));
+  if (!cred.visitorData) {
+    console.error("ERROR: no visitorData available (set YT_VISITOR_DATA or innertube_cookie.txt)");
+    process.exit(1);
+  }
+  const t0 = performance.now();
+  const { playerRequestPoToken, streamingDataPoToken } = await mintWebPoTokens({
+    visitorData: cred.visitorData,
+    videoId,
+  });
+  const dt = (performance.now() - t0).toFixed(0);
+  console.error(`minted in ${dt}ms`);
+  console.log(JSON.stringify(
+    {
+      visitorData: cred.visitorData,
+      videoId,
+      playerRequestPoToken,
+      streamingDataPoToken,
+      playerRequestPoToken_len: playerRequestPoToken?.length ?? 0,
+      streamingDataPoToken_len: streamingDataPoToken?.length ?? 0,
+    },
+    null,
+    2,
+  ));
+  process.exit(0);
+}

--- a/tests/results.json
+++ b/tests/results.json
@@ -1,0 +1,222 @@
+[
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "WEB",
+    "mode": "anon",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "Video unavailable",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "WEB_REMIX",
+    "mode": "anon",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "Video unavailable",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "WEB_REMIX",
+    "mode": "auth",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "Video unavailable",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "WEB_CREATOR",
+    "mode": "anon",
+    "http": 200,
+    "playability": "LOGIN_REQUIRED",
+    "reason": "Please sign in",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "WEB_CREATOR",
+    "mode": "auth",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "The page needs to be reloaded.",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "TVHTML5",
+    "mode": "anon",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "The page needs to be reloaded.",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "TVHTML5",
+    "mode": "auth",
+    "http": 200,
+    "playability": "UNPLAYABLE",
+    "reason": "The page needs to be reloaded.",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+    "mode": "anon",
+    "http": 200,
+    "playability": "ERROR",
+    "reason": "YouTube is no longer supported in this application or device.",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+    "mode": "auth",
+    "http": 200,
+    "playability": "ERROR",
+    "reason": "YouTube is no longer supported in this application or device.",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "IOS",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 23,
+    "audio": "direct",
+    "stream": "206"
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 22,
+    "audio": "no-url",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID",
+    "mode": "auth",
+    "http": 400,
+    "playability": "-",
+    "reason": "",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_NO_SDK",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 22,
+    "audio": "no-url",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_VR_NO_AUTH",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 22,
+    "audio": "direct",
+    "stream": "206"
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_VR_1_61_48",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 22,
+    "audio": "direct",
+    "stream": "206"
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_VR_1_43_32",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 16,
+    "audio": "direct",
+    "stream": "206"
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_CREATOR",
+    "mode": "anon",
+    "http": 200,
+    "playability": "LOGIN_REQUIRED",
+    "reason": "Please sign in",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "ANDROID_CREATOR",
+    "mode": "auth",
+    "http": 400,
+    "playability": "-",
+    "reason": "",
+    "formats": 0,
+    "audio": "none",
+    "stream": ""
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "VISIONOS",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 17,
+    "audio": "direct",
+    "stream": "206"
+  },
+  {
+    "videoId": "_n4qgos_dZc",
+    "client": "IPADOS",
+    "mode": "anon",
+    "http": 200,
+    "playability": "OK",
+    "reason": "",
+    "formats": 23,
+    "audio": "direct",
+    "stream": "206"
+  }
+]

--- a/tests/retest-web.mjs
+++ b/tests/retest-web.mjs
@@ -1,0 +1,58 @@
+// Retest the web clients (WEB_REMIX, TVHTML5) old vs current clientVersion,
+// to separate "stale client version" from "needs poToken". No poToken sent.
+import crypto from "node:crypto";
+
+const UA_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
+const UA_TV = "Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 (KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15";
+const ORIGIN = "https://music.youtube.com";
+const VID = process.env.VIDEO_ID || "dQw4w9WgXcQ";
+const STS = process.env.STS || "20602";
+
+async function getCred() {
+  return await (await fetch(process.env.CRED_URL || "https://mc.alltech.dev/credentials")).json();
+}
+async function currentVersion(url, ua) {
+  try {
+    const h = await (await fetch(url, { headers: { "User-Agent": ua, "Accept-Language": "en-US,en" } })).text();
+    return h.match(/"INNERTUBE_CLIENT_VERSION":"([\d.]+)"/)?.[1];
+  } catch { return null; }
+}
+function sapisid(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  return `SAPISIDHASH ${ts}_${crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex")}`;
+}
+async function player(cn, cid, cv, ua, { cookie, auth, vd } = {}) {
+  const client = { clientName: cn, clientVersion: cv, hl: "en", gl: "US" };
+  if (vd) client.visitorData = vd;
+  const body = { context: { client }, videoId: VID, contentCheckOk: true, racyCheckOk: true,
+    playbackContext: { contentPlaybackContext: { signatureTimestamp: Number(STS) } } };
+  const h = { "Content-Type": "application/json", "X-Goog-Api-Format-Version": "1", "X-YouTube-Client-Name": cid,
+    "X-YouTube-Client-Version": cv, "X-Origin": ORIGIN, Referer: ORIGIN + "/", "User-Agent": ua };
+  if (vd) h["X-Goog-Visitor-Id"] = vd;
+  if (auth && cookie) { h.cookie = cookie; const a = sapisid(cookie); if (a) h.Authorization = a; }
+  const r = await fetch(ORIGIN + "/youtubei/v1/player?prettyPrint=false", { method: "POST", headers: h, body: JSON.stringify(body) });
+  let j = {}; try { j = JSON.parse(await r.text()); } catch {}
+  return { http: r.status, ps: j?.playabilityStatus?.status, reason: j?.playabilityStatus?.reason || "", nf: (j?.streamingData?.adaptiveFormats || []).length };
+}
+
+(async () => {
+  const cred = await getCred();
+  const tvNew = await currentVersion("https://www.youtube.com/tv", UA_TV);
+  const remixNew = await currentVersion("https://music.youtube.com/", UA_WEB);
+  console.log(`current: WEB_REMIX=${remixNew}  TVHTML5=${tvNew}  STS=${STS}\n`);
+  const matrix = [
+    ["WEB_REMIX", "67", "1.20260213.01.00", UA_WEB, "OLD"],
+    ["WEB_REMIX", "67", remixNew || "1.20260531.05.00", UA_WEB, "NEW"],
+    ["TVHTML5", "7", "7.20260213.00.00", UA_TV, "OLD"],
+    ["TVHTML5", "7", tvNew || "7.20260213.00.00", UA_TV, "NEW"],
+  ];
+  for (const [cn, cid, cv, ua, tag] of matrix) {
+    for (const auth of [false, true]) {
+      const r = await player(cn, cid, cv, ua, { cookie: cred.cookie, auth, vd: cred.visitorData });
+      console.log(`${cn} ${tag} ${cv} [${auth ? "auth" : "anon"}] -> HTTP ${r.http} ${r.ps} "${r.reason}" fmts=${r.nf}`);
+      await new Promise((x) => setTimeout(x, 150));
+    }
+  }
+})();

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -1,0 +1,181 @@
+// Probe the YouTube Music /player endpoint with every client to discover,
+// per client, what must be sent for it to return a STREAMABLE audio URL.
+//
+//   node tests/run.mjs
+//
+// Env:
+//   CRED_URL          credential worker (default https://mc.alltech.dev/credentials)
+//   YT_COOKIE         override cookie instead of fetching from CRED_URL
+//   YT_VISITOR_DATA   override visitorData
+//   VIDEO_IDS         comma-separated video ids (default two well-known songs)
+//
+// For each client it sends a player request (varying auth/STS), classifies the
+// best audio format (direct url / ciphered / none), and — for direct urls —
+// does a Range GET to confirm the stream actually serves bytes (206/200).
+// poToken is NOT generated here (needs BotGuard); web clients are expected to
+// come back ciphered / require pot=, which the report makes explicit.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { CLIENTS, USER_AGENT_WEB, ORIGIN, PLAYER_URL } from "./clients.mjs";
+
+const CRED_URL = process.env.CRED_URL || "https://mc.alltech.dev/credentials";
+const VIDEO_IDS = (process.env.VIDEO_IDS || "dQw4w9WgXcQ,kJQP7kiw5Fk").split(",");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getCred() {
+  if (process.env.YT_COOKIE) {
+    return { cookie: process.env.YT_COOKIE, visitorData: process.env.YT_VISITOR_DATA || "", dataSyncId: "" };
+  }
+  const j = await (await fetch(CRED_URL)).json();
+  return { cookie: j.cookie || "", visitorData: j.visitorData || "", dataSyncId: j.dataSyncId || "" };
+}
+
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  const hash = crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex");
+  return `SAPISIDHASH ${ts}_${hash}`;
+}
+
+// Best-effort signatureTimestamp from the live base.js (needed by web clients
+// so the returned URLs deobfuscate correctly).
+async function fetchSts() {
+  try {
+    const ifr = await (await fetch(ORIGIN + "/iframe_api")).text();
+    const ver = ifr.match(/\/player\/([0-9a-fA-F]{8})\//)?.[1];
+    if (!ver) return null;
+    const js = await (await fetch(`https://www.youtube.com/s/player/${ver}/player_ias.vflset/en_US/base.js`)).text();
+    return js.match(/signatureTimestamp[:=](\d+)/)?.[1] || js.match(/[,{]sts[:=](\d+)/)?.[1] || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildBody(c, videoId, visitorData, { onBehalf, sts, poToken } = {}) {
+  const client = { clientName: c.clientName, clientVersion: c.clientVersion, hl: "en", gl: "US" };
+  if (visitorData) client.visitorData = visitorData;
+  for (const k of ["osName", "osVersion", "deviceMake", "deviceModel", "androidSdkVersion"]) {
+    if (c[k]) client[k] = c[k];
+  }
+  const body = { context: { client }, videoId, contentCheckOk: true, racyCheckOk: true };
+  if (onBehalf) body.context.user = { onBehalfOfUser: onBehalf };
+  if (c.useSignatureTimestamp && sts) {
+    body.playbackContext = { contentPlaybackContext: { signatureTimestamp: Number(sts) } };
+  }
+  if (poToken) body.serviceIntegrityDimensions = { poToken };
+  return body;
+}
+
+function buildHeaders(c, visitorData, { cookie, auth } = {}) {
+  const h = {
+    "Content-Type": "application/json",
+    "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": c.clientId,
+    "X-YouTube-Client-Version": c.clientVersion,
+    "X-Origin": ORIGIN,
+    Referer: ORIGIN + "/",
+    "User-Agent": c.userAgent,
+  };
+  if (visitorData) h["X-Goog-Visitor-Id"] = visitorData;
+  if (auth && cookie) {
+    h.cookie = cookie;
+    const a = sapisidHash(cookie);
+    if (a) h.Authorization = a;
+  }
+  return h;
+}
+
+async function player(c, videoId, visitorData, opts = {}) {
+  const res = await fetch(PLAYER_URL, {
+    method: "POST",
+    headers: buildHeaders(c, visitorData, opts),
+    body: JSON.stringify(buildBody(c, videoId, visitorData, opts)),
+  });
+  const text = await res.text();
+  let j = {};
+  try { j = JSON.parse(text); } catch {}
+  return { http: res.status, j };
+}
+
+function bestAudio(j) {
+  const fmts = j?.streamingData?.adaptiveFormats || [];
+  return fmts.filter((f) => (f.mimeType || "").startsWith("audio")).sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0] || null;
+}
+
+function classifyAudio(a) {
+  if (!a) return "none";
+  if (a.url) return "direct";
+  if (a.signatureCipher) return "ciphered";
+  return "no-url";
+}
+
+async function streamable(url, ua) {
+  try {
+    const r = await fetch(url, { headers: { Range: "bytes=0-1", "User-Agent": ua } });
+    r.body?.cancel?.();
+    return String(r.status);
+  } catch (e) {
+    return "ERR:" + e.message;
+  }
+}
+
+const pad = (s, n) => String(s).padEnd(n);
+
+(async () => {
+  const cred = await getCred();
+  const sts = await fetchSts();
+  console.log(
+    `cred: cookie=${cred.cookie ? "yes" : "NO"} | SAPISID=${/SAPISID=/.test(cred.cookie) ? "yes" : "NO"} | ` +
+    `visitorData=${(cred.visitorData || "").slice(0, 14)}… | sts=${sts || "UNKNOWN"} | videos=${VIDEO_IDS.join(",")}`,
+  );
+
+  const results = [];
+  for (const videoId of VIDEO_IDS) {
+    console.log(`\n=== videoId ${videoId} ===`);
+    console.log(pad("client", 30), pad("mode", 5), pad("http", 5), pad("playability", 13), pad("fmts", 5), pad("audio", 9), "stream / reason");
+    for (const c of CLIENTS) {
+      const modes = c.loginSupported ? ["anon", "auth"] : ["anon"];
+      for (const mode of modes) {
+        let res;
+        try {
+          res = await player(c, videoId, cred.visitorData, { cookie: cred.cookie, auth: mode === "auth", sts });
+        } catch (e) {
+          console.log(pad(c.key, 30), pad(mode, 5), "ERR  ", "", "", "", e.message);
+          continue;
+        }
+        const a = bestAudio(res.j);
+        const cls = classifyAudio(a);
+        const ps = res.j?.playabilityStatus?.status || "-";
+        const reason = res.j?.playabilityStatus?.reason || "";
+        const nf = (res.j?.streamingData?.adaptiveFormats || []).length;
+        let strm = cls === "direct" ? await streamable(a.url, c.userAgent) : "";
+        const tail = cls === "direct" ? strm : (ps !== "OK" ? reason : cls);
+        console.log(pad(c.key, 30), pad(mode, 5), pad(res.http, 5), pad(ps, 13), pad(nf, 5), pad(cls, 9), tail);
+        results.push({ videoId, client: c.key, mode, http: res.http, playability: ps, reason, formats: nf, audio: cls, stream: strm });
+        await sleep(150);
+      }
+    }
+  }
+
+  // Demonstrate the onBehalfOfUser / dataSyncId effect (the playback-breaking bug).
+  if (cred.dataSyncId && /SAPISID=/.test(cred.cookie)) {
+    console.log(`\n=== onBehalfOfUser effect (WEB_REMIX auth, dataSyncId=${cred.dataSyncId}) ===`);
+    const c = CLIENTS.find((x) => x.key === "WEB_REMIX");
+    for (const onBehalf of [null, cred.dataSyncId]) {
+      const res = await player(c, VIDEO_IDS[0], cred.visitorData, { cookie: cred.cookie, auth: true, sts, onBehalf });
+      console.log(`  onBehalfOfUser=${onBehalf ? "set" : "absent"} -> HTTP ${res.http}, playability=${res.j?.playabilityStatus?.status || "-"}`);
+      await sleep(150);
+    }
+  }
+
+  const streamers = results.filter((r) => r.audio === "direct" && (r.stream === "200" || r.stream === "206"));
+  console.log(`\n=== STREAMABLE without poToken (playability OK + direct url + bytes served) ===`);
+  for (const r of [...new Set(streamers.map((s) => `${s.client} [${s.mode}]`))]) console.log("  ✓ " + r);
+  if (!streamers.length) console.log("  (none — every working client needs poToken or deobfuscation)");
+
+  const outPath = new URL("./results.json", import.meta.url);
+  fs.writeFileSync(outPath, JSON.stringify(results, null, 2));
+  console.log(`\nFull matrix -> tests/results.json`);
+})();

--- a/tests/web-remix-stream.mjs
+++ b/tests/web-remix-stream.mjs
@@ -1,0 +1,277 @@
+// Reproduce the WEB_REMIX playback hiccup with HARD DATA, using the app's EXACT path.
+//
+// Pipeline (identical to YTPlayerUtils.playerResponseForPlayback for the WEB_REMIX main client):
+//   1. cipher.mjs fetches the SAME base.js -> STS + sig/n (run in jsdom, byte-identical to the
+//      app's CipherWebView).
+//   2. potoken.mjs mints the SAME two tokens: player(videoId) + streaming(visitorData).
+//   3. raw /player POST to music.youtube.com, faithful to InnerTube.kt (WEB_REMIX context,
+//      X-Goog-* headers, SAPISIDHASH auth, signatureTimestamp, serviceIntegrityDimensions.poToken).
+//   4. findFormat: adaptiveFormats.filter(isAudio && isOriginal).maxBy(bitrate + webm bias).
+//   5. findUrlOrNull: signatureCipher -> cipher.deobfuscateStreamUrl (sig).
+//   6. transformNParamInUrl (n) -> append &pot=enc(streamingDataPoToken).
+//   7. Then exercise the URL like ExoPlayer and record real HTTP results:
+//        A initial chunk, B sequential continuation (header ranges), B2 (query ranges),
+//        C seek (~75%), D one open-ended GET, E re-resolve-on-403, plus a pot-variant probe.
+//   8. IOS direct-url control to prove the harness is sound.
+//
+//   node tests/web-remix-stream.mjs                 # JTF9fLJvniI
+//   node tests/web-remix-stream.mjs <videoId>
+//   CHUNK=262144 COVER_SECONDS=90 node tests/web-remix-stream.mjs
+
+import crypto from "node:crypto";
+import { CLIENTS, USER_AGENT_WEB, ORIGIN, PLAYER_URL } from "./clients.mjs";
+import { getCred, describeCred } from "./cred.mjs";
+import { mintWebPoTokens } from "./potoken.mjs";
+import { createCipher } from "./cipher.mjs";
+
+const VIDEO_ID = process.argv[2] || process.env.VIDEO_ID || "JTF9fLJvniI";
+const CHUNK = Number(process.env.CHUNK || 262144);
+const COVER_SECONDS = Number(process.env.COVER_SECONDS || 90);
+const WEB_REMIX = CLIENTS.find((c) => c.key === "WEB_REMIX");
+const IOS = CLIENTS.find((c) => c.key === "IOS");
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const msOf = (a, b) => `${(b - a).toFixed(0)}ms`;
+const kb = (n) => `${(n / 1024).toFixed(0)}KB`;
+const dec = (s) => { try { return s && /%[0-9A-Fa-f]{2}/.test(s) ? decodeURIComponent(s) : s; } catch { return s; } };
+
+// ---- faithful /player request (InnerTube.kt) ----
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  const hash = crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex");
+  return `SAPISIDHASH ${ts}_${hash}`;
+}
+function buildBody(c, videoId, visitorData, dataSyncId, { sts, poToken } = {}) {
+  const client = { clientName: c.clientName, clientVersion: c.clientVersion, hl: "en", gl: "US" };
+  if (visitorData) client.visitorData = visitorData;
+  for (const k of ["osName", "osVersion", "deviceMake", "deviceModel", "androidSdkVersion"]) if (c[k]) client[k] = c[k];
+  const body = { context: { client }, videoId, contentCheckOk: true, racyCheckOk: true };
+  if (c.loginSupported && dataSyncId) body.context.user = { onBehalfOfUser: dataSyncId };
+  if (c.useSignatureTimestamp && sts) body.playbackContext = { contentPlaybackContext: { signatureTimestamp: Number(sts) } };
+  if (poToken) body.serviceIntegrityDimensions = { poToken };
+  return body;
+}
+function buildHeaders(c, visitorData, { cookie, auth } = {}) {
+  const h = {
+    "Content-Type": "application/json", "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": c.clientId, "X-YouTube-Client-Version": c.clientVersion,
+    "X-Origin": ORIGIN, Referer: ORIGIN + "/", "User-Agent": c.userAgent,
+  };
+  if (visitorData) h["X-Goog-Visitor-Id"] = visitorData;
+  if (auth && cookie && c.loginSupported) {
+    h.cookie = cookie;
+    const a = sapisidHash(cookie);
+    if (a) h.Authorization = a;
+  }
+  return h;
+}
+async function playerRequest(c, videoId, visitorData, dataSyncId, opts = {}) {
+  const res = await fetch(PLAYER_URL, {
+    method: "POST", headers: buildHeaders(c, visitorData, opts),
+    body: JSON.stringify(buildBody(c, videoId, visitorData, dataSyncId, opts)),
+  });
+  const text = await res.text();
+  let j = {}; try { j = JSON.parse(text); } catch {}
+  return { http: res.status, j };
+}
+
+// ---- app format selection (YTPlayerUtils.findFormat, streaming/HIGH) ----
+const isAudio = (f) => f.width == null;
+const isOriginal = (f) => !f.audioTrack || f.audioTrack.isAutoDubbed == null;
+function findFormat(j) {
+  const fmts = (j?.streamingData?.adaptiveFormats || []).filter((f) => isAudio(f) && isOriginal(f));
+  return fmts.sort((a, b) =>
+    (b.bitrate + ((b.mimeType || "").startsWith("audio/webm") ? 10240 : 0)) -
+    (a.bitrate + ((a.mimeType || "").startsWith("audio/webm") ? 10240 : 0)))[0] || null;
+}
+
+function urlAnatomy(u) {
+  let q; try { q = new URL(u).searchParams; } catch { return {}; }
+  return {
+    host: (() => { try { return new URL(u).host; } catch { return "?"; } })(),
+    hasPot: q.has("pot"), hasN: q.has("n"), itag: q.get("itag"), mime: q.get("mime"),
+    clen: q.get("clen") ? Number(q.get("clen")) : null,
+    expire: q.get("expire") ? Number(q.get("expire")) : null,
+  };
+}
+
+// One HTTP request on a fresh connection.
+async function fetchRange(url, start, end, { ua, useQueryParam = false } = {}) {
+  let target = url;
+  const headers = { "User-Agent": ua, Connection: "close" };
+  if (useQueryParam) { target = `${url}${url.includes("?") ? "&" : "?"}range=${start}-${end ?? ""}`; }
+  else { headers.Range = `bytes=${start}-${end ?? ""}`; }
+  const t0 = performance.now();
+  try {
+    const r = await fetch(target, { headers });
+    const contentRange = r.headers.get("content-range");
+    r.body?.cancel?.();
+    return { status: r.status, contentRange, ms: performance.now() - t0 };
+  } catch (e) { return { status: "ERR", error: e.message, ms: performance.now() - t0 }; }
+}
+async function drainWhole(url, ua, capBytes) {
+  const t0 = performance.now();
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": ua, Range: "bytes=0-" } });
+    if (r.status !== 200 && r.status !== 206) return { status: r.status, read: 0, ms: performance.now() - t0 };
+    let read = 0; const reader = r.body.getReader();
+    for (;;) { const { done, value } = await reader.read(); if (done) break; read += value.length; if (capBytes && read >= capBytes) { await reader.cancel(); break; } }
+    return { status: r.status, read, ms: performance.now() - t0, capped: capBytes && read >= capBytes };
+  } catch (e) { return { status: "ERR", error: e.message, read: 0, ms: performance.now() - t0 }; }
+}
+
+// ---- resolve a playable URL the app's exact way ----
+async function resolveAppUrl(c, { cipher, tokens, cred }) {
+  const visitorData = dec(cred.visitorData);
+  const auth = !!c.loginSupported;
+  const playerPot = c.useWebPoTokens ? tokens?.playerRequestPoToken : null;
+  const { http, j } = await playerRequest(c, VIDEO_ID, visitorData, cred.dataSyncId, {
+    cookie: cred.cookie, auth, sts: cipher?.sts, poToken: playerPot,
+  });
+  const ps = j?.playabilityStatus || {};
+  const fmt = findFormat(j);
+  let url = null, sigUsed = false, nUsed = false;
+  if (fmt) {
+    if (fmt.url) url = fmt.url;
+    else if (fmt.signatureCipher) { url = cipher.deobfuscateStreamUrl(fmt.signatureCipher); sigUsed = true; }
+    const isWeb = c.useWebPoTokens || ["WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5"].includes(c.clientName);
+    if (url && isWeb) {
+      const before = url;
+      url = cipher.transformNParamInUrl(url);
+      nUsed = url !== before;
+      // URL_POT selects which token to append:
+      //   streaming (default) = visitorData-bound = the app's CURRENT behavior (reproduces the 403)
+      //   player              = videoId-bound      = the FIX
+      //   none                = no pot
+      const urlPotMode = process.env.URL_POT || "streaming";
+      const urlPot = urlPotMode === "player" ? tokens?.playerRequestPoToken
+        : urlPotMode === "none" ? null
+        : tokens?.streamingDataPoToken;
+      if (c.useWebPoTokens && urlPot) {
+        url += `${url.includes("?") ? "&" : "?"}pot=${encodeURIComponent(urlPot)}`;
+      }
+    }
+  }
+  return {
+    http, ps: { status: ps.status, reason: ps.reason },
+    nFormats: (j?.streamingData?.adaptiveFormats || []).length,
+    sabrUrl: j?.streamingData?.serverAbrStreamingUrl ? "PRESENT" : "none",
+    fmt, url, sigUsed, nUsed,
+    contentLength: fmt?.contentLength ? Number(fmt.contentLength) : urlAnatomy(url).clen,
+    approxDurationMs: fmt?.approxDurationMs ? Number(fmt.approxDurationMs) : null,
+    itag: fmt?.itag, mime: fmt?.mimeType, bitrate: fmt?.bitrate, anatomy: url ? urlAnatomy(url) : {},
+  };
+}
+
+const secAt = (off, clen, durMs) => (!clen || !durMs ? null : (off / clen) * (durMs / 1000));
+
+async function battery(label, r, ua, { reResolve, potVariants } = {}) {
+  const { url, contentLength, approxDurationMs } = r;
+  const toSec = (o) => { const s = secAt(o, contentLength, approxDurationMs); return s == null ? "?" : s.toFixed(1) + "s"; };
+  console.log(`\n----- ${label}: range battery -----`);
+  console.log(`url host=${r.anatomy.host} pot=${r.anatomy.hasPot} n=${r.anatomy.hasN} itag=${r.anatomy.itag} clen=${contentLength ?? "?"} dur=${approxDurationMs ? (approxDurationMs / 1000).toFixed(0) + "s" : "?"} expire=${r.anatomy.expire || "?"}`);
+  if (!url) { console.log("  no url — cannot test"); return; }
+
+  const a = await fetchRange(url, 0, CHUNK - 1, { ua });
+  console.log(`A initial    bytes=0-${CHUNK - 1}  -> ${a.status} ${a.contentRange ? `(cr ${a.contentRange})` : ""} ${msOf(0, a.ms)}`);
+
+  const targetBytes = contentLength || CHUNK * 64;
+  async function sweep(useQueryParam) {
+    let offset = CHUNK, firstFail = null;
+    while (offset < targetBytes && (secAt(offset, contentLength, approxDurationMs) ?? 0) < COVER_SECONDS) {
+      const res = await fetchRange(url, offset, offset + CHUNK - 1, { ua, useQueryParam });
+      if (res.status !== 200 && res.status !== 206) { firstFail = { offset, status: res.status, error: res.error }; break; }
+      offset += CHUNK;
+    }
+    return { firstFail, lastOffset: offset };
+  }
+  const bh = await sweep(false);
+  console.log(`B  continuation (fresh conn / chunk, HEADER Range): ${bh.firstFail
+    ? `FAIL @${toSec(bh.firstFail.offset)} (byte ${bh.firstFail.offset}) -> ${bh.firstFail.status} ${bh.firstFail.error || ""}`
+    : `all 200/206 through ${toSec(bh.lastOffset)} — no drop`}`);
+  const bq = await sweep(true);
+  console.log(`B2 continuation (fresh conn / chunk, QUERY &range=): ${bq.firstFail
+    ? `FAIL @${toSec(bq.firstFail.offset)} (byte ${bq.firstFail.offset}) -> ${bq.firstFail.status}`
+    : `all 200/206 through ${toSec(bq.lastOffset)} — no drop`}`);
+
+  const seekOff = contentLength ? Math.floor(contentLength * 0.75) : CHUNK * 40;
+  const cH = await fetchRange(url, seekOff, seekOff + CHUNK - 1, { ua });
+  const cQ = await fetchRange(url, seekOff, seekOff + CHUNK - 1, { ua, useQueryParam: true });
+  console.log(`C  seek @${toSec(seekOff)} (byte ${seekOff})  HEADER -> ${cH.status}   QUERY -> ${cQ.status}`);
+
+  const d = await drainWhole(url, ua, contentLength ? contentLength + 1 : CHUNK * 200);
+  console.log(`D  one open GET bytes=0-  -> ${d.status} delivered ${kb(d.read)}${contentLength ? ` / ${kb(contentLength)}` : ""} (${secAt(d.read, contentLength, approxDurationMs)?.toFixed(1) ?? "?"}s) ${d.capped ? "[whole file]" : "[server ended early]"} ${msOf(0, d.ms)}`);
+
+  if (potVariants) {
+    const off = (bh.firstFail || bq.firstFail || { offset: seekOff }).offset;
+    console.log(`P  pot-variant probe @${toSec(off)} (byte ${off}) on a fresh connection:`);
+    for (const [name, u] of Object.entries(potVariants(url))) {
+      const res = await fetchRange(u, off, off + CHUNK - 1, { ua });
+      console.log(`     ${name.padEnd(22)} -> ${res.status}`);
+    }
+  }
+
+  if ((bh.firstFail || bq.firstFail) && reResolve) {
+    const off = (bh.firstFail || bq.firstFail).offset;
+    console.log(`E  re-resolve @${toSec(off)} (byte ${off}) with fresh url + fresh tokens:`);
+    try {
+      const fresh = await reResolve();
+      const rr = await fetchRange(fresh.url, off, off + CHUNK - 1, { ua });
+      console.log(`     fresh url pot=${fresh.anatomy.hasPot} -> ${rr.status} ${rr.contentRange ? `(cr ${rr.contentRange})` : ""} ${rr.status === 206 || rr.status === 200 ? "✓ recovers" : "✗ still fails"}`);
+    } catch (e) { console.log(`     re-resolve failed: ${e.message}`); }
+  }
+}
+
+(async () => {
+  const cred = await getCred();
+  const visitorData = dec(cred.visitorData);
+  console.log(describeCred(cred));
+  console.log(`video=${VIDEO_ID} chunk=${kb(CHUNK)} coverTarget=${COVER_SECONDS}s`);
+
+  let t = performance.now();
+  const cipher = await createCipher({ verbose: true });
+  console.log(`cipher ready ${msOf(t, performance.now())}  hash=${cipher.hash} sts=${cipher.sts} sig=${cipher.sigAvailable} n=${cipher.nAvailable}`);
+
+  t = performance.now();
+  let tokens;
+  try {
+    tokens = await mintWebPoTokens({ visitorData, videoId: VIDEO_ID });
+    console.log(`poTokens minted ${msOf(t, performance.now())}  player(videoId)=${tokens.playerRequestPoToken?.slice(0, 16)}…(${tokens.playerRequestPoToken?.length})  streaming(visitorData)=${tokens.streamingDataPoToken?.slice(0, 16)}…(${tokens.streamingDataPoToken?.length})`);
+  } catch (e) { console.log(`poToken mint FAILED: ${e.message}`); tokens = {}; }
+
+  console.log(`\n========== WEB_REMIX (app main client, exact path) ==========`);
+  console.log(`URL_POT=${process.env.URL_POT || "streaming"} (streaming=visitorData/app default, player=videoId/fix, none)`);
+  try {
+    const r = await resolveAppUrl(WEB_REMIX, { cipher, tokens, cred });
+    console.log(`http=${r.http} playability=${r.ps.status}${r.ps.reason ? ` (${r.ps.reason})` : ""} formats=${r.nFormats} sabr=${r.sabrUrl}`);
+    console.log(`format itag=${r.itag} mime="${r.mime}" bitrate=${r.bitrate} sigUsed=${r.sigUsed} nUsed=${r.nUsed}`);
+    if (r.url) {
+      await battery("WEB_REMIX", r, USER_AGENT_WEB, {
+        potVariants: (u) => {
+          const base = u.replace(/([?&])pot=[^&]*/, "$1").replace(/[?&]$/, "");
+          return {
+            "no pot": base,
+            "streaming pot (app)": `${base}${base.includes("?") ? "&" : "?"}pot=${encodeURIComponent(tokens.streamingDataPoToken)}`,
+            "player pot (videoId)": `${base}${base.includes("?") ? "&" : "?"}pot=${encodeURIComponent(tokens.playerRequestPoToken)}`,
+          };
+        },
+        reResolve: async () => {
+          const freshTok = await mintWebPoTokens({ visitorData, videoId: VIDEO_ID });
+          return resolveAppUrl(WEB_REMIX, { cipher, tokens: freshTok, cred });
+        },
+      });
+    }
+  } catch (e) { console.log(`WEB_REMIX FAILED: ${e.message}\n${e.stack}`); }
+
+  console.log(`\n========== IOS (control, direct url, no pot/cipher) ==========`);
+  try {
+    const r = await resolveAppUrl(IOS, { cipher, tokens, cred: { ...cred, cookie: "" } });
+    console.log(`http=${r.http} playability=${r.ps.status}${r.ps.reason ? ` (${r.ps.reason})` : ""} formats=${r.nFormats} sabr=${r.sabrUrl} itag=${r.itag} mime="${r.mime}"`);
+    if (r.url) await battery("IOS", r, IOS.userAgent, {});
+  } catch (e) { console.log(`IOS FAILED: ${e.message}`); }
+
+  cipher._close?.();
+  process.exit(0);
+})();


### PR DESCRIPTION
Tooling + docs that backed #55 (the WEB_REMIX poToken fix). No app/runtime code — `tests/` only.

## What's here
Node scripts that reproduce the app's **exact** streaming path against the live CDN (InnerTube `/player` request, the Zemer cipher's sig+n run in jsdom, BotGuard poTokens via bgutils):

- **`web-remix-stream.mjs`** — reproduce the WEB_REMIX ~45 s drop + seek 403; verify a fix with `URL_POT=player`.
- **`pot-probe.mjs`** — the definitive poToken-binding matrix (request-pot × url-pot × {none/videoId/visitorData}). This is what proved the URL needs a videoId-bound pot.
- **`client-fulldownload.mjs`** — which clients deliver a *whole* song (drains the full file, not a 2-byte check).
- **`cipher.mjs` / `potoken.mjs` / `cred.mjs`** — building blocks: live base.js sig+n, BotGuard mint, local cookie loader.
- **`INVESTIGATION.md`** — methodology + a symptom-indexed runbook for re-diagnosing when YouTube rotates players, changes the pot scheme, or a client breaks.

## Safety
`tests/node_modules/` and `innertube_cookie.txt` (live cookies) are gitignored; a staged-blob scan confirmed no secrets in the commit.