### PR TITLE
Stream-sources settings + WEB_CREATOR streaming fix + resilient resolution

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -71,6 +71,14 @@ val LastWhitelistVersionKey = longPreferencesKey("lastWhitelistVersion")
 
 val AudioQualityKey = stringPreferencesKey("audioQuality")
 
+// Stream source toggles — each key maps to whether that client is enabled
+val StreamSourceWebRemixKey   = booleanPreferencesKey("streamSourceWebRemix")
+val StreamSourceTVHTML5Key    = booleanPreferencesKey("streamSourceTVHTML5")
+val StreamSourceAndroidVRKey  = booleanPreferencesKey("streamSourceAndroidVR")
+val StreamSourceIOSKey        = booleanPreferencesKey("streamSourceIOS")
+val StreamSourceIPadOSKey     = booleanPreferencesKey("streamSourceIPadOS")
+val StreamSourceWebCreatorKey = booleanPreferencesKey("streamSourceWebCreator")
+
 enum class AudioQuality {
     AUTO,
     HIGH,

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -78,6 +78,7 @@ val StreamSourceAndroidVRKey  = booleanPreferencesKey("streamSourceAndroidVR")
 val StreamSourceIOSKey        = booleanPreferencesKey("streamSourceIOS")
 val StreamSourceIPadOSKey     = booleanPreferencesKey("streamSourceIPadOS")
 val StreamSourceWebCreatorKey = booleanPreferencesKey("streamSourceWebCreator")
+val StreamSourceAndroidCreatorKey = booleanPreferencesKey("streamSourceAndroidCreator")
 
 enum class AudioQuality {
     AUTO,

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -337,6 +337,7 @@ class MusicService :
                 if (prefs[com.jtech.zemer.constants.StreamSourceIOSKey]       == false) disabled += "IOS"
                 if (prefs[com.jtech.zemer.constants.StreamSourceIPadOSKey]    == false) disabled += "IOS" // IPADOS uses IOS clientName
                 if (prefs[com.jtech.zemer.constants.StreamSourceWebCreatorKey] == false) disabled += "WEB_CREATOR"
+                if (prefs[com.jtech.zemer.constants.StreamSourceAndroidCreatorKey] == false) disabled += "ANDROID_CREATOR"
                 YTPlayerUtils.disabledStreamClients = disabled
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -325,6 +325,22 @@ class MusicService :
             }
         }
 
+        // Keep YTPlayerUtils in sync with the stream source toggles
+        scope.launch {
+            dataStore.data.collect { prefs ->
+                val disabled = mutableSetOf<String>()
+                if (prefs[com.jtech.zemer.constants.StreamSourceWebRemixKey] == false) disabled += "WEB_REMIX"
+                if (prefs[com.jtech.zemer.constants.StreamSourceTVHTML5Key]   == false) disabled += "TVHTML5"
+                if (prefs[com.jtech.zemer.constants.StreamSourceAndroidVRKey] == false) {
+                    disabled += "ANDROID_VR"
+                }
+                if (prefs[com.jtech.zemer.constants.StreamSourceIOSKey]       == false) disabled += "IOS"
+                if (prefs[com.jtech.zemer.constants.StreamSourceIPadOSKey]    == false) disabled += "IOS" // IPADOS uses IOS clientName
+                if (prefs[com.jtech.zemer.constants.StreamSourceWebCreatorKey] == false) disabled += "WEB_CREATOR"
+                YTPlayerUtils.disabledStreamClients = disabled
+            }
+        }
+
         scope.launch {
             connectivityObserver.networkStatus.collect { isConnected ->
                 isNetworkConnected.value = isConnected

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -36,6 +36,7 @@ import com.jtech.zemer.ui.screens.settings.PlayerSettings
 import com.jtech.zemer.ui.screens.settings.PrivacySettings
 import com.jtech.zemer.ui.screens.settings.SettingsScreen
 import com.jtech.zemer.ui.screens.settings.StorageSettings
+import com.jtech.zemer.ui.screens.settings.StreamSourceSettings
 import com.jtech.zemer.ui.screens.settings.UpdaterScreen
 import com.jtech.zemer.ui.screens.settings.integrations.IntegrationScreen
 import com.jtech.zemer.viewmodels.HomeViewModel
@@ -304,6 +305,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings/player") {
         PlayerSettings(navController, scrollBehavior)
+    }
+    composable("settings/stream_sources") {
+        StreamSourceSettings(navController, scrollBehavior)
     }
     composable("settings/general") {
         GeneralSettings(navController, scrollBehavior)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -86,6 +86,14 @@ fun SettingsScreen(
             route = "settings/player"
         ),
         SettingItem(
+            id = "stream_sources",
+            title = stringResource(R.string.stream_sources),
+            description = stringResource(R.string.stream_sources_description),
+            icon = R.drawable.play,
+            section = "Player & Content",
+            route = "settings/stream_sources"
+        ),
+        SettingItem(
             id = "content",
             title = stringResource(R.string.content),
             description = "Language, content settings",

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
@@ -1,0 +1,141 @@
+package com.jtech.zemer.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.StreamSourceAndroidVRKey
+import com.jtech.zemer.constants.StreamSourceIOSKey
+import com.jtech.zemer.constants.StreamSourceIPadOSKey
+import com.jtech.zemer.constants.StreamSourceTVHTML5Key
+import com.jtech.zemer.constants.StreamSourceWebCreatorKey
+import com.jtech.zemer.constants.StreamSourceWebRemixKey
+import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.utils.rememberPreference
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StreamSourceSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    val (webRemixEnabled, onWebRemixChange)     = rememberPreference(StreamSourceWebRemixKey,   defaultValue = true)
+    val (tvhtml5Enabled, onTVHTML5Change)       = rememberPreference(StreamSourceTVHTML5Key,    defaultValue = true)
+    val (androidVREnabled, onAndroidVRChange)   = rememberPreference(StreamSourceAndroidVRKey,  defaultValue = true)
+    val (iosEnabled, onIOSChange)               = rememberPreference(StreamSourceIOSKey,        defaultValue = true)
+    val (ipadosEnabled, onIPadOSChange)         = rememberPreference(StreamSourceIPadOSKey,     defaultValue = true)
+    val (webCreatorEnabled, onWebCreatorChange) = rememberPreference(StreamSourceWebCreatorKey, defaultValue = true)
+
+    val backFocus = remember { FocusRequester() }
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        firstFocus.requestFocus()
+    }
+
+    Column(
+        Modifier
+            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        PreferenceGroupTitle(
+            title = stringResource(R.string.stream_source_web_clients)
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_web_remix)) },
+            description = stringResource(R.string.stream_source_web_remix_desc),
+            icon = { Icon(painterResource(R.drawable.music_note), null) },
+            checked = webRemixEnabled,
+            onCheckedChange = onWebRemixChange,
+            modifier = Modifier.focusRequester(firstFocus),
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_tvhtml5)) },
+            description = stringResource(R.string.stream_source_tvhtml5_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = tvhtml5Enabled,
+            onCheckedChange = onTVHTML5Change,
+        )
+
+        PreferenceGroupTitle(
+            title = stringResource(R.string.stream_source_native_clients)
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_android_vr)) },
+            description = stringResource(R.string.stream_source_android_vr_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = androidVREnabled,
+            onCheckedChange = onAndroidVRChange,
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_ios)) },
+            description = stringResource(R.string.stream_source_ios_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = iosEnabled,
+            onCheckedChange = onIOSChange,
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_ipad_os)) },
+            description = stringResource(R.string.stream_source_ipad_os_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = ipadosEnabled,
+            onCheckedChange = onIPadOSChange,
+        )
+
+        PreferenceGroupTitle(
+            title = stringResource(R.string.stream_source_creator_clients)
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_web_creator)) },
+            description = stringResource(R.string.stream_source_web_creator_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = webCreatorEnabled,
+            onCheckedChange = onWebCreatorChange,
+        )
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.stream_sources)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .focusRequester(backFocus)
+                        .focusProperties { down = firstFocus },
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.constants.StreamSourceAndroidCreatorKey
 import com.jtech.zemer.constants.StreamSourceAndroidVRKey
 import com.jtech.zemer.constants.StreamSourceIOSKey
 import com.jtech.zemer.constants.StreamSourceIPadOSKey
@@ -45,6 +46,7 @@ fun StreamSourceSettings(
     val (iosEnabled, onIOSChange)               = rememberPreference(StreamSourceIOSKey,        defaultValue = true)
     val (ipadosEnabled, onIPadOSChange)         = rememberPreference(StreamSourceIPadOSKey,     defaultValue = true)
     val (webCreatorEnabled, onWebCreatorChange) = rememberPreference(StreamSourceWebCreatorKey, defaultValue = true)
+    val (androidCreatorEnabled, onAndroidCreatorChange) = rememberPreference(StreamSourceAndroidCreatorKey, defaultValue = true)
 
     val backFocus = remember { FocusRequester() }
     val firstFocus = remember { FocusRequester() }
@@ -117,6 +119,14 @@ fun StreamSourceSettings(
             icon = { Icon(painterResource(R.drawable.play), null) },
             checked = webCreatorEnabled,
             onCheckedChange = onWebCreatorChange,
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.stream_source_android_creator)) },
+            description = stringResource(R.string.stream_source_android_creator_desc),
+            icon = { Icon(painterResource(R.drawable.play), null) },
+            checked = androidCreatorEnabled,
+            onCheckedChange = onAndroidCreatorChange,
         )
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -139,15 +139,19 @@ object YTPlayerUtils {
         Timber.tag(TAG).d( "PoToken: ${if (poTokenResult != null) "generated" else "unavailable"}")
 
         Timber.tag(TAG).d( "Fetching main player response with client: ${mainClient.clientName}")
+        // Resilient: the chosen main client can fail outright (e.g. ANDROID_CREATOR returns
+        // HTTP 400 with login). Use getOrNull, not getOrThrow, so one bad client never kills the
+        // whole resolution — the stream loop below falls through to the next enabled client, and
+        // metadata is captured from the first client that returns OK.
         val mainPlayerResponse =
             YouTube.player(
                 videoId, playlistId, mainClient, signatureTimestamp,
                 webPlayerPot = if (mainClient.useWebPoTokens) poTokenResult?.playerRequestPoToken else null
-            ).getOrThrow()
-        Timber.tag(TAG).d( "Main response status: ${mainPlayerResponse.playabilityStatus.status}")
-        val audioConfig = mainPlayerResponse.playerConfig?.audioConfig
-        val videoDetails = mainPlayerResponse.videoDetails
-        val playbackTracking = mainPlayerResponse.playbackTracking
+            ).getOrNull()
+        Timber.tag(TAG).d( "Main response status: ${mainPlayerResponse?.playabilityStatus?.status ?: "request failed"}")
+        var audioConfig = mainPlayerResponse?.playerConfig?.audioConfig
+        var videoDetails = mainPlayerResponse?.videoDetails
+        var playbackTracking = mainPlayerResponse?.playbackTracking
         var format: PlayerResponse.StreamingData.Format? = null
         var streamUrl: String? = null
         var streamExpiresInSeconds: Int? = null
@@ -187,6 +191,11 @@ object YTPlayerUtils {
             // process current client response
             if (streamPlayerResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(TAG).d( "Status OK for ${client.clientName}")
+
+                // Capture metadata from the first OK client (main may have failed/returned null above).
+                if (audioConfig == null) audioConfig = streamPlayerResponse?.playerConfig?.audioConfig
+                if (videoDetails == null) videoDetails = streamPlayerResponse?.videoDetails
+                if (playbackTracking == null) playbackTracking = streamPlayerResponse?.playbackTracking
 
                 // Use the player response as-is. The old NewPipe StreamInfo.getInfo
                 // pre-processing ran a full second extraction for EVERY song (fetch watch

--- a/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt
@@ -4,6 +4,12 @@ import android.net.ConnectivityManager
 import androidx.core.net.toUri
 import androidx.media3.common.PlaybackException
 import com.jtech.zemer.constants.AudioQuality
+import com.jtech.zemer.constants.StreamSourceAndroidVRKey
+import com.jtech.zemer.constants.StreamSourceIOSKey
+import com.jtech.zemer.constants.StreamSourceIPadOSKey
+import com.jtech.zemer.constants.StreamSourceTVHTML5Key
+import com.jtech.zemer.constants.StreamSourceWebRemixKey
+import kotlinx.coroutines.flow.first
 
 import timber.log.Timber
 import com.metrolist.innertube.NewPipeUtils
@@ -50,9 +56,12 @@ object YTPlayerUtils {
         webRemixFailedIds.add(videoId)
     }
 
+    /** Client names disabled by the user in Settings → Stream sources. Updated by MusicService. */
+    var disabledStreamClients: Set<String> = emptySet()
+
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
-    private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
+    private val ALL_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
         TVHTML5,
         ANDROID_VR_1_43_32,
         IOS,
@@ -64,6 +73,9 @@ object YTPlayerUtils {
         WEB,
         WEB_CREATOR
     )
+
+    private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient>
+        get() = ALL_FALLBACK_CLIENTS.filter { it.clientName !in disabledStreamClients }.toTypedArray()
     data class PlaybackData(
         val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,
         val videoDetails: PlayerResponse.VideoDetails?,
@@ -87,8 +99,13 @@ object YTPlayerUtils {
         maxVideoBitrateKbps: Int? = null,
         forDownload: Boolean = false,
     ): Result<PlaybackData> = runCatching {
-        val mainClient = MAIN_CLIENT
-        val fallbackClients = STREAM_FALLBACK_CLIENTS
+        val mainClient = if (MAIN_CLIENT.clientName in disabledStreamClients) {
+            STREAM_FALLBACK_CLIENTS.firstOrNull()
+                ?: throw PlaybackException("All stream sources are disabled", null, PlaybackException.ERROR_CODE_REMOTE_ERROR)
+        } else {
+            MAIN_CLIENT
+        }
+        val fallbackClients = STREAM_FALLBACK_CLIENTS.filter { it.clientName != mainClient.clientName }.toTypedArray()
 
         Timber.tag(TAG).d( "=== Stream resolution START for videoId=$videoId ===")
         Timber.tag(TAG).d( "Main client: ${mainClient.clientName}, audioQuality=$audioQuality, preferVideo=$preferVideo")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -553,6 +553,25 @@
     <string name="setting_up_library_title">Setting up your library…</string>
     <string name="setting_up_library_progress">Setting up your library… %1$d%%</string>
 
+    <!-- Stream sources -->
+    <string name="stream_sources">Stream sources</string>
+    <string name="stream_sources_description">Enable/Disable streaming clients</string>
+    <string name="stream_source_web_clients">Web clients</string>
+    <string name="stream_source_native_clients">Native clients</string>
+    <string name="stream_source_creator_clients">Creator clients</string>
+    <string name="stream_source_web_remix">WEB_REMIX</string>
+    <string name="stream_source_web_remix_desc">YouTube Music web client — best quality, opus audio</string>
+    <string name="stream_source_tvhtml5">TVHTML5</string>
+    <string name="stream_source_tvhtml5_desc">YouTube TV web client — fallback for login-gated content</string>
+    <string name="stream_source_android_vr">Android VR</string>
+    <string name="stream_source_android_vr_desc">Direct URL client — reliable fallback, no cipher needed</string>
+    <string name="stream_source_ios">iOS</string>
+    <string name="stream_source_ios_desc">Direct URL client — Apple device client</string>
+    <string name="stream_source_ipad_os">iPadOS</string>
+    <string name="stream_source_ipad_os_desc">Direct URL client — iPad client</string>
+    <string name="stream_source_web_creator">WEB_CREATOR</string>
+    <string name="stream_source_web_creator_desc">YouTube Studio web client</string>
+
     <!-- Widget -->
     <string name="widget_name">Zemer Music</string>
     <string name="widget_description">Control your music playback</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -571,6 +571,8 @@
     <string name="stream_source_ipad_os_desc">Direct URL client — iPad client</string>
     <string name="stream_source_web_creator">WEB_CREATOR</string>
     <string name="stream_source_web_creator_desc">YouTube Studio web client</string>
+    <string name="stream_source_android_creator">ANDROID_CREATOR</string>
+    <string name="stream_source_android_creator_desc">YouTube Studio mobile client — login required, often unavailable</string>
 
     <!-- Widget -->
     <string name="widget_name">Zemer Music</string>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
@@ -76,6 +76,11 @@ data class YouTubeClient(
             loginSupported = true,
             loginRequired = true,
             useSignatureTimestamp = true,
+            // Verified against the live CDN (tests/web-creator-stream.mjs): WEB_CREATOR returns
+            // ciphered URLs that 403 past the 1 MiB free window unless a videoId-bound pot is
+            // appended (HEAD also 403s without it). Enabling poTokens makes it stream the whole
+            // song — without this it is a dead fallback.
+            useWebPoTokens = true,
         )
 
         val TVHTML5 = YouTubeClient(

--- a/tests/web-creator-stream.mjs
+++ b/tests/web-creator-stream.mjs
@@ -1,0 +1,142 @@
+// Hard-data probe for WEB_CREATOR streaming.
+//
+// WEB_CREATOR is loginRequired + useSignatureTimestamp, and (in the app) useWebPoTokens=false.
+// Two questions, answered against the live CDN with the real logged-in cookie:
+//   1. Is WEB_CREATOR even PLAYABLE with this account? Tested with no / videoId / visitorData
+//      poToken in the /player request.
+//   2. If it returns a stream, does the URL serve the WHOLE song, and which &pot= (if any) does
+//      it need to get past googlevideo's 1 MiB free window?
+//
+//   PLAYER_HASH=4f38b487 node tests/web-creator-stream.mjs            # pin a known player
+//   node tests/web-creator-stream.mjs <videoId>
+
+import crypto from "node:crypto";
+import { CLIENTS, ORIGIN, PLAYER_URL, USER_AGENT_WEB } from "./clients.mjs";
+import { getCred, describeCred } from "./cred.mjs";
+import { createCipher } from "./cipher.mjs";
+import { createMinter } from "./potoken.mjs";
+
+const VIDEO_ID = process.argv[2] || process.env.VIDEO_ID || "JTF9fLJvniI";
+const WEB_CREATOR = CLIENTS.find((c) => c.key === "WEB_CREATOR");
+const dec = (s) => { try { return s && /%[0-9A-Fa-f]{2}/.test(s) ? decodeURIComponent(s) : s; } catch { return s; } };
+const kb = (n) => `${(n / 1024).toFixed(0)}KB`;
+const MIB = 1048576;
+
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  return `SAPISIDHASH ${ts}_${crypto.createHash("sha1").update(`${ts} ${m[1]} ${ORIGIN}`).digest("hex")}`;
+}
+async function playerRequest(c, visitorData, dataSyncId, cookie, { sts, poToken }) {
+  const client = { clientName: c.clientName, clientVersion: c.clientVersion, hl: "en", gl: "US", visitorData };
+  const body = { context: { client }, videoId: VIDEO_ID, contentCheckOk: true, racyCheckOk: true };
+  if (dataSyncId) body.context.user = { onBehalfOfUser: dataSyncId };
+  if (c.useSignatureTimestamp && sts) body.playbackContext = { contentPlaybackContext: { signatureTimestamp: Number(sts) } };
+  if (poToken) body.serviceIntegrityDimensions = { poToken };
+  const h = {
+    "Content-Type": "application/json", "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": c.clientId, "X-YouTube-Client-Version": c.clientVersion,
+    "X-Origin": ORIGIN, Referer: ORIGIN + "/", "User-Agent": c.userAgent, "X-Goog-Visitor-Id": visitorData,
+  };
+  if (cookie) { h.cookie = cookie; const a = sapisidHash(cookie); if (a) h.Authorization = a; }
+  const res = await fetch(PLAYER_URL, { method: "POST", headers: h, body: JSON.stringify(body) });
+  let j = {}; try { j = JSON.parse(await res.text()); } catch {}
+  return { http: res.status, j };
+}
+const isAudio = (f) => f.width == null;
+const isOriginal = (f) => !f.audioTrack || f.audioTrack.isAutoDubbed == null;
+const findFormat = (j) => (j?.streamingData?.adaptiveFormats || []).filter((f) => isAudio(f) && isOriginal(f))
+  .sort((a, b) => (b.bitrate + ((b.mimeType || "").startsWith("audio/webm") ? 10240 : 0)) -
+                  (a.bitrate + ((a.mimeType || "").startsWith("audio/webm") ? 10240 : 0)))[0] || null;
+function resolveUrl(cipher, fmt) {
+  if (!fmt) return null;
+  let url = fmt.url || (fmt.signatureCipher ? cipher.deobfuscateStreamUrl(fmt.signatureCipher) : null);
+  if (!url) return null;
+  return cipher.transformNParamInUrl(url);
+}
+function withPot(url, pot) {
+  const base = url.replace(/([?&])pot=[^&]*/, "$1").replace(/[?&]$/, "");
+  return pot ? `${base}${base.includes("?") ? "&" : "?"}pot=${encodeURIComponent(pot)}` : base;
+}
+async function status(url, start, end) {
+  try { const r = await fetch(url, { headers: { "User-Agent": USER_AGENT_WEB, Range: `bytes=${start}-${end}`, Connection: "close" } }); r.body?.cancel?.(); return r.status; }
+  catch { return "ERR"; }
+}
+async function headStatus(url) {
+  try { const r = await fetch(url, { method: "HEAD", headers: { "User-Agent": USER_AGENT_WEB } }); r.body?.cancel?.(); return r.status; }
+  catch { return "ERR"; }
+}
+async function drainWhole(url, cap) {
+  try {
+    const r = await fetch(url, { headers: { "User-Agent": USER_AGENT_WEB, Range: "bytes=0-" } });
+    if (r.status !== 200 && r.status !== 206) return { status: r.status, read: 0 };
+    let read = 0; const rd = r.body.getReader();
+    for (;;) { const { done, value } = await rd.read(); if (done) break; read += value.length; if (cap && read >= cap) { await rd.cancel(); break; } }
+    return { status: r.status, read };
+  } catch { return { status: "ERR", read: 0 }; }
+}
+
+(async () => {
+  const cred = await getCred();
+  const visitorData = dec(cred.visitorData);
+  console.log(describeCred(cred));
+  console.log(`video=${VIDEO_ID}  client=WEB_CREATOR (loginRequired=true, useWebPoTokens=false in app)\n`);
+  if (!/SAPISID=/.test(cred.cookie)) console.log("WARNING: no SAPISID in cookie — WEB_CREATOR is login-required, expect LOGIN_REQUIRED\n");
+
+  const cipher = await createCipher({ verbose: true });
+  console.log(`cipher hash=${cipher.hash} sts=${cipher.sts}\n`);
+  const minter = await createMinter(visitorData);
+  const potVideo = await minter.mint(VIDEO_ID);
+  const potVisitor = await minter.mint(visitorData);
+
+  // 1) Playability under each request-pot variant
+  console.log("========== 1) WEB_CREATOR /player playability ==========");
+  const reqPots = { "no pot": null, "videoId pot": potVideo, "visitorData pot": potVisitor };
+  let best = null;
+  for (const [name, rp] of Object.entries(reqPots)) {
+    const { http, j } = await playerRequest(WEB_CREATOR, visitorData, cred.dataSyncId, cred.cookie, { sts: cipher.sts, poToken: rp });
+    const ps = j?.playabilityStatus || {};
+    const fmt = findFormat(j);
+    const nFmt = (j?.streamingData?.adaptiveFormats || []).length;
+    console.log(`  req=${name.padEnd(16)} http=${http} playability=${ps.status}${ps.reason ? ` (${ps.reason})` : ""} formats=${nFmt} itag=${fmt?.itag ?? "-"} cipher=${fmt?.signatureCipher ? "yes" : fmt?.url ? "direct" : "-"}`);
+    if (ps.status === "OK" && fmt && !best) best = { name, fmt, j };
+  }
+
+  if (!best) {
+    console.log("\nRESULT: WEB_CREATOR returned no playable stream with this account (no OK + format). It is a dead fallback.");
+    cipher._close?.(); process.exit(0);
+  }
+
+  // 2) URL-pot matrix on the playable resolution
+  console.log(`\n========== 2) WEB_CREATOR stream URL (from req=${best.name}) ==========`);
+  const base = resolveUrl(cipher, best.fmt);
+  if (!base) { console.log("could not deobfuscate a URL"); cipher._close?.(); process.exit(0); }
+  const clen = best.fmt.contentLength ? Number(best.fmt.contentLength) : null;
+  const dur = best.fmt.approxDurationMs ? Number(best.fmt.approxDurationMs) : null;
+  let host = "?"; try { host = new URL(base).host; } catch {}
+  console.log(`itag=${best.fmt.itag} mime="${best.fmt.mimeType}" host=${host} clen=${clen ?? "?"} dur=${dur ? (dur / 1000).toFixed(0) + "s" : "?"}`);
+  const urlPots = { "none": null, "videoId": potVideo, "visitorData": potVisitor };
+  let winner = null;
+  for (const [name, up] of Object.entries(urlPots)) {
+    const u = withPot(base, up);
+    const hd = await headStatus(u);
+    const s0 = await status(u, 0, 262143);
+    const s1 = await status(u, MIB, MIB + 262143);
+    const s2 = await status(u, 2 * MIB, 2 * MIB + 262143);
+    const pass = [s1, s2].every((s) => s === 200 || s === 206);
+    console.log(`  url pot=${name.padEnd(11)} HEAD=${hd}  @0=${s0}  @1MiB=${s1}  @2MiB=${s2}  ${pass ? "PAST FREE WINDOW" : ""}`);
+    if (pass && !winner) winner = { name, url: u };
+  }
+
+  if (winner) {
+    const d = await drainWhole(winner.url, clen ? clen + 1 : 50 * MIB);
+    const whole = clen && d.read >= clen;
+    console.log(`\nFull download [url pot=${winner.name}] -> ${d.status} ${kb(d.read)}${clen ? ` / ${kb(clen)}` : ""}  ${whole ? "WHOLE SONG" : "stopped early"}`);
+    console.log(`\nRESULT: WEB_CREATOR CAN stream (req=${best.name}, url pot=${winner.name}).`);
+  } else {
+    console.log(`\nRESULT: WEB_CREATOR resolves a URL but NO pot serves past 1 MiB — playback would drop at the wall.`);
+  }
+  cipher._close?.();
+  process.exit(0);
+})();


### PR DESCRIPTION
Brings the Stream-sources feature and the WEB_CREATOR work onto `main`.

## Stream-sources settings
Settings -> Stream sources lets the user toggle which streaming clients are used
(WEB_REMIX, TVHTML5, ANDROID_VR, IOS, IPadOS, WEB_CREATOR, ANDROID_CREATOR). Disabled
clients are dropped from the resolver's fallback chain.

## WEB_CREATOR now streams (terminal-verified)
`useWebPoTokens = true` on WEB_CREATOR so the videoId-bound pot is appended to its URL.
Verified against the live CDN (`tests/web-creator-stream.mjs`): WEB_CREATOR is a signed
web client whose URL 403s past googlevideo's ~1 MiB free window without a videoId-bound pot
(HEAD also 403s). With the pot it serves the whole song (HEAD 200, 206 throughout). Without
this it was a dead fallback.

## Resilient resolution (the "doesn't play" fix)
`YTPlayerUtils.playerResponseForPlayback` fetched the main player response with `getOrThrow()`.
When the chosen main client failed outright — e.g. `ANDROID_CREATOR`, which returns **HTTP 400**
for a logged-in session (mobile clients reject cookie auth) — the entire resolution threw and
nothing played, with no fallback attempted. Changed to `getOrNull()` + fall-through: a failing
main client now drops to the next enabled client, and metadata is taken from the first client
that returns OK.

## ANDROID_CREATOR toggle
`ANDROID_CREATOR`/`MOBILE`/`WEB` had no menu toggle and sat before WEB_CREATOR in the fallback
list; `ANDROID_CREATOR` is a guaranteed 400 with login, so it blocked reaching WEB_CREATOR.
Added an ANDROID_CREATOR toggle (Creator clients) so it can be cut out.

## Tests
`tests/web-creator-stream.mjs` — reusable WEB_CREATOR streaming probe (playability under
request-pot variants + url-pot matrix + full download).