### PR TITLE
feat(android-auto): configurable Android Auto settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         <intent>
             <action android:name="android.media.action.DISPLAY_AUDIO_EFFECT_CONTROL_PANEL" />
         </intent>
+        <package android:name="com.google.android.projection.gearhead" />
     </queries>
     <application
         android:name=".App"

--- a/app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt
@@ -10,10 +10,14 @@ object MediaSessionConstants {
     const val ACTION_TOGGLE_LIKE = "TOGGLE_LIKE"
     const val ACTION_TOGGLE_SHUFFLE = "TOGGLE_SHUFFLE"
     const val ACTION_TOGGLE_REPEAT_MODE = "TOGGLE_REPEAT_MODE"
+    const val ACTION_ADD_TO_TARGET_PLAYLIST = "ADD_TO_TARGET_PLAYLIST"
     val CommandToggleLibrary = SessionCommand(ACTION_TOGGLE_LIBRARY, Bundle.EMPTY)
     val CommandToggleLike = SessionCommand(ACTION_TOGGLE_LIKE, Bundle.EMPTY)
     val CommandToggleStartRadio = SessionCommand(ACTION_TOGGLE_START_RADIO, Bundle.EMPTY)
     val CommandToggleShuffle = SessionCommand(ACTION_TOGGLE_SHUFFLE, Bundle.EMPTY)
     @Suppress("unused")
     val CommandToggleRepeatMode = SessionCommand(ACTION_TOGGLE_REPEAT_MODE, Bundle.EMPTY)
+    val CommandAddToTargetPlaylist = SessionCommand(ACTION_ADD_TO_TARGET_PLAYLIST, Bundle.EMPTY)
+
+    const val TARGET_PLAYLIST_AUTO = "auto"
 }

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -363,6 +363,9 @@ enum class SearchSource {
 
 val VisitorDataKey = stringPreferencesKey("visitorData")
 val DataSyncIdKey = stringPreferencesKey("dataSyncId")
+val AndroidAutoYouTubePlaylistsKey = booleanPreferencesKey("androidAutoYoutubePlaylists")
+val AndroidAutoSectionsOrderKey = stringPreferencesKey("androidAutoSectionsOrder")
+val AndroidAutoTargetPlaylistKey = stringPreferencesKey("androidAutoTargetPlaylist")
 val InnerTubeCookieKey = stringPreferencesKey("innerTubeCookie")
 val AccountNameKey = stringPreferencesKey("accountName")
 val AccountEmailKey = stringPreferencesKey("accountEmail")

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
@@ -21,12 +21,18 @@ import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.ListenableFuture
 import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.filterExplicit
 import com.jtech.zemer.R
+import com.jtech.zemer.constants.AndroidAutoSectionsOrderKey
+import com.jtech.zemer.constants.AndroidAutoYouTubePlaylistsKey
 import com.jtech.zemer.constants.HideExplicitKey
 import com.jtech.zemer.constants.MediaSessionConstants
 import com.jtech.zemer.constants.SongSortType
+import com.jtech.zemer.ui.screens.settings.AndroidAutoSection
+import com.jtech.zemer.ui.screens.settings.deserializeSections
+import com.jtech.zemer.ui.screens.settings.serializeSections
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.PlaylistEntity
 import com.jtech.zemer.db.entities.Song
@@ -69,6 +75,7 @@ constructor(
     var toggleLike: () -> Unit = {}
     var toggleStartRadio: () -> Unit = {}
     var toggleLibrary: () -> Unit = {}
+    var addToTargetPlaylist: () -> Unit = {}
 
     override fun onConnect(
         session: MediaSession,
@@ -83,6 +90,7 @@ constructor(
                 .add(MediaSessionConstants.CommandToggleLibrary)
                 .add(MediaSessionConstants.CommandToggleShuffle)
                 .add(MediaSessionConstants.CommandToggleRepeatMode)
+                .add(MediaSessionConstants.CommandAddToTargetPlaylist)
                 .build(),
             connectionResult.availablePlayerCommands,
         )
@@ -102,6 +110,7 @@ constructor(
                 !session.player.shuffleModeEnabled
 
             MediaSessionConstants.ACTION_TOGGLE_REPEAT_MODE -> session.player.toggleRepeatMode()
+            MediaSessionConstants.ACTION_ADD_TO_TARGET_PLAYLIST -> addToTargetPlaylist()
         }
         return immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
     }
@@ -146,37 +155,67 @@ constructor(
         scope.future(Dispatchers.IO) {
             LibraryResult.ofItemList(
                 when (parentId) {
-                    MusicService.ROOT ->
-                        listOf(
-                            browsableMediaItem(
-                                MusicService.SONG,
-                                context.getString(R.string.songs),
-                                null,
-                                drawableUri(R.drawable.music_note),
-                                MediaMetadata.MEDIA_TYPE_PLAYLIST,
-                            ),
-                            browsableMediaItem(
-                                MusicService.ARTIST,
-                                context.getString(R.string.artists),
-                                null,
-                                drawableUri(R.drawable.artist),
-                                MediaMetadata.MEDIA_TYPE_FOLDER_ARTISTS,
-                            ),
-                            browsableMediaItem(
-                                MusicService.ALBUM,
-                                context.getString(R.string.albums),
-                                null,
-                                drawableUri(R.drawable.album),
-                                MediaMetadata.MEDIA_TYPE_FOLDER_ALBUMS,
-                            ),
-                            browsableMediaItem(
-                                MusicService.PLAYLIST,
-                                context.getString(R.string.playlists),
-                                null,
-                                drawableUri(R.drawable.queue_music),
-                                MediaMetadata.MEDIA_TYPE_FOLDER_PLAYLISTS,
-                            ),
+                    MusicService.ROOT -> {
+                        val sectionsRaw = context.dataStore.get(
+                            AndroidAutoSectionsOrderKey,
+                            serializeSections(AndroidAutoSection.entries.map { it to true })
                         )
+                        val sections = deserializeSections(sectionsRaw)
+                        val showYoutubePlaylists = context.dataStore.get(AndroidAutoYouTubePlaylistsKey, false)
+                        val rootItems = sections
+                            .filter { (_, enabled) -> enabled }
+                            .ifEmpty { listOf(AndroidAutoSection.LIKED to true) }
+                            .map { (section, _) ->
+                                when (section) {
+                                    AndroidAutoSection.LIKED -> browsableMediaItem(
+                                        "${MusicService.PLAYLIST}/${PlaylistEntity.LIKED_PLAYLIST_ID}",
+                                        context.getString(R.string.liked_songs),
+                                        null,
+                                        drawableUri(R.drawable.favorite),
+                                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                                    )
+                                    AndroidAutoSection.SONGS -> browsableMediaItem(
+                                        MusicService.SONG,
+                                        context.getString(R.string.songs),
+                                        null,
+                                        drawableUri(R.drawable.music_note),
+                                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                                    )
+                                    AndroidAutoSection.ARTISTS -> browsableMediaItem(
+                                        MusicService.ARTIST,
+                                        context.getString(R.string.artists),
+                                        null,
+                                        drawableUri(R.drawable.artist),
+                                        MediaMetadata.MEDIA_TYPE_FOLDER_ARTISTS,
+                                    )
+                                    AndroidAutoSection.ALBUMS -> browsableMediaItem(
+                                        MusicService.ALBUM,
+                                        context.getString(R.string.albums),
+                                        null,
+                                        drawableUri(R.drawable.album),
+                                        MediaMetadata.MEDIA_TYPE_FOLDER_ALBUMS,
+                                    )
+                                    AndroidAutoSection.PLAYLISTS -> browsableMediaItem(
+                                        MusicService.PLAYLIST,
+                                        context.getString(R.string.playlists),
+                                        null,
+                                        drawableUri(R.drawable.queue_music),
+                                        MediaMetadata.MEDIA_TYPE_FOLDER_PLAYLISTS,
+                                    )
+                                }
+                            }
+                        if (showYoutubePlaylists) {
+                            rootItems + browsableMediaItem(
+                                MusicService.YOUTUBE_PLAYLIST,
+                                context.getString(R.string.mixes),
+                                null,
+                                drawableUri(R.drawable.explore_outlined),
+                                MediaMetadata.MEDIA_TYPE_FOLDER_PLAYLISTS,
+                            )
+                        } else {
+                            rootItems
+                        }
+                    }
 
                     MusicService.SONG -> {
                         val whitelistedArtistIds = database.getAllWhitelistedArtistIdsSync()
@@ -267,6 +306,52 @@ constructor(
                         }
                     }
 
+                    MusicService.YOUTUBE_PLAYLIST -> {
+                        if (!context.dataStore.get(AndroidAutoYouTubePlaylistsKey, false)) {
+                            emptyList()
+                        } else {
+                            try {
+                                val allSections = mutableListOf<com.metrolist.innertube.pages.HomePage.Section>()
+                                var continuation: String? = null
+                                val maxPages = 4
+
+                                for (p in 0 until maxPages) {
+                                    val result = YouTube.home(continuation)
+                                        .onFailure { reportException(it) }
+                                        .getOrNull() ?: break
+                                    allSections.addAll(result.sections)
+                                    continuation = result.continuation
+                                    if (continuation == null) break
+                                }
+
+                                // Drop playlists already saved to the local library,
+                                // which are exposed under MusicService.PLAYLIST.
+                                val savedBrowseIds = database.playlistsByCreateDateAsc()
+                                    .first()
+                                    .mapNotNullTo(mutableSetOf()) { it.playlist.browseId }
+
+                                val playlists = allSections
+                                    .flatMap { it.items }
+                                    .filterIsInstance<PlaylistItem>()
+                                    .filterNot { it.id in savedBrowseIds }
+                                    .distinctBy { it.id }
+
+                                playlists.map { playlist ->
+                                    browsableMediaItem(
+                                        "${MusicService.YOUTUBE_PLAYLIST}/${playlist.id}",
+                                        playlist.title,
+                                        playlist.author?.name,
+                                        playlist.thumbnail?.toUri(),
+                                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                                    )
+                                }
+                            } catch (e: Exception) {
+                                reportException(e)
+                                emptyList()
+                            }
+                        }
+                    }
+
                     else ->
                         when {
                             parentId.startsWith("${MusicService.ARTIST}/") ->
@@ -310,9 +395,42 @@ constructor(
                                         database.playlistSongs(playlistId).map { list ->
                                             list.map { it.song }
                                         }
-                                }.first().map {
-                                    it.toMediaItem(parentId)
+                                }.first().let { songs ->
+                                    listOf(shuffleMediaItem(parentId)) +
+                                        songs.map { it.toMediaItem(parentId) }
                                 }
+
+                            parentId.startsWith("${MusicService.YOUTUBE_PLAYLIST}/") -> {
+                                val playlistId = parentId.removePrefix("${MusicService.YOUTUBE_PLAYLIST}/")
+                                try {
+                                    val songs = YouTube.playlist(playlistId).getOrNull()?.songs
+                                        ?.take(100)
+                                        ?.filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                                        ?.filterWhitelisted(database)
+                                        ?.filterIsInstance<SongItem>()
+                                        ?: emptyList()
+
+                                    listOf(shuffleMediaItem(parentId)) + songs.map { songItem ->
+                                        MediaItem.Builder()
+                                            .setMediaId("$parentId/${songItem.id}")
+                                            .setMediaMetadata(
+                                                MediaMetadata.Builder()
+                                                    .setTitle(songItem.title)
+                                                    .setSubtitle(songItem.artists.joinToString(", ") { it.name })
+                                                    .setArtist(songItem.artists.joinToString(", ") { it.name })
+                                                    .setArtworkUri(songItem.thumbnail.toUri())
+                                                    .setIsPlayable(true)
+                                                    .setIsBrowsable(false)
+                                                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                                                    .build()
+                                            )
+                                            .build()
+                                    }
+                                } catch (e: Exception) {
+                                    reportException(e)
+                                    emptyList()
+                                }
+                            }
 
                             else -> emptyList()
                         }
@@ -516,11 +634,51 @@ constructor(
                             list.map { it.song }
                         }
                     }.first()
-                    MediaItemsWithStartPosition(
-                        songs.map { it.toMediaItem() },
-                        songs.indexOfFirst { it.id == songId }.takeIf { it != -1 } ?: 0,
-                        startPositionMs
-                    )
+
+                    if (songId == MusicService.SHUFFLE_ACTION) {
+                        MediaItemsWithStartPosition(
+                            songs.shuffled().map { it.toMediaItem() },
+                            0,
+                            C.TIME_UNSET
+                        )
+                    } else {
+                        MediaItemsWithStartPosition(
+                            songs.map { it.toMediaItem() },
+                            songs.indexOfFirst { it.id == songId }.takeIf { it != -1 } ?: 0,
+                            startPositionMs
+                        )
+                    }
+                }
+
+                MusicService.YOUTUBE_PLAYLIST -> {
+                    val songId = path.getOrNull(2) ?: return@future defaultResult
+                    val playlistId = path.getOrNull(1) ?: return@future defaultResult
+
+                    val songs = try {
+                        YouTube.playlist(playlistId).getOrNull()?.songs
+                            ?.filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                            ?.filterWhitelisted(database)
+                            ?.filterIsInstance<SongItem>()
+                            ?.map { it.toMediaItem() }
+                            ?: emptyList()
+                    } catch (e: Exception) {
+                        reportException(e)
+                        return@future defaultResult
+                    }
+
+                    if (songId == MusicService.SHUFFLE_ACTION) {
+                        MediaItemsWithStartPosition(
+                            songs.shuffled(),
+                            0,
+                            C.TIME_UNSET
+                        )
+                    } else {
+                        MediaItemsWithStartPosition(
+                            songs,
+                            songs.indexOfFirst { it.mediaId.endsWith(songId) }.takeIf { it != -1 } ?: 0,
+                            C.TIME_UNSET
+                        )
+                    }
                 }
 
                 MusicService.SEARCH -> {
@@ -613,6 +771,21 @@ constructor(
         .appendPath(context.resources.getResourceTypeName(id))
         .appendPath(context.resources.getResourceEntryName(id))
         .build()
+
+    private fun shuffleMediaItem(parentId: String) =
+        MediaItem
+            .Builder()
+            .setMediaId("$parentId/${MusicService.SHUFFLE_ACTION}")
+            .setMediaMetadata(
+                MediaMetadata
+                    .Builder()
+                    .setTitle(context.getString(R.string.shuffle))
+                    .setArtworkUri(drawableUri(R.drawable.shuffle))
+                    .setIsPlayable(true)
+                    .setIsBrowsable(false)
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                    .build()
+            ).build()
 
     private fun browsableMediaItem(
         id: String,

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
@@ -335,6 +335,10 @@ constructor(
                                     .filterIsInstance<PlaylistItem>()
                                     .filterNot { it.id in savedBrowseIds }
                                     .distinctBy { it.id }
+                                    // Whitelist edition: only surface playlists whose author
+                                    // is a whitelisted artist (songs are filtered separately too).
+                                    .filterWhitelisted(database)
+                                    .filterIsInstance<PlaylistItem>()
 
                                 playlists.map { playlist ->
                                     browsableMediaItem(

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -17,6 +17,7 @@ import android.media.audiofx.AudioEffect
 import android.media.audiofx.LoudnessEnhancer
 import android.net.ConnectivityManager
 import android.os.Binder
+import android.widget.Toast
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.datastore.preferences.core.edit
@@ -70,6 +71,7 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
 import com.jtech.zemer.MainActivity
 import com.jtech.zemer.R
+import com.jtech.zemer.constants.AndroidAutoTargetPlaylistKey
 import com.jtech.zemer.constants.AudioNormalizationKey
 import com.jtech.zemer.constants.AudioOffload
 import com.jtech.zemer.constants.AudioQualityKey
@@ -79,6 +81,8 @@ import com.jtech.zemer.constants.AutoSkipNextOnErrorKey
 import com.jtech.zemer.constants.DisableLoadMoreWhenRepeatAllKey
 import com.jtech.zemer.constants.HideExplicitKey
 import com.jtech.zemer.constants.HistoryDuration
+import com.jtech.zemer.constants.MediaSessionConstants
+import com.jtech.zemer.constants.MediaSessionConstants.CommandAddToTargetPlaylist
 import com.jtech.zemer.constants.MediaSessionConstants.CommandToggleLike
 import com.jtech.zemer.constants.MediaSessionConstants.CommandToggleRepeatMode
 import com.jtech.zemer.constants.MediaSessionConstants.CommandToggleShuffle
@@ -290,6 +294,7 @@ class MusicService :
             toggleLike = ::toggleLike
             toggleStartRadio = ::toggleStartRadio
             toggleLibrary = ::toggleLibrary
+            addToTargetPlaylist = ::addToTargetPlaylist
         }
         mediaSession =
             MediaLibrarySession
@@ -715,6 +720,12 @@ class MusicService :
                     .setSessionCommand(CommandToggleStartRadio)
                     .setEnabled(currentSong.value != null)
                     .build(),
+                CommandButton.Builder()
+                    .setDisplayName(getString(R.string.android_auto_target_playlist))
+                    .setIconResId(R.drawable.playlist_add)
+                    .setSessionCommand(CommandAddToTargetPlaylist)
+                    .setEnabled(currentSong.value != null)
+                    .build(),
             ),
         )
     }
@@ -984,6 +995,33 @@ class MusicService :
 
     fun toggleStartRadio() {
         startRadioSeamlessly()
+    }
+
+    fun addToTargetPlaylist() {
+        scope.launch {
+            val current = currentSong.value ?: return@launch
+            val targetPlaylistId = dataStore.get(
+                AndroidAutoTargetPlaylistKey,
+                MediaSessionConstants.TARGET_PLAYLIST_AUTO,
+            )
+
+            if (targetPlaylistId == MediaSessionConstants.TARGET_PLAYLIST_AUTO) {
+                Toast.makeText(
+                    this@MusicService,
+                    getString(R.string.android_auto_target_playlist_not_set),
+                    Toast.LENGTH_SHORT,
+                ).show()
+                return@launch
+            }
+
+            val targetPlaylist = withContext(Dispatchers.IO) {
+                database.playlist(targetPlaylistId).first()
+            } ?: return@launch
+
+            database.query {
+                addSongToPlaylist(targetPlaylist, listOf(current.id))
+            }
+        }
     }
 
     private fun setupLoudnessEnhancer() {
@@ -1588,7 +1626,9 @@ class MusicService :
         const val ARTIST = "artist"
         const val ALBUM = "album"
         const val PLAYLIST = "playlist"
+        const val YOUTUBE_PLAYLIST = "youtube_playlist"
         const val SEARCH = "search"
+        const val SHUFFLE_ACTION = "__shuffle__"
 
         const val CHANNEL_ID = "music_channel_01"
         const val NOTIFICATION_ID = 888

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -27,6 +27,7 @@ import com.jtech.zemer.ui.screens.playlist.OnlinePlaylistScreen
 import com.jtech.zemer.ui.screens.playlist.TopPlaylistScreen
 import com.jtech.zemer.ui.screens.search.OnlineSearchResult
 import com.jtech.zemer.ui.screens.settings.AboutScreen
+import com.jtech.zemer.ui.screens.settings.AndroidAutoSettings
 import com.jtech.zemer.ui.screens.settings.AppearanceSettings
 import com.jtech.zemer.ui.screens.settings.BackupAndRestore
 import com.jtech.zemer.ui.screens.settings.ButtonSetupScreen
@@ -296,6 +297,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings") {
         SettingsScreen(navController, scrollBehavior, latestVersionName)
+    }
+    composable("settings/android_auto") {
+        AndroidAutoSettings(navController, scrollBehavior)
     }
     composable("settings/appearance") {
         AppearanceSettings(navController, scrollBehavior)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -1,0 +1,339 @@
+package com.jtech.zemer.ui.screens.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.jtech.zemer.LocalDatabase
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.AndroidAutoSectionsOrderKey
+import com.jtech.zemer.constants.AndroidAutoTargetPlaylistKey
+import com.jtech.zemer.constants.AndroidAutoYouTubePlaylistsKey
+import com.jtech.zemer.constants.MediaSessionConstants
+import com.jtech.zemer.ui.component.Material3SettingsGroup
+import com.jtech.zemer.ui.component.Material3SettingsItem
+import com.jtech.zemer.utils.rememberPreference
+import kotlinx.coroutines.flow.map
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+
+enum class AndroidAutoSection(val id: String) {
+    LIKED("liked"),
+    SONGS("songs"),
+    ARTISTS("artists"),
+    ALBUMS("albums"),
+    PLAYLISTS("playlists"),
+}
+
+@Composable
+fun AndroidAutoSection.label(): String = when (this) {
+    AndroidAutoSection.LIKED -> stringResource(R.string.liked_songs)
+    AndroidAutoSection.SONGS -> stringResource(R.string.songs)
+    AndroidAutoSection.ARTISTS -> stringResource(R.string.artists)
+    AndroidAutoSection.ALBUMS -> stringResource(R.string.albums)
+    AndroidAutoSection.PLAYLISTS -> stringResource(R.string.playlists)
+}
+
+fun serializeSections(sections: List<Pair<AndroidAutoSection, Boolean>>): String =
+    sections.joinToString(",") { (section, enabled) -> "${section.id}:$enabled" }
+
+fun deserializeSections(raw: String): List<Pair<AndroidAutoSection, Boolean>> {
+    if (raw.isBlank()) return AndroidAutoSection.entries.map { it to true }
+    val parsed = raw.split(",").mapNotNull { token ->
+        val parts = token.split(":")
+        if (parts.size != 2) return@mapNotNull null
+        val section = AndroidAutoSection.entries.find { it.id == parts[0] } ?: return@mapNotNull null
+        val enabled = parts[1].toBooleanStrictOrNull() ?: true
+        section to enabled
+    }
+    // Append any sections missing from the stored value (e.g. after an app update adds one).
+    val present = parsed.map { it.first }.toSet()
+    val missing = AndroidAutoSection.entries.filter { it !in present }.map { it to true }
+    return parsed + missing
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AndroidAutoSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    val haptic = LocalHapticFeedback.current
+    val database = LocalDatabase.current
+
+    val userPlaylists by remember {
+        database.playlistsByCreateDateAsc().map { list -> list.map { it.playlist } }
+    }.collectAsStateWithLifecycle(initialValue = emptyList())
+
+    val (youtubePlaylistsEnabled, onYoutubePlaylistsChange) = rememberPreference(
+        key = AndroidAutoYouTubePlaylistsKey,
+        defaultValue = false
+    )
+
+    val (sectionsRaw, onSectionsChange) = rememberPreference(
+        key = AndroidAutoSectionsOrderKey,
+        defaultValue = serializeSections(AndroidAutoSection.entries.map { it to true })
+    )
+
+    val (targetPlaylist, onTargetPlaylistChange) = rememberPreference(
+        key = AndroidAutoTargetPlaylistKey,
+        defaultValue = MediaSessionConstants.TARGET_PLAYLIST_AUTO
+    )
+
+    var sections by remember(sectionsRaw) {
+        mutableStateOf(deserializeSections(sectionsRaw))
+    }
+
+    val lazyListState = rememberLazyListState()
+    val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val fromReal = from.index
+        val toReal = to.index
+        if (fromReal in sections.indices && toReal in sections.indices) {
+            sections = sections.toMutableList().apply {
+                add(toReal, removeAt(fromReal))
+            }
+            onSectionsChange(serializeSections(sections))
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+
+    val playlistOptions = listOf(MediaSessionConstants.TARGET_PLAYLIST_AUTO) +
+            userPlaylists.map { it.id }
+
+    val playlistLabels: @Composable (String) -> String = { id ->
+        if (id == MediaSessionConstants.TARGET_PLAYLIST_AUTO) {
+            stringResource(R.string.android_auto_target_playlist_auto)
+        } else {
+            userPlaylists.find { it.id == id }?.name ?: id
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp)
+    ) {
+        // Visible sections
+        Material3SettingsGroup(
+            title = stringResource(R.string.android_auto_visible_sections),
+            items = listOf(
+                Material3SettingsItem(
+                    title = {},
+                    description = { Text(stringResource(R.string.android_auto_reorder_hint)) },
+                    onClick = null
+                )
+            )
+        )
+
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height((sections.size * 80).dp),
+            userScrollEnabled = false,
+        ) {
+            items(sections, key = { (section, _) -> section.id }) { (section, enabled) ->
+                ReorderableItem(reorderableState, key = section.id) {
+                    Material3SettingsGroup(
+                        items = listOf(
+                            Material3SettingsItem(
+                                icon = painterResource(
+                                    when (section) {
+                                        AndroidAutoSection.LIKED -> R.drawable.favorite
+                                        AndroidAutoSection.SONGS -> R.drawable.music_note
+                                        AndroidAutoSection.ARTISTS -> R.drawable.artist
+                                        AndroidAutoSection.ALBUMS -> R.drawable.album
+                                        AndroidAutoSection.PLAYLISTS -> R.drawable.queue_music
+                                    }
+                                ),
+                                title = { Text(section.label()) },
+                                trailingContent = {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.drag_handle),
+                                            contentDescription = null,
+                                            modifier = Modifier
+                                                .size(24.dp)
+                                                .longPressDraggableHandle(
+                                                    onDragStarted = {
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                    }
+                                                ),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                        Spacer(Modifier.width(12.dp))
+                                        Switch(
+                                            checked = enabled,
+                                            onCheckedChange = { newValue ->
+                                                sections = sections.map { (s, e) ->
+                                                    if (s == section) s to newValue else s to e
+                                                }
+                                                onSectionsChange(serializeSections(sections))
+                                            },
+                                            thumbContent = {
+                                                Icon(
+                                                    painter = painterResource(
+                                                        if (enabled) R.drawable.check else R.drawable.close
+                                                    ),
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                                )
+                                            }
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    sections = sections.map { (s, e) ->
+                                        if (s == section) s to !e else s to e
+                                    }
+                                    onSectionsChange(serializeSections(sections))
+                                },
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(27.dp))
+
+        // Quick-add destination playlist
+        var showTargetPlaylistDialog by remember { mutableStateOf(false) }
+
+        if (showTargetPlaylistDialog) {
+            AlertDialog(
+                onDismissRequest = { showTargetPlaylistDialog = false },
+                title = { Text(stringResource(R.string.android_auto_target_playlist)) },
+                text = {
+                    LazyColumn {
+                        items(playlistOptions) { value ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        showTargetPlaylistDialog = false
+                                        onTargetPlaylistChange(value)
+                                    }
+                                    .padding(vertical = 12.dp),
+                            ) {
+                                RadioButton(
+                                    selected = value == targetPlaylist,
+                                    onClick = null,
+                                )
+                                Text(
+                                    text = playlistLabels(value),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(start = 16.dp),
+                                )
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = { showTargetPlaylistDialog = false }
+                    ) {
+                        Text(stringResource(android.R.string.cancel))
+                    }
+                }
+            )
+        }
+
+        Material3SettingsGroup(
+            title = stringResource(R.string.android_auto_target_playlist),
+            items = listOf(
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.playlist_add),
+                    title = { Text(stringResource(R.string.android_auto_target_playlist)) },
+                    description = { Text(playlistLabels(targetPlaylist)) },
+                    onClick = { showTargetPlaylistDialog = true }
+                )
+            )
+        )
+
+        Spacer(Modifier.height(27.dp))
+
+        // YouTube playlists
+        Material3SettingsGroup(
+            title = stringResource(R.string.mixes),
+            items = listOf(
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.queue_music),
+                    title = { Text(stringResource(R.string.android_auto_youtube_playlists)) },
+                    description = { Text(stringResource(R.string.android_auto_youtube_playlists_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = youtubePlaylistsEnabled,
+                            onCheckedChange = onYoutubePlaylistsChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        if (youtubePlaylistsEnabled) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                                )
+                            }
+                        )
+                    },
+                    onClick = { onYoutubePlaylistsChange(!youtubePlaylistsEnabled) }
+                )
+            )
+        )
+
+        Spacer(Modifier.height(27.dp))
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.android_auto)) },
+        navigationIcon = {
+            IconButton(onClick = navController::navigateUp) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -1,6 +1,7 @@
 package com.jtech.zemer.ui.screens.settings
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -168,7 +169,8 @@ fun AndroidAutoSettings(
             state = lazyListState,
             modifier = Modifier
                 .fillMaxWidth()
-                .height((sections.size * 80).dp),
+                .height((sections.size * 88).dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
             userScrollEnabled = false,
         ) {
             items(sections, key = { (section, _) -> section.id }) { (section, enabled) ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -1,12 +1,9 @@
 package com.jtech.zemer.ui.screens.settings
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -14,8 +11,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -49,8 +44,9 @@ import com.jtech.zemer.constants.AndroidAutoSectionsOrderKey
 import com.jtech.zemer.constants.AndroidAutoTargetPlaylistKey
 import com.jtech.zemer.constants.AndroidAutoYouTubePlaylistsKey
 import com.jtech.zemer.constants.MediaSessionConstants
-import com.jtech.zemer.ui.component.Material3SettingsGroup
-import com.jtech.zemer.ui.component.Material3SettingsItem
+import com.jtech.zemer.ui.component.PreferenceEntry
+import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.SwitchPreference
 import com.jtech.zemer.utils.rememberPreference
 import kotlinx.coroutines.flow.map
 import sh.calvin.reorderable.ReorderableItem
@@ -71,6 +67,14 @@ fun AndroidAutoSection.label(): String = when (this) {
     AndroidAutoSection.ARTISTS -> stringResource(R.string.artists)
     AndroidAutoSection.ALBUMS -> stringResource(R.string.albums)
     AndroidAutoSection.PLAYLISTS -> stringResource(R.string.playlists)
+}
+
+private fun AndroidAutoSection.iconRes(): Int = when (this) {
+    AndroidAutoSection.LIKED -> R.drawable.favorite
+    AndroidAutoSection.SONGS -> R.drawable.music_note
+    AndroidAutoSection.ARTISTS -> R.drawable.artist
+    AndroidAutoSection.ALBUMS -> R.drawable.album
+    AndroidAutoSection.PLAYLISTS -> R.drawable.queue_music
 }
 
 fun serializeSections(sections: List<Pair<AndroidAutoSection, Boolean>>): String =
@@ -106,40 +110,38 @@ fun AndroidAutoSettings(
 
     val (youtubePlaylistsEnabled, onYoutubePlaylistsChange) = rememberPreference(
         key = AndroidAutoYouTubePlaylistsKey,
-        defaultValue = false
+        defaultValue = false,
     )
-
     val (sectionsRaw, onSectionsChange) = rememberPreference(
         key = AndroidAutoSectionsOrderKey,
-        defaultValue = serializeSections(AndroidAutoSection.entries.map { it to true })
+        defaultValue = serializeSections(AndroidAutoSection.entries.map { it to true }),
     )
-
     val (targetPlaylist, onTargetPlaylistChange) = rememberPreference(
         key = AndroidAutoTargetPlaylistKey,
-        defaultValue = MediaSessionConstants.TARGET_PLAYLIST_AUTO
+        defaultValue = MediaSessionConstants.TARGET_PLAYLIST_AUTO,
     )
 
-    var sections by remember(sectionsRaw) {
-        mutableStateOf(deserializeSections(sectionsRaw))
+    // Local working copy: initialized once from the stored value, mutated during interaction, and
+    // persisted on toggle / drag-end — so a drag isn't fighting a DataStore round-trip every move.
+    var sections by remember { mutableStateOf(deserializeSections(sectionsRaw)) }
+
+    fun toggle(section: AndroidAutoSection, value: Boolean) {
+        sections = sections.map { (s, e) -> if (s == section) s to value else s to e }
+        onSectionsChange(serializeSections(sections))
     }
 
     val lazyListState = rememberLazyListState()
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
-        val fromReal = from.index
-        val toReal = to.index
-        if (fromReal in sections.indices && toReal in sections.indices) {
-            sections = sections.toMutableList().apply {
-                add(toReal, removeAt(fromReal))
-            }
-            onSectionsChange(serializeSections(sections))
+        val fromIdx = sections.indexOfFirst { it.first.id == from.key }
+        val toIdx = sections.indexOfFirst { it.first.id == to.key }
+        if (fromIdx != -1 && toIdx != -1) {
+            sections = sections.toMutableList().apply { add(toIdx, removeAt(fromIdx)) }
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
         }
     }
 
-    val playlistOptions = listOf(MediaSessionConstants.TARGET_PLAYLIST_AUTO) +
-            userPlaylists.map { it.id }
-
-    val playlistLabels: @Composable (String) -> String = { id ->
+    val playlistOptions = listOf(MediaSessionConstants.TARGET_PLAYLIST_AUTO) + userPlaylists.map { it.id }
+    val playlistLabel: @Composable (String) -> String = { id ->
         if (id == MediaSessionConstants.TARGET_PLAYLIST_AUTO) {
             stringResource(R.string.android_auto_target_playlist_auto)
         } else {
@@ -147,199 +149,135 @@ fun AndroidAutoSettings(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp)
-    ) {
-        // Visible sections
-        Material3SettingsGroup(
-            title = stringResource(R.string.android_auto_visible_sections),
-            items = listOf(
-                Material3SettingsItem(
-                    title = {},
-                    description = {
-                        Text(
-                            text = stringResource(R.string.android_auto_reorder_hint),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    },
-                    onClick = null
-                )
-            )
-        )
+    var showTargetPlaylistDialog by remember { mutableStateOf(false) }
 
-        LazyColumn(
-            state = lazyListState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height((sections.size * 88).dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            userScrollEnabled = false,
-        ) {
-            items(sections, key = { (section, _) -> section.id }) { (section, enabled) ->
-                ReorderableItem(reorderableState, key = section.id) {
-                    Material3SettingsGroup(
-                        items = listOf(
-                            Material3SettingsItem(
-                                icon = painterResource(
-                                    when (section) {
-                                        AndroidAutoSection.LIKED -> R.drawable.favorite
-                                        AndroidAutoSection.SONGS -> R.drawable.music_note
-                                        AndroidAutoSection.ARTISTS -> R.drawable.artist
-                                        AndroidAutoSection.ALBUMS -> R.drawable.album
-                                        AndroidAutoSection.PLAYLISTS -> R.drawable.queue_music
-                                    }
-                                ),
-                                title = { Text(section.label()) },
-                                trailingContent = {
-                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.drag_handle),
-                                            contentDescription = null,
-                                            modifier = Modifier
-                                                .size(24.dp)
-                                                .longPressDraggableHandle(
-                                                    onDragStarted = {
-                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                    }
-                                                ),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                        Spacer(Modifier.width(12.dp))
-                                        Switch(
-                                            checked = enabled,
-                                            onCheckedChange = { newValue ->
-                                                sections = sections.map { (s, e) ->
-                                                    if (s == section) s to newValue else s to e
-                                                }
-                                                onSectionsChange(serializeSections(sections))
-                                            },
-                                            thumbContent = {
-                                                Icon(
-                                                    painter = painterResource(
-                                                        if (enabled) R.drawable.check else R.drawable.close
-                                                    ),
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(SwitchDefaults.IconSize),
-                                                )
-                                            }
-                                        )
-                                    }
-                                },
-                                onClick = {
-                                    sections = sections.map { (s, e) ->
-                                        if (s == section) s to !e else s to e
-                                    }
-                                    onSectionsChange(serializeSections(sections))
+    LazyColumn(
+        state = lazyListState,
+        modifier = Modifier.windowInsetsPadding(LocalPlayerAwareWindowInsets.current),
+    ) {
+        item(key = "sections_title") {
+            PreferenceGroupTitle(title = stringResource(R.string.android_auto_visible_sections))
+        }
+        item(key = "sections_hint") {
+            Text(
+                text = stringResource(R.string.android_auto_reorder_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 8.dp),
+            )
+        }
+        items(sections, key = { (section, _) -> section.id }) { (section, enabled) ->
+            ReorderableItem(reorderableState, key = section.id) {
+                PreferenceEntry(
+                    icon = { Icon(painterResource(section.iconRes()), contentDescription = null) },
+                    title = { Text(section.label()) },
+                    trailingContent = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                painter = painterResource(R.drawable.drag_handle),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .longPressDraggableHandle(
+                                        onDragStarted = {
+                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        },
+                                        onDragStopped = {
+                                            onSectionsChange(serializeSections(sections))
+                                        },
+                                    ),
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Switch(
+                                checked = enabled,
+                                onCheckedChange = { toggle(section, it) },
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            if (enabled) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
                                 },
                             )
-                        )
-                    )
-                }
+                        }
+                    },
+                    onClick = { toggle(section, !enabled) },
+                )
             }
         }
 
-        Spacer(Modifier.height(27.dp))
-
-        // Quick-add destination playlist
-        var showTargetPlaylistDialog by remember { mutableStateOf(false) }
-
-        if (showTargetPlaylistDialog) {
-            AlertDialog(
-                onDismissRequest = { showTargetPlaylistDialog = false },
+        item(key = "playlist_title") {
+            PreferenceGroupTitle(title = stringResource(R.string.android_auto_target_playlist))
+        }
+        item(key = "playlist_entry") {
+            PreferenceEntry(
+                icon = { Icon(painterResource(R.drawable.playlist_add), contentDescription = null) },
                 title = { Text(stringResource(R.string.android_auto_target_playlist)) },
-                text = {
-                    LazyColumn {
-                        items(playlistOptions) { value ->
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable {
-                                        showTargetPlaylistDialog = false
-                                        onTargetPlaylistChange(value)
-                                    }
-                                    .padding(vertical = 12.dp),
-                            ) {
-                                RadioButton(
-                                    selected = value == targetPlaylist,
-                                    onClick = null,
-                                )
-                                Text(
-                                    text = playlistLabels(value),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    modifier = Modifier.padding(start = 16.dp),
-                                )
-                            }
-                        }
-                    }
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = { showTargetPlaylistDialog = false }
-                    ) {
-                        Text(stringResource(android.R.string.cancel))
-                    }
-                }
+                description = playlistLabel(targetPlaylist),
+                onClick = { showTargetPlaylistDialog = true },
             )
         }
 
-        Material3SettingsGroup(
-            title = stringResource(R.string.android_auto_target_playlist),
-            items = listOf(
-                Material3SettingsItem(
-                    icon = painterResource(R.drawable.playlist_add),
-                    title = { Text(stringResource(R.string.android_auto_target_playlist)) },
-                    description = { Text(playlistLabels(targetPlaylist)) },
-                    onClick = { showTargetPlaylistDialog = true }
-                )
+        item(key = "youtube_title") {
+            PreferenceGroupTitle(title = stringResource(R.string.mixes))
+        }
+        item(key = "youtube_switch") {
+            SwitchPreference(
+                icon = { Icon(painterResource(R.drawable.queue_music), contentDescription = null) },
+                title = { Text(stringResource(R.string.android_auto_youtube_playlists)) },
+                description = stringResource(R.string.android_auto_youtube_playlists_desc),
+                checked = youtubePlaylistsEnabled,
+                onCheckedChange = onYoutubePlaylistsChange,
             )
+        }
+    }
+
+    if (showTargetPlaylistDialog) {
+        AlertDialog(
+            onDismissRequest = { showTargetPlaylistDialog = false },
+            title = { Text(stringResource(R.string.android_auto_target_playlist)) },
+            text = {
+                LazyColumn {
+                    items(playlistOptions) { value ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    showTargetPlaylistDialog = false
+                                    onTargetPlaylistChange(value)
+                                }
+                                .padding(vertical = 12.dp),
+                        ) {
+                            RadioButton(selected = value == targetPlaylist, onClick = null)
+                            Text(
+                                text = playlistLabel(value),
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(start = 16.dp),
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showTargetPlaylistDialog = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
         )
-
-        Spacer(Modifier.height(27.dp))
-
-        // YouTube playlists
-        Material3SettingsGroup(
-            title = stringResource(R.string.mixes),
-            items = listOf(
-                Material3SettingsItem(
-                    icon = painterResource(R.drawable.queue_music),
-                    title = { Text(stringResource(R.string.android_auto_youtube_playlists)) },
-                    description = { Text(stringResource(R.string.android_auto_youtube_playlists_desc)) },
-                    trailingContent = {
-                        Switch(
-                            checked = youtubePlaylistsEnabled,
-                            onCheckedChange = onYoutubePlaylistsChange,
-                            thumbContent = {
-                                Icon(
-                                    painter = painterResource(
-                                        if (youtubePlaylistsEnabled) R.drawable.check else R.drawable.close
-                                    ),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SwitchDefaults.IconSize),
-                                )
-                            }
-                        )
-                    },
-                    onClick = { onYoutubePlaylistsChange(!youtubePlaylistsEnabled) }
-                )
-            )
-        )
-
-        Spacer(Modifier.height(27.dp))
     }
 
     TopAppBar(
         title = { Text(stringResource(R.string.android_auto)) },
         navigationIcon = {
             IconButton(onClick = navController::navigateUp) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
+                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
             }
         },
         scrollBehavior = scrollBehavior,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -159,7 +159,13 @@ fun AndroidAutoSettings(
             items = listOf(
                 Material3SettingsItem(
                     title = {},
-                    description = { Text(stringResource(R.string.android_auto_reorder_hint)) },
+                    description = {
+                        Text(
+                            text = stringResource(R.string.android_auto_reorder_hint),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
                     onClick = null
                 )
             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -56,6 +56,17 @@ fun SettingsScreen(
     LocalUriHandler.current
     val context = LocalContext.current
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    // Android Auto app package; declared in <queries> so getPackageInfo is visible on API 30+.
+    val hasAndroidAuto = remember {
+        try {
+            context.packageManager.getPackageInfo(
+                "com.google.android.projection.gearhead", 0
+            )
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
     val firebaseAuth = remember { FirebaseAuth.getInstance() }
     var isLoggedIn by remember { mutableStateOf(firebaseAuth.currentUser != null) }
 
@@ -158,16 +169,20 @@ fun SettingsScreen(
             route = "settings/about"
         )
     )
-    val androidAutoSettings = listOf(
-        SettingItem(
-            id = "android_auto",
-            title = stringResource(R.string.android_auto),
-            description = "Customize browsing & quick-add",
-            icon = R.drawable.ic_android_auto,
-            section = "Player & Content",
-            route = "settings/android_auto"
+    val androidAutoSettings = if (hasAndroidAuto) {
+        listOf(
+            SettingItem(
+                id = "android_auto",
+                title = stringResource(R.string.android_auto),
+                description = "Customize browsing & quick-add",
+                icon = R.drawable.ic_android_auto,
+                section = "Player & Content",
+                route = "settings/android_auto"
+            )
         )
-    )
+    } else {
+        emptyList()
+    }
     val allSettings = baseSettings + androidAutoSettings + if (isLoggedIn) {
         listOf(
             SettingItem(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -176,7 +176,7 @@ fun SettingsScreen(
                 title = stringResource(R.string.android_auto),
                 description = "Customize browsing & quick-add",
                 icon = R.drawable.ic_android_auto,
-                section = "Player & Content",
+                section = "Android Auto",
                 route = "settings/android_auto"
             )
         )
@@ -226,7 +226,19 @@ fun SettingsScreen(
         ) {
             Spacer(modifier = Modifier.height(8.dp))
             val sections = allSettings.groupBy { it.section }
-            sections.forEach { (sectionTitle, items) ->
+            // Fixed section order; "Android Auto" sits right after "Player & Content" (matches Metrolist).
+            val sectionOrder = listOf(
+                "Interface",
+                "Player & Content",
+                "Android Auto",
+                "Privacy & Security",
+                "Storage & Data",
+                "System & About",
+            )
+            val orderedSectionTitles = sectionOrder.filter { sections.containsKey(it) } +
+                sections.keys.filterNot { it in sectionOrder }
+            orderedSectionTitles.forEach { sectionTitle ->
+                val items = sections[sectionTitle] ?: return@forEach
                 Material3SettingsGroup(
                     title = sectionTitle,
                     items = items.map { setting ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -56,6 +56,16 @@ fun SettingsScreen(
     LocalUriHandler.current
     val context = LocalContext.current
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val hasAndroidAuto = remember {
+        try {
+            context.packageManager.getPackageInfo(
+                "com.google.android.projection.gearhead", 0
+            )
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
     val firebaseAuth = remember { FirebaseAuth.getInstance() }
     var isLoggedIn by remember { mutableStateOf(firebaseAuth.currentUser != null) }
 
@@ -158,7 +168,21 @@ fun SettingsScreen(
             route = "settings/about"
         )
     )
-    val allSettings = baseSettings + if (isLoggedIn) {
+    val androidAutoSettings = if (hasAndroidAuto) {
+        listOf(
+            SettingItem(
+                id = "android_auto",
+                title = stringResource(R.string.android_auto),
+                description = "Customize browsing & quick-add",
+                icon = R.drawable.ic_android_auto,
+                section = "Player & Content",
+                route = "settings/android_auto"
+            )
+        )
+    } else {
+        emptyList()
+    }
+    val allSettings = baseSettings + androidAutoSettings + if (isLoggedIn) {
         listOf(
             SettingItem(
                 id = "logout",

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -56,16 +56,6 @@ fun SettingsScreen(
     LocalUriHandler.current
     val context = LocalContext.current
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    val hasAndroidAuto = remember {
-        try {
-            context.packageManager.getPackageInfo(
-                "com.google.android.projection.gearhead", 0
-            )
-            true
-        } catch (e: Exception) {
-            false
-        }
-    }
     val firebaseAuth = remember { FirebaseAuth.getInstance() }
     var isLoggedIn by remember { mutableStateOf(firebaseAuth.currentUser != null) }
 
@@ -168,20 +158,16 @@ fun SettingsScreen(
             route = "settings/about"
         )
     )
-    val androidAutoSettings = if (hasAndroidAuto) {
-        listOf(
-            SettingItem(
-                id = "android_auto",
-                title = stringResource(R.string.android_auto),
-                description = "Customize browsing & quick-add",
-                icon = R.drawable.ic_android_auto,
-                section = "Player & Content",
-                route = "settings/android_auto"
-            )
+    val androidAutoSettings = listOf(
+        SettingItem(
+            id = "android_auto",
+            title = stringResource(R.string.android_auto),
+            description = "Customize browsing & quick-add",
+            icon = R.drawable.ic_android_auto,
+            section = "Player & Content",
+            route = "settings/android_auto"
         )
-    } else {
-        emptyList()
-    }
+    )
     val allSettings = baseSettings + androidAutoSettings + if (isLoggedIn) {
         listOf(
             SettingItem(

--- a/app/src/main/res/drawable/ic_android_auto.xml
+++ b/app/src/main/res/drawable/ic_android_auto.xml
@@ -1,0 +1,22 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:name="android_auto_external_arrow"
+        android:pathData="M 7 18.229 L 3.26 18.229 C 2.87 18.229 2.63 17.809 2.83 17.469 L 11.57 2.939 C 11.77 2.619 12.23 2.619 12.43 2.939 L 21.235 17.508 L 21.17 17.469 C 21.37 17.469 21.13 18.229 20.74 18.229 L 17 18.229"
+        android:strokeColor="@android:color/white"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:name="android_auto_internal_arrow"
+        android:pathData="M 5.25 21.25 L 12 9.75 L 18.75 21.25 L 12 18.25 Z"
+        android:strokeColor="@android:color/white"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -300,4 +300,18 @@
     <string name="stream_source_web_creator_desc">YouTube Studio web client</string>
     <string name="stream_source_android_creator">ANDROID_CREATOR</string>
     <string name="stream_source_android_creator_desc">YouTube Studio client — needs DroidGuard attestation; off by default</string>
+
+    <!-- Mixes / suggested playlists -->
+    <string name="mixes">Mixes</string>
+
+    <!-- Android Auto settings -->
+    <string name="android_auto">Android Auto</string>
+    <string name="android_auto_visible_sections">Visible sections</string>
+    <string name="android_auto_reorder_hint">Tap a section to enable or disable it.\nLong-press the drag handle to reorder. The first section will be shown by default</string>
+    <string name="android_auto_youtube_playlists">Show YouTube suggested playlists</string>
+    <string name="android_auto_youtube_playlists_desc">Show YouTube Music recommended playlists in the playlists section while browsing with Android Auto</string>
+    <string name="android_auto_target_playlist">Quick-add destination</string>
+    <string name="android_auto_target_playlist_desc">Choose the playlist where songs are saved when using the quick-add button in Android Auto</string>
+    <string name="android_auto_target_playlist_auto">Not set</string>
+    <string name="android_auto_target_playlist_not_set">No playlist selected. Choose one in Android Auto settings</string>
 </resources>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This documentation is code-derived. It records facts visible in tracked reposito
 | [`whitelist/README.md`](whitelist/README.md) | Artist whitelist storage, Firebase fetch path, filtering rules, sync integration points, UI entry points, and database queries. |
 | [`innertube/README.md`](innertube/README.md) | `:innertube` module architecture, request wrapper APIs, parser pages, models, dependencies, and consumers in the app module. |
 | [`ui/README.md`](ui/README.md) | Compose UI structure, navigation routes, screen files, reusable components, player UI, settings UI, and theme utilities. |
+| [`ui/standards.md`](ui/standards.md) | UI standards and rules: settings-screen skeleton, the standard `Preference.kt` widgets, preferences and state, strings policy, lists and reordering, dialogs, theme and color roles, and icons. |
 | [`reference/kotlin-files.md`](reference/kotlin-files.md) | Every tracked Kotlin file with line count, package, composable flag, declaration list, import count, and top external import roots. |
 | [`reference/non-kotlin-files.md`](reference/non-kotlin-files.md) | Every tracked non-Kotlin file with line/byte count and file-type-specific metadata for XML, JSON, Gradle, scripts, assets, resources, and gitlinks. |
 | [`reference/resource-index.md`](reference/resource-index.md) | Android resource directory/file inventory with XML roots and resource names where parseable. |

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -1,0 +1,150 @@
+# UI standards and rules
+
+How to build UI in this app so new screens look and behave like the existing ones. These are the
+conventions the codebase already follows; match them rather than inventing parallel patterns. All
+UI is Jetpack Compose + Material 3.
+
+## 1. Reuse before building
+
+- Look in `app/src/main/kotlin/com/jtech/zemer/ui/component/` first. There are ready components for
+  settings rows (`Preference.kt`), dialogs (`Dialog.kt`, `*Dialog.kt`), bottom sheets
+  (`BottomSheet*.kt`), menus (`GridMenu.kt`, `NewMenuComponents.kt`), list items (`Items.kt`),
+  icon buttons (`IconButton.kt`), chips (`ChipsRow.kt`), placeholders (`EmptyPlaceholder.kt`,
+  `AppStateViews.kt`), and more.
+- Do not introduce a second component that duplicates one of these. (For example, settings rows use
+  the `Preference.kt` widgets below — do not add a parallel "settings group" widget set.)
+
+## 2. Settings screens
+
+Every settings screen is a `@Composable fun XxxSettings(navController: NavController,
+scrollBehavior: TopAppBarScrollBehavior)` annotated `@OptIn(ExperimentalMaterial3Api::class)`.
+
+Skeleton:
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExampleSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    val (enabled, onEnabledChange) = rememberPreference(ExampleKey, defaultValue = true)
+
+    Column(
+        Modifier
+            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        PreferenceGroupTitle(title = stringResource(R.string.example_group))
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.example_toggle)) },
+            description = stringResource(R.string.example_toggle_desc),
+            icon = { Icon(painterResource(R.drawable.example), null) },
+            checked = enabled,
+            onCheckedChange = onEnabledChange,
+        )
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.example_title)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}
+```
+
+Rules:
+
+- Body is a scrollable `Column` (`verticalScroll(rememberScrollState())`) padded with
+  `windowInsetsPadding(LocalPlayerAwareWindowInsets.current)`. Use a `LazyColumn` instead only when
+  the screen contains a dynamic or reorderable list (see section 6) — never nest a `LazyColumn`
+  inside a `verticalScroll` `Column`.
+- The `TopAppBar` is emitted after the body (it draws over the top) and is given the passed
+  `scrollBehavior`. Its back button is the app's `com.jtech.zemer.ui.component.IconButton` with
+  `onClick = navController::navigateUp` and `onLongClick = navController::backToMain`.
+- Group separation comes from `PreferenceGroupTitle` (it has its own 16dp padding). Do not insert
+  arbitrary `Spacer` heights between groups.
+
+## 3. Settings widgets (`ui/component/Preference.kt`)
+
+Use these; do not hand-roll equivalents.
+
+| Component | Use for |
+| --- | --- |
+| `PreferenceGroupTitle(title)` | Section header. Renders an uppercase `labelLarge` in `primary`. |
+| `PreferenceEntry(title, description?, icon?, trailingContent?, onClick?, isEnabled?)` | Generic clickable row; the base for everything below. Use directly when you need a custom trailing control (e.g. a drag handle + switch) or a row that opens a dialog. |
+| `SwitchPreference(title, description?, icon?, checked, onCheckedChange, isEnabled?)` | Boolean toggle row. The thumb shows `check`/`close` icons automatically. |
+| `EditTextPreference(...)` | Inline text field preference. |
+| `SliderPreference(...)` | Numeric slider preference. |
+
+- `title` is `@Composable () -> Unit` (usually `{ Text(stringResource(...)) }`); `description` is a
+  plain `String?`; `icon` is `{ Icon(painterResource(R.drawable.x), null) }`.
+- A row that opens a chooser is a `PreferenceEntry` whose `description` shows the current value and
+  whose `onClick` sets a `showDialog` state (see section 7).
+
+## 4. Preferences and state
+
+- Read/write DataStore preferences with `rememberPreference(key, defaultValue)`; it returns a
+  `(value, setter)` pair.
+- Declare keys in `com.jtech.zemer.constants.PreferenceKeys` (`booleanPreferencesKey`,
+  `stringPreferencesKey`, etc.).
+- If a default-off feature must behave as off when the key is unset, gate the consumer on
+  `!= true`, not `== false` (an unset key reads as null).
+- Persist on discrete actions (a toggle) or at the end of a continuous gesture (a drag), not on
+  every intermediate frame. Keep a local working copy for in-progress gestures and write once when
+  it settles.
+
+## 5. Strings (localization)
+
+- Add every new user-facing string to `app/src/main/res/values/metrolist_strings.xml`.
+- Never add strings to `app/src/main/res/values/strings.xml` — it is upstream InnerTune strings and
+  is headed `Do not add new features here`.
+- No hardcoded user-facing text in Kotlin; always `stringResource(R.string.x)`. Technical
+  identifiers shown verbatim (client names, etc.) may be literals.
+
+## 6. Lists and reordering
+
+- Static content: a `Column` (see section 2).
+- Dynamic or long content: a `LazyColumn` that is the screen's single scroll container. Put the
+  non-list parts in `item { }` blocks and the list in `items(...) { }` so there is exactly one
+  scrollable. Do not give a `LazyColumn` a hardcoded pixel height to embed it in a `Column`.
+- Reordering uses `sh.calvin.reorderable` (`rememberReorderableLazyListState`, `ReorderableItem`,
+  `longPressDraggableHandle`). Map moves by stable item `key`, not lazy index, and persist the new
+  order in the handle's `onDragStopped`.
+
+## 7. Dialogs
+
+- Use Material 3 `AlertDialog` (or the app's `Dialog.kt` helpers).
+- `confirmButton` is the affirmative action; `dismissButton` is Cancel. A pick-and-close list puts
+  its Cancel in `dismissButton` (and may leave `confirmButton` empty), not in `confirmButton`.
+
+## 8. Theme and color
+
+- Colors come from `MaterialTheme.colorScheme` roles; never hardcode hex. Common usage in this app:
+  - `primary` — group titles, emphasis.
+  - `onSurfaceVariant` — secondary/hint text, inactive icons.
+  - `secondaryContainer` / `onSecondaryContainer` — chips and soft pills.
+  - `surface` / `surfaceVariant` — backgrounds and subtle containers.
+- Typography comes from `MaterialTheme.typography` (`Type.kt`); do not set raw font sizes. Hints and
+  secondary text are `bodyMedium`/`bodySmall` in `onSurfaceVariant`.
+- Theme setup lives in `ui/theme/` (`Theme.kt`, `Type.kt`); dynamic/player colors in
+  `PlayerColorExtractor.kt`.
+
+## 9. Icons
+
+- Vector drawables in `app/src/main/res/drawable/`, referenced with `painterResource(R.drawable.x)`.
+- Switch thumbs use `check`/`close`; the back arrow is `arrow_back`. Reuse existing drawables before
+  adding new ones.
+
+## 10. Documentation
+
+- No emojis or decorative symbols anywhere in `docs/` — ASCII only. (Arrows like `->` over a glyph.)
+- Keep this file in sync when a shared UI convention changes.


### PR DESCRIPTION
## Summary

Adds a configurable **Android Auto** settings screen and the browse-tree wiring behind it.

## What's included

Settings -> Android Auto:
- **Visible sections** — toggle and reorder the sections shown while browsing in Android Auto
  (Liked / Songs / Artists / Albums / Playlists): drag to reorder, switch to show/hide.
- **Quick-add destination** — choose the playlist that the in-car quick-add button saves to.
- **Show YouTube suggested playlists** (Mixes) toggle.

Backing wiring:
- `MediaLibrarySessionCallback` builds the Android Auto browse tree from the saved section
  order/visibility and the quick-add target.
- New prefs in `MediaSessionConstants` + `PreferenceKeys`; settings entry added in
  `SettingsScreen` / `NavigationBuilder`; `ic_android_auto` drawable; strings in
  `metrolist_strings.xml`.

The settings screen uses the app's standard preference components
(`PreferenceGroupTitle` / `SwitchPreference` / `PreferenceEntry`) in a single `LazyColumn` —
consistent with every other settings screen. Section reorder is keyed by section id and persists
on drag-end; the playlist picker uses a proper `dismissButton`.

## Docs

- `docs/ui/standards.md` — a UI standards and rules guide (settings-screen skeleton, the standard
  `Preference.kt` widgets, preferences/state, strings policy, lists and reordering, dialogs,
  theme/color roles, icons), indexed in `docs/README.md`.

Branch is rebased on current `main`; debug build passes.


## Credits

The Android Auto settings feature is ported and adapted from [Metrolist](https://github.com/MetrolistGroup/Metrolist), which this app is based on.

