### PR TITLE
chore(ui): remove dead menu composables, route font sizes through typography

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
@@ -399,7 +399,7 @@ fun Lyrics(
             ) {
                 Text(
                     text = stringResource(R.string.lyrics_not_found),
-                    fontSize = 20.sp,
+                    style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.secondary,
                     textAlign = TextAlign.Center,
                     fontWeight = FontWeight.Bold,
@@ -572,7 +572,7 @@ fun Lyrics(
                     ) {
                         Text(
                             text = item.text,
-                            fontSize = 24.sp, // Uniform size for all lines matching latest enh version
+                            style = MaterialTheme.typography.headlineSmall, // Uniform size for all lines matching latest enh version
                             color = if (index == displayedCurrentLineIndex && isSynced) {
                                 textColor // Full color for active line
                             } else {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt
@@ -1,14 +1,9 @@
-@file:Suppress("unused")
-
 package com.jtech.zemer.ui.component
 
-import android.annotation.SuppressLint
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -20,12 +15,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,10 +27,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -115,69 +105,6 @@ fun NewActionButton(
     }
 }
 
-// Enhanced Menu Item - Material 3 Expressive Design
-@Composable
-fun NewMenuItem(
-    headlineContent: @Composable () -> Unit,
-    leadingContent: @Composable (() -> Unit)? = null,
-    trailingContent: @Composable (() -> Unit)? = null,
-    supportingContent: @Composable (() -> Unit)? = null,
-    onClick: (() -> Unit)? = null,
-    enabled: Boolean = true,
-    isActive: Boolean = false,
-    @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
-) {
-    var isFocused by remember { mutableStateOf(false) }
-    val backgroundColor by animateColorAsState(
-        targetValue = when {
-            isActive -> MaterialTheme.colorScheme.secondaryContainer
-            isFocused -> MaterialTheme.colorScheme.surfaceVariant
-            else -> Color.Transparent
-        },
-        label = "list_item_focus_bg"
-    )
-    val borderColor by animateColorAsState(
-        targetValue = when {
-            isActive -> MaterialTheme.colorScheme.primary
-            isFocused -> MaterialTheme.colorScheme.outline
-            else -> Color.Transparent
-        },
-        label = "list_item_focus_border"
-    )
-
-    ListItem(
-        headlineContent = headlineContent,
-        leadingContent = leadingContent,
-        trailingContent = trailingContent,
-        supportingContent = supportingContent,
-        modifier = modifier
-            .padding(horizontal = 4.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .onFocusChanged { isFocused = it.isFocused }
-            .focusable()
-            .clickable(enabled = enabled) { onClick?.invoke() }
-            .background(backgroundColor)
-            .border(width = 1.5.dp, color = borderColor, shape = RoundedCornerShape(8.dp)),
-        tonalElevation = 0.dp
-    )
-}
-
-// Enhanced Menu Section Header - Material 3 Expressive Design
-@Composable
-fun NewMenuSectionHeader(
-    text: String,
-    modifier: Modifier = Modifier
-) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleMedium.copy(
-            fontWeight = FontWeight.SemiBold
-        ),
-        color = MaterialTheme.colorScheme.primary,
-        modifier = modifier.padding(horizontal = 20.dp, vertical = 12.dp)
-    )
-}
-
 // Enhanced Action Grid - Material 3 Expressive Design
 @Composable
 fun NewActionGrid(
@@ -225,96 +152,3 @@ data class NewAction(
     val backgroundColor: Color = Color.Unspecified,
     val contentColor: Color = Color.Unspecified
 )
-
-// Enhanced Menu Content - Material 3 Expressive Design
-@Composable
-fun NewMenuContent(
-    headerContent: @Composable (() -> Unit)? = null,
-    actionGrid: @Composable (() -> Unit)? = null,
-    menuItems: @Composable (() -> Unit)? = null,
-    @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        // Header
-        headerContent?.invoke()
-
-        // Action Grid
-        actionGrid?.invoke()
-
-        // Divider if both header and actions exist
-        if (headerContent != null && actionGrid != null) {
-            HorizontalDivider(
-                modifier = Modifier.padding(vertical = 16.dp),
-                color = MaterialTheme.colorScheme.outlineVariant
-            )
-        }
-
-        // Menu Items
-        menuItems?.invoke()
-    }
-}
-
-// Enhanced Icon Button - Material 3 Expressive Design
-@Composable
-fun NewIconButton(
-    icon: @Composable () -> Unit,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
-    contentColor: Color = MaterialTheme.colorScheme.onSurfaceVariant
-) {
-    var isFocused by remember { mutableStateOf(false) }
-    val animatedBackground by animateColorAsState(
-        targetValue = if (enabled) backgroundColor else backgroundColor.copy(alpha = 0.5f),
-        animationSpec = tween(200),
-        label = "background"
-    )
-
-    val borderColor by animateColorAsState(
-        targetValue = if (isFocused) MaterialTheme.colorScheme.outline else Color.Transparent,
-        label = "icon_button_focus_border"
-    )
-
-    Card(
-        modifier = modifier
-            .onFocusChanged { isFocused = it.isFocused }
-            .focusable()
-            .clickable(enabled = enabled) { onClick() },
-        colors = CardDefaults.cardColors(
-            containerColor = animatedBackground
-        ),
-        shape = CircleShape,
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 2.dp
-        ),
-        border = BorderStroke(width = if (isFocused) 1.5.dp else 0.dp, color = borderColor)
-    ) {
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .padding(12.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            icon()
-        }
-    }
-}
-
-// Enhanced Menu Container - Material 3 Expressive Design
-@Composable
-fun NewMenuContainer(
-    content: @Composable () -> Unit,
-    modifier: Modifier = Modifier
-) {    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp)
-            .padding(bottom = 32.dp)
-    ) {
-        content()
-    }
-}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -69,7 +69,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import coil3.compose.AsyncImage
@@ -448,7 +447,7 @@ private fun NewMiniPlayer(
                             Text(
                                 text = stringResource(R.string.error_playing),
                                 color = MaterialTheme.colorScheme.error,
-                                fontSize = 10.sp,
+                                style = MaterialTheme.typography.labelSmall,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
@@ -84,7 +84,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
@@ -270,7 +269,7 @@ fun Queue(
                                 Text(
                                     text = makeTimeString(sleepTimerTimeLeft),
                                     color = TextBackgroundColor,
-                                    fontSize = 10.sp,
+                                    style = MaterialTheme.typography.labelSmall,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
                                     textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -95,7 +94,7 @@ fun SplashScreen(
         ) {
             Text(
                 text = stringResource(R.string.app_name),
-                fontSize = 44.sp,
+                style = MaterialTheme.typography.displayMedium,
                 fontWeight = FontWeight.ExtraBold,
                 color = MaterialTheme.colorScheme.primary
             )

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (313)
+## `app` Kotlin files (315)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -116,6 +116,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Dialog.kt` | 389 | `com.jtech.zemer.ui.component` | yes | 50 | 9 | androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/DraggableScrollBarOverlay.kt` | 242 | `com.jtech.zemer.ui.component` | yes | 34 | 51 | androidx.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/EmptyPlaceholder.kt` | 47 | `com.jtech.zemer.ui.component` | yes | 16 | 1 | androidx.annotation, androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 50 | `com.jtech.zemer.ui.component` | no | 17 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 197 | `com.jtech.zemer.ui.component` | yes | 34 | 6 | androidx.annotation, androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 | `com.jtech.zemer.ui.component` | yes | 36 | 6 | androidx.annotation, androidx.compose |
@@ -125,10 +126,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 139 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 215 | `com.jtech.zemer.ui.component` | yes | 37 | 13 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MenuDialogs.kt` | 124 | `com.jtech.zemer.ui.component` | yes | 27 | 6 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NavigationTile.kt` | 59 | `com.jtech.zemer.ui.component` | yes | 19 | 1 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NavigationTitle.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 22 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NetworkRequiredDialog.kt` | 100 | `com.jtech.zemer.ui.component` | yes | 25 | 4 | androidx.compose, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt` | 320 | `com.jtech.zemer.ui.component` | yes | 40 | 25 | android.annotation, androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt` | 154 | `com.jtech.zemer.ui.component` | yes | 32 | 14 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/PlayerSlider.kt` | 112 | `com.jtech.zemer.ui.component` | yes | 17 | 19 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/PlayingIndicator.kt` | 113 | `com.jtech.zemer.ui.component` | yes | 29 | 3 | androidx.compose, kotlin.random, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 367 | `com.jtech.zemer.ui.component` | yes | 47 | 12 | androidx.compose, kotlin.math |
@@ -160,10 +162,10 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 508 | `com.jtech.zemer.ui.menu` | yes | 74 | 20 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 549 | `com.jtech.zemer.ui.menu` | yes | 78 | 28 | android.annotation, android.content, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, java.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 796 | `com.jtech.zemer.ui.player` | yes | 96 | 35 | android.app, android.content, android.view, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, androidx.palette, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, dagger.hilt, kotlinx.coroutines, me.saket |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 901 | `com.jtech.zemer.ui.player` | yes | 86 | 86 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 900 | `com.jtech.zemer.ui.player` | yes | 85 | 86 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1359 | `com.jtech.zemer.ui.player` | yes | 146 | 106 | android.annotation, android.content, android.widget, androidx.compose, androidx.media3, androidx.navigation, androidx.palette, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.math, kotlinx.coroutines, me.saket |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1131 | `com.jtech.zemer.ui.player` | yes | 117 | 48 | android.annotation, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines, sh.calvin |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1130 | `com.jtech.zemer.ui.player` | yes | 116 | 48 | android.annotation, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines, sh.calvin |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 471 | `com.jtech.zemer.ui.player` | yes | 73 | 56 | androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt` | 200 | `com.jtech.zemer.ui.screens` | yes | 39 | 8 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 723 | `com.jtech.zemer.ui.screens` | yes | 98 | 46 | androidx.activity, androidx.compose, androidx.hilt, androidx.media3, androidx.navigation, coil3.compose, kotlinx.coroutines |
@@ -180,7 +182,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt` | 254 | `com.jtech.zemer.ui.screens` | yes | 45 | 12 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt` | 2072 | `com.jtech.zemer.ui.screens` | yes | 113 | 113 | android.Manifest, android.annotation, android.content, android.graphics, android.net, android.os, android.provider, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, com.airbnb, com.google, dagger.hilt, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 53 | `com.jtech.zemer.ui.screens` | no | 4 | 11 | androidx.annotation, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 165 | `com.jtech.zemer.ui.screens` | yes | 42 | 5 | android.graphics, androidx.compose, com.airbnb |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 164 | `com.jtech.zemer.ui.screens` | yes | 41 | 5 | android.graphics, androidx.compose, com.airbnb |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt` | 426 | `com.jtech.zemer.ui.screens` | yes | 58 | 34 | androidx.compose, androidx.hilt, androidx.navigation, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoNavigation.kt` | 12 | `com.jtech.zemer.ui.screens` | no | 1 | 3 | android.net |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedArtistsScreen.kt` | 404 | `com.jtech.zemer.ui.screens` | yes | 82 | 21 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -274,7 +274,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `lrclib/build.gradle.kts` | 16 lines | text `.kts`; plugins `kotlin.serialization, jvm` |
 | `scripts/check-16kb-alignment.sh` | 67 lines | text `.sh` |
 | `scripts/telegram-chats.sh` | 38 lines | text `.sh` |
-| `scripts/ui-audit-baseline.tsv` | 15 lines | text `.tsv` |
+| `scripts/ui-audit-baseline.tsv` | 11 lines | text `.tsv` |
 | `scripts/ui-audit.sh` | 111 lines | text `.sh` |
 | `scripts/ui-strings-scan.py` | 96 lines | text `.py` |
 | `settings.gradle.kts` | 56 lines | text `.kts`; plugins `org.gradle.toolchains.foojay-resolver-convention` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `789`
+- Files counted: `791`
 - By extension:
-  - `.kt`: `413`
+  - `.kt`: `415`
   - `.xml`: `183`
   - `.mjs`: `66`
   - `.json`: `35`
@@ -270,6 +270,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Dialog.kt` | 389 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/DraggableScrollBarOverlay.kt` | 242 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/EmptyPlaceholder.kt` | 47 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 50 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 197 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 lines | `.kt` |
@@ -279,10 +280,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 139 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 215 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MenuDialogs.kt` | 124 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NavigationTile.kt` | 59 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NavigationTitle.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/NetworkRequiredDialog.kt` | 100 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt` | 320 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/NewMenuComponents.kt` | 154 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/PlayerSlider.kt` | 112 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/PlayingIndicator.kt` | 113 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 367 lines | `.kt` |
@@ -314,10 +316,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 508 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 549 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 796 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 901 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 900 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1359 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1131 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1130 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 471 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt` | 200 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 723 lines | `.kt` |
@@ -334,7 +336,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt` | 254 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt` | 2072 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 53 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 165 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 164 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt` | 426 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoNavigation.kt` | 12 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedArtistsScreen.kt` | 404 lines | `.kt` |
@@ -690,7 +692,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/multi_update/04-wiring.md` | 95 lines | `.md` |
 | `docs/multi_update/05-runbook.md` | 83 lines | `.md` |
 | `docs/multi_update/README.md` | 77 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 436 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 438 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 354 lines | `.md` |
 | `docs/reference/resource-index.md` | 288 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -701,7 +703,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 99 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 110 lines | `.md` |
-| `docs/repository-map.md` | 898 lines | `.md` |
+| `docs/repository-map.md` | 900 lines | `.md` |
 | `docs/ui/README.md` | 329 lines | `.md` |
 | `docs/ui/standards.md` | 224 lines | `.md` |
 | `docs/whitelist/README.md` | 181 lines | `.md` |
@@ -816,7 +818,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `lrclib/src/main/kotlin/com/metrolist/lrclib/models/Track.kt` | 137 lines | `.kt` |
 | `scripts/check-16kb-alignment.sh` | 67 lines | `.sh` |
 | `scripts/telegram-chats.sh` | 38 lines | `.sh` |
-| `scripts/ui-audit-baseline.tsv` | 15 lines | `.tsv` |
+| `scripts/ui-audit-baseline.tsv` | 11 lines | `.tsv` |
 | `scripts/ui-audit.sh` | 111 lines | `.sh` |
 | `scripts/ui-strings-scan.py` | 96 lines | `.py` |
 | `settings.gradle.kts` | 56 lines | `.kts` |

--- a/scripts/ui-audit-baseline.tsv
+++ b/scripts/ui-audit-baseline.tsv
@@ -1,15 +1,11 @@
 app/src/main/kotlin/com/jtech/zemer/ui/component/Dialog.kt	R8-hex	1
 app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt	R8-fontsize	3
 app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt	R8-hex	1
-app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt	R8-fontsize	2
 app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt	R8-hex	4
 app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialog.kt	R11-menu	1
 app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialogOnline.kt	R11-menu	2
 app/src/main/kotlin/com/jtech/zemer/ui/menu/ArtistMenu.kt	R11-menu	1
 app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt	R11-menu	1
 app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt	R11-menu	1
-app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt	R8-fontsize	1
 app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt	R8-hex	1
-app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt	R8-fontsize	1
 app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt	R8-hex	1
-app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt	R8-fontsize	1


### PR DESCRIPTION
Follow-up cleanup after the menu/dialog modernization (#76, #77). Two small, low-risk passes.

## 1. Dead code — `NewMenuComponents.kt` (320 → 166 lines)
Removed 5 composables with **zero references** anywhere, superseded by `Material3MenuGroup`:
`NewMenuItem` (which also hand-rolled the focus-border logic `focusBorder()` now centralizes), `NewMenuSectionHeader`, `NewMenuContent`, `NewIconButton`, `NewMenuContainer`. Kept the live `NewActionGrid` / `NewAction` / `NewActionButton` (the quick-action grid atop every menu).

## 2. Token debt — raw `fontSize` → `MaterialTheme.typography`
Sizes matched to avoid visual change:
| Site | Was | Now |
|---|---|---|
| MiniPlayer error badge | `10.sp` | `labelSmall` |
| Queue sleep-timer badge | `10.sp` | `labelSmall` |
| SplashScreen title | `44.sp` | `displayMedium` (45sp) |
| Lyrics "not found" | `20.sp` | `titleLarge` |
| Lyrics line | `24.sp` | `headlineSmall` (24sp) |

Removed 3 now-orphaned `sp` imports.

## Audit
All 5 `R8-fontsize` entries burned down; baseline tightened **22 → 17**. The remaining `R8` entries are all legitimate fixed-value exceptions (AMOLED pure-black, lyric-**image-export** canvas, lyric color-picker swatches).

## Verification
- `:app:assembleDebug` ✅ and `:app:assembleRelease` (R8) ✅
- `bash scripts/ui-audit.sh` ✅; touched files scan clean of unused imports
- Code-derived docs regenerated