### PR TITLE
fix(ui): resize yt3.googleusercontent thumbnails so player art isn't blurry

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt
@@ -7,7 +7,11 @@ fun String.resize(
     height: Int? = null,
 ): String {
     if (width == null && height == null) return this
-    "https://lh3\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
+    // Match BOTH lh3 and yt3 googleusercontent: YouTube migrated music/album art from
+    // lh3.googleusercontent.com to yt3.googleusercontent.com. Both serve the same =wW-hH resize
+    // params; matching only lh3 silently no-ops on the new host, so the player upscales the raw
+    // ~60px thumbnail (blurry). Verified live: a yt3 URL + =w544-h544 returns a sharp full-size image.
+    "https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
         .matchEntire(this)?.groupValues?.let { group ->
         val (W, H) = group.drop(1).map { it.toInt() }
         var w = width

--- a/app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt
@@ -1,0 +1,45 @@
+package com.jtech.zemer.ui.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YouTubeUtilsTest {
+
+    @Test
+    fun `lh3 googleusercontent is rewritten to the requested size`() {
+        val url = "https://lh3.googleusercontent.com/abc=w120-h120-l90-rj"
+        assertEquals(
+            "https://lh3.googleusercontent.com/abc=w544-h544-p-l90-rj",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `yt3 googleusercontent is rewritten too (YouTube migrated host - fixes the blurry player)`() {
+        // YT moved album art to yt3.googleusercontent and serves a ~60px thumbnail; without matching
+        // this host resize() no-ops and the player upscales the 60px image into a blur.
+        val url = "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w60-h60-l90-rj"
+        assertEquals(
+            "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w544-h544-p-l90-rj",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `i_ytimg urls are left unchanged (no resize param to rewrite)`() {
+        val url = "https://i.ytimg.com/vi/abc/hqdefault.jpg?sqp=-oaymwE"
+        assertEquals(url, url.resize(544, 544))
+    }
+
+    @Test
+    fun `null dimensions return the url unchanged`() {
+        val url = "https://yt3.googleusercontent.com/abc=w60-h60-l90-rj"
+        assertEquals(url, url.resize())
+    }
+
+    @Test
+    fun `ggpht avatar still appends the size suffix`() {
+        val url = "https://yt3.ggpht.com/abc=s88"
+        assertEquals("$url-s544", url.resize(544, 544))
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -235,7 +235,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShapeUtils.kt` | 8 | `com.jtech.zemer.ui.utils` | no | 3 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt` | 357 | `com.jtech.zemer.ui.utils` | yes | 49 | 16 | android.content, android.text, android.widget, androidx.compose, com.zemer |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/StringUtils.kt` | 36 | `com.jtech.zemer.ui.utils` | no | 2 | 5 | java.text, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 23 | `com.jtech.zemer.ui.utils` | no | 0 | 5 |  |
+| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 27 | `com.jtech.zemer.ui.utils` | no | 0 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/AccessibilityUtils.kt` | 91 | `com.jtech.zemer.utils` | yes | 19 | 18 | android.content, android.database, android.net, android.os, android.provider, android.text, androidx.compose, androidx.lifecycle |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonInputCapture.kt` | 40 | `com.jtech.zemer.utils` | no | 5 | 10 | android.view, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonMapperBridge.kt` | 35 | `com.jtech.zemer.utils` | no | 5 | 8 | android.view, java.util |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -389,7 +389,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShapeUtils.kt` | 8 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt` | 357 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/StringUtils.kt` | 36 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 23 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 27 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/AccessibilityUtils.kt` | 91 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonInputCapture.kt` | 40 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonMapperBridge.kt` | 35 lines | `.kt` |


### PR DESCRIPTION
## Problem
Song-player cover art renders **blurry**.

## Root cause (a YouTube-side change)
YouTube **migrated music/album-art thumbnails** from `lh3.googleusercontent.com` → `yt3.googleusercontent.com`. `String.resize()` (`YouTubeUtils.kt`) only matched `lh3`, so on the new host it **silently no-ops** — the app uses YouTube's raw **~60×60 px** thumbnail and the player **upscales it into the blur**.

## Fix
Match both hosts in the resize regex. They serve the same `=wW-hH` params — verified against live YT Music that a `yt3.googleusercontent` URL with `=w544-h544` returns a sharp full-size image (vs the 3 KB / 60px raw).

```diff
- "https://lh3\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*"
+ "https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*"
```

One-line behavioral change; `i.ytimg` / `ggpht` / `lh3` / null paths are untouched.

## Tests / verification
- New `YouTubeUtilsTest`: yt3 rewrite, lh3 still works, i.ytimg unchanged, ggpht suffix, null no-op.
- `assembleDebug` + `assembleRelease` (R8) green.
- Confirmed on a device/emulator: blurry player covers now render sharp and full-resolution.

Scoped to the thumbnail-URL helper — does not touch the streaming pipeline.