### PR TITLE
fix(library): anonymous sessions are local-only — no remote account sync/writes

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumEntity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,10 +43,13 @@ data class AlbumEntity(
     )
 
     fun toggleLike() = localToggleLike().also {
-        CoroutineScope(Dispatchers.IO).launch {
-            if (playlistId != null)
-                YouTube.likePlaylist(playlistId, bookmarkedAt == null)
-            this.cancel()
+        // Anonymous (pooled) sessions are local-only — only a personal account pushes to remote.
+        if (isPersonalAccountSignedIn) {
+            CoroutineScope(Dispatchers.IO).launch {
+                if (playlistId != null)
+                    YouTube.likePlaylist(playlistId, bookmarkedAt == null)
+                this.cancel()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,12 +37,15 @@ data class ArtistEntity(
     )
 
     fun toggleLike() = localToggleLike().also {
-        CoroutineScope(Dispatchers.IO).launch {
-            if (channelId == null)
-                YouTube.subscribeChannel(YouTube.getChannelId(id), bookmarkedAt == null)
-            else
-                YouTube.subscribeChannel(channelId, bookmarkedAt == null)
-            this.cancel()
+        // Anonymous (pooled) sessions are local-only — only a personal account pushes to remote.
+        if (isPersonalAccountSignedIn) {
+            CoroutineScope(Dispatchers.IO).launch {
+                if (channelId == null)
+                    YouTube.subscribeChannel(YouTube.getChannelId(id), bookmarkedAt == null)
+                else
+                    YouTube.subscribeChannel(channelId, bookmarkedAt == null)
+                this.cancel()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/PlaylistEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/PlaylistEntity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,10 +50,13 @@ data class PlaylistEntity(
     )
 
     fun toggleLike() = localToggleLike().also {
-        CoroutineScope(Dispatchers.IO).launch {
-            if (browseId != null)
-                YouTube.likePlaylist(browseId, bookmarkedAt == null)
-            this.cancel()
+        // Anonymous (pooled) sessions are local-only — only a personal account pushes to remote.
+        if (isPersonalAccountSignedIn) {
+            CoroutineScope(Dispatchers.IO).launch {
+                if (browseId != null)
+                    YouTube.likePlaylist(browseId, bookmarkedAt == null)
+                this.cancel()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/SongEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,9 +65,12 @@ data class SongEntity(
         likedDate = if (!liked) LocalDateTime.now() else null,
         inLibrary = if (!liked) inLibrary ?: LocalDateTime.now() else inLibrary
     ).also {
-        CoroutineScope(Dispatchers.IO).launch {
-            YouTube.likeVideo(id, !liked)
-            this.cancel()
+        // Anonymous (pooled) sessions are local-only — only a personal account pushes to remote.
+        if (isPersonalAccountSignedIn) {
+            CoroutineScope(Dispatchers.IO).launch {
+                YouTube.likeVideo(id, !liked)
+                this.cancel()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/extensions/AccountState.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/extensions/AccountState.kt
@@ -1,0 +1,29 @@
+package com.jtech.zemer.extensions
+
+import android.content.Context
+import com.jtech.zemer.constants.DataSyncIdKey
+import com.jtech.zemer.utils.dataStore
+import com.metrolist.innertube.YouTube
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Whether a **personal** Google account is signed in.
+ *
+ * The "anonymous" login signs into a shared, pooled account whose cookie DOES carry `SAPISID`, so
+ * the cookie-based [isUserLoggedIn]/[isUserLoggedInFlow] return `true` for anonymous sessions and
+ * must NOT be used to authorize remote *account* reads or writes — doing so leaks the pooled
+ * account's library/likes/subscriptions across every anonymous user. Only a personal login sets a
+ * `dataSyncId` (the anonymous flow explicitly clears it; see `App.kt` / `LoginGateScreen`), so that
+ * is the correct discriminator for "may this session touch the remote account".
+ *
+ * This reads the in-memory [YouTube.dataSyncId] (kept in sync with DataStore by `App.kt`) so it is
+ * usable from context-free call sites such as entity data classes. For Composables that must
+ * recompose on login changes, use [isPersonalAccountFlow].
+ */
+val isPersonalAccountSignedIn: Boolean
+    get() = !YouTube.dataSyncId.isNullOrEmpty()
+
+/** Reactive equivalent of [isPersonalAccountSignedIn] for Compose UI. */
+fun Context.isPersonalAccountFlow(): Flow<Boolean> =
+    dataStore.data.map { (it[DataSyncIdKey] ?: "").isNotBlank() }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/CreatePlaylistDialog.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.unit.dp
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.PlaylistEntity
+import com.jtech.zemer.extensions.isPersonalAccountFlow
 import com.jtech.zemer.extensions.isSyncEnabledFlow
-import com.jtech.zemer.extensions.isUserLoggedInFlow
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
@@ -46,12 +46,14 @@ fun CreatePlaylistDialog(
     var syncedPlaylist by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
-    val isSignedIn by remember { context.isUserLoggedInFlow() }.collectAsState(false)
+    // A personal account (not the anonymous pooled account) is required to create a *synced*
+    // playlist; anonymous users can still create local playlists (the `else null` branch below).
+    val isSignedIn by remember { context.isPersonalAccountFlow() }.collectAsState(false)
     val isSyncEnabled by
         remember {
             combine(
                 context.isSyncEnabledFlow(),
-                context.isUserLoggedInFlow()
+                context.isPersonalAccountFlow()
             ) { syncEnabled, loggedIn -> syncEnabled && loggedIn }
         }.collectAsState(false)
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialog.kt
@@ -26,6 +26,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.constants.InnerTubeCookieKey
 import com.jtech.zemer.constants.ListThumbnailSize
 import com.jtech.zemer.db.entities.Playlist
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.ui.component.CreatePlaylistDialog
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.ListDialog
@@ -110,9 +111,12 @@ fun AddToPlaylistDialog(
                                 onDismiss()
                                 database.addSongToPlaylist(playlist, songIds!!)
 
-                                playlist.playlist.browseId?.let { plist ->
-                                    songIds?.forEach {
-                                        YouTube.addToPlaylist(plist, it)
+                                // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                if (isPersonalAccountSignedIn) {
+                                    playlist.playlist.browseId?.let { plist ->
+                                        songIds?.forEach {
+                                            YouTube.addToPlaylist(plist, it)
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -53,6 +53,7 @@ import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalDownloadUtil
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.ui.component.DefaultDialog
@@ -112,8 +113,11 @@ fun PlayerMenu(
             database.transaction {
                 insert(mediaMetadata)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
+            // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
+                }
             }
             listOf(mediaMetadata.id)
         },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
@@ -39,6 +39,7 @@ import com.jtech.zemer.LocalSyncUtils
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.PlaylistSongMap
 import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
@@ -120,10 +121,13 @@ fun SelectionSongMenu(
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
         onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                songSelection.forEach { song ->
-                    playlist.playlist.browseId?.let { browseId ->
-                        YouTube.addToPlaylist(browseId, song.id)
+            // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    songSelection.forEach { song ->
+                        playlist.playlist.browseId?.let { browseId ->
+                            YouTube.addToPlaylist(browseId, song.id)
+                        }
                     }
                 }
             }
@@ -361,10 +365,13 @@ fun SelectionSongMenu(
                                             inLibrary(song.id, null)
                                         }
                                     }
-                                    coroutineScope.launch {
-                                        val tokens = songSelection.mapNotNull { it.song.libraryRemoveToken }
-                                        tokens.chunked(20).forEach {
-                                            YouTube.feedback(it)
+                                    // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                    if (isPersonalAccountSignedIn) {
+                                        coroutineScope.launch {
+                                            val tokens = songSelection.mapNotNull { it.song.libraryRemoveToken }
+                                            tokens.chunked(20).forEach {
+                                                YouTube.feedback(it)
+                                            }
                                         }
                                     }
                                 } else {
@@ -374,10 +381,13 @@ fun SelectionSongMenu(
                                             inLibrary(song.id, LocalDateTime.now())
                                         }
                                     }
-                                    coroutineScope.launch {
-                                        val tokens = songSelection.filter {it.song.inLibrary == null}.mapNotNull { it.song.libraryAddToken }
-                                        tokens.chunked(20).forEach {
-                                            YouTube.feedback(it)
+                                    // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                    if (isPersonalAccountSignedIn) {
+                                        coroutineScope.launch {
+                                            val tokens = songSelection.filter {it.song.inLibrary == null}.mapNotNull { it.song.libraryAddToken }
+                                            tokens.chunked(20).forEach {
+                                                YouTube.feedback(it)
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -56,6 +56,7 @@ import com.jtech.zemer.constants.BlockVideosKey
 import com.jtech.zemer.db.entities.Event
 import com.jtech.zemer.db.entities.PlaylistSong
 import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.YouTubeQueue
@@ -216,9 +217,12 @@ fun SongMenu(
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
         onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
+            // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    playlist.playlist.browseId?.let { browseId ->
+                        YouTube.addToPlaylist(browseId, song.id)
+                    }
                 }
             }
             listOf(song.id)
@@ -401,9 +405,12 @@ fun SongMenu(
                                 val isInLibrary = currentSong.inLibrary != null
                                 val token = if (isInLibrary) currentSong.libraryRemoveToken else currentSong.libraryAddToken
 
-                                token?.let {
-                                    coroutineScope.launch {
-                                        YouTube.feedback(listOf(it))
+                                // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                if (isPersonalAccountSignedIn) {
+                                    token?.let {
+                                        coroutineScope.launch {
+                                            YouTube.feedback(listOf(it))
+                                        }
                                     }
                                 }
 
@@ -438,12 +445,15 @@ fun SongMenu(
                             title = { Text(stringResource(R.string.remove_from_playlist)) },
                             onClick = {
                                 database.transaction {
-                                    coroutineScope.launch {
-                                        playlistBrowseId?.let { playlistId ->
-                                            if (playlistSong.map.setVideoId != null) {
-                                                YouTube.removeFromPlaylist(
-                                                    playlistId, playlistSong.map.songId, playlistSong.map.setVideoId
-                                                )
+                                    // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                    if (isPersonalAccountSignedIn) {
+                                        coroutineScope.launch {
+                                            playlistBrowseId?.let { playlistId ->
+                                                if (playlistSong.map.setVideoId != null) {
+                                                    YouTube.removeFromPlaylist(
+                                                        playlistId, playlistSong.map.songId, playlistSong.map.setVideoId
+                                                    )
+                                                }
                                             }
                                         }
                                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -53,6 +53,7 @@ import com.jtech.zemer.constants.BlockVideosKey
 import com.jtech.zemer.constants.ListThumbnailSize
 import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.SongEntity
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
@@ -126,15 +127,18 @@ fun YouTubeSongMenu(
     AddToPlaylistDialog(  
         isVisible = showChoosePlaylistDialog,  
         onGetSong = { playlist ->  
-            database.transaction {  
-                insert(song.toMediaMetadata())  
-            }  
-            coroutineScope.launch(Dispatchers.IO) {  
-                playlist.playlist.browseId?.let { browseId ->  
-                    YouTube.addToPlaylist(browseId, song.id)  
-                }  
-            }  
-            listOf(song.id)  
+            database.transaction {
+                insert(song.toMediaMetadata())
+            }
+            // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    playlist.playlist.browseId?.let { browseId ->
+                        YouTube.addToPlaylist(browseId, song.id)
+                    }
+                }
+            }
+            listOf(song.id)
         },  
         onDismiss = { showChoosePlaylistDialog = false }  
     )  
@@ -333,7 +337,10 @@ fun YouTubeSongMenu(
                                 title = { Text(stringResource(R.string.remove_from_history)) },
                                 onClick = {
                                     coroutineScope.launch {
-                                        YouTube.feedback(listOf(song.historyRemoveToken!!))
+                                        // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                        if (isPersonalAccountSignedIn) {
+                                            YouTube.feedback(listOf(song.historyRemoveToken!!))
+                                        }
 
                                         delay(500)
 
@@ -361,9 +368,12 @@ fun YouTubeSongMenu(
                                 val isInLibrary = librarySong?.song?.inLibrary != null
                                 val token = if (isInLibrary) song.libraryRemoveToken else song.libraryAddToken
 
-                                token?.let {
-                                    coroutineScope.launch {
-                                        YouTube.feedback(listOf(it))
+                                // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                if (isPersonalAccountSignedIn) {
+                                    token?.let {
+                                        coroutineScope.launch {
+                                            YouTube.feedback(listOf(it))
+                                        }
                                     }
                                 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -117,6 +117,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.PlaylistSong
 import com.jtech.zemer.db.entities.PlaylistSongMap
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.move
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
@@ -281,8 +282,11 @@ fun LocalPlaylistScreen(
                             )
                         )
                     }
-                    viewModel.viewModelScope.launch(Dispatchers.IO) {
-                        playlistEntity.browseId?.let { YouTube.renamePlaylist(it, name) }
+                    // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                    if (isPersonalAccountSignedIn) {
+                        viewModel.viewModelScope.launch(Dispatchers.IO) {
+                            playlistEntity.browseId?.let { YouTube.renamePlaylist(it, name) }
+                        }
                     }
                 },
             )
@@ -364,8 +368,11 @@ fun LocalPlaylistScreen(
                         database.query {
                             playlist?.let { delete(it.playlist) }
                         }
-                        viewModel.viewModelScope.launch(Dispatchers.IO) {
-                            playlist?.playlist?.browseId?.let { YouTube.deletePlaylist(it) }
+                        // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                        if (isPersonalAccountSignedIn) {
+                            viewModel.viewModelScope.launch(Dispatchers.IO) {
+                                playlist?.playlist?.browseId?.let { YouTube.deletePlaylist(it) }
+                            }
                         }
                         navController.popBackStack()
                     }
@@ -515,13 +522,16 @@ fun LocalPlaylistScreen(
 
                         fun deleteFromPlaylist() {
                             database.transaction {
-                                coroutineScope.launch {
-                                    playlist?.playlist?.browseId?.let { it1 ->
-                                        val setVideoId = getSetVideoId(currentItem.map.songId)
-                                        if (setVideoId?.setVideoId != null) {
-                                            YouTube.removeFromPlaylist(
-                                                it1, currentItem.map.songId, setVideoId.setVideoId
-                                            )
+                                // Anonymous (pooled) sessions are local-only — only a personal account writes to remote.
+                                if (isPersonalAccountSignedIn) {
+                                    coroutineScope.launch {
+                                        playlist?.playlist?.browseId?.let { it1 ->
+                                            val setVideoId = getSetVideoId(currentItem.map.songId)
+                                            if (setVideoId?.setVideoId != null) {
+                                                YouTube.removeFromPlaylist(
+                                                    it1, currentItem.map.songId, setVideoId.setVideoId
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -10,6 +10,7 @@ import com.jtech.zemer.db.entities.ArtistEntity
 import com.jtech.zemer.db.entities.PlaylistEntity
 import com.jtech.zemer.db.entities.PlaylistSongMap
 import com.jtech.zemer.db.entities.SongEntity
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toSQLiteQuery
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.utils.filterWhitelisted
@@ -80,12 +81,14 @@ class SyncUtils @Inject constructor(
     }
 
     fun likeSong(s: SongEntity) {
+        if (!isPersonalAccountSignedIn) return
         syncScope.launch {
             YouTube.likeVideo(s.id, s.liked)
         }
     }
 
     suspend fun syncLikedSongs() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingLikedSongs.value) return
         isSyncingLikedSongs.value = true
         try {
@@ -123,6 +126,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncLibrarySongs() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingLibrarySongs.value) return
         isSyncingLibrarySongs.value = true
         try {
@@ -170,6 +174,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncUploadedSongs() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingUploadedSongs.value) return
         isSyncingUploadedSongs.value = true
         try {
@@ -202,6 +207,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncLikedAlbums() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingLikedAlbums.value) return
         isSyncingLikedAlbums.value = true
         try {
@@ -237,6 +243,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncUploadedAlbums() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingUploadedAlbums.value) return
         isSyncingUploadedAlbums.value = true
         try {
@@ -272,6 +279,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncArtistsSubscriptions() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingArtists.value) return
         isSyncingArtists.value = true
         try {
@@ -311,6 +319,7 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncSavedPlaylists() {
+        if (!isPersonalAccountSignedIn) return
         if (isSyncingPlaylists.value) return
         isSyncingPlaylists.value = true
         try {


### PR DESCRIPTION
## Problem
The "anonymous" login signs into a **shared, pooled** Google account whose cookie carries `SAPISID` but has **no `dataSyncId`**. The app's existing cookie/`SAPISID` checks treated anonymous as logged-in, so the pooled account's library synced and mutated for every anonymous user — one anon's like/subscribe/saved-playlist was visible to all anon users.

## Fix
One shared discriminator, then gate every remote **account** operation on it (local DB writes always run, so anon keeps everything locally):

- **`extensions/AccountState.kt`** (new): `isPersonalAccountSignedIn` (= non-empty `YouTube.dataSyncId`) + `isPersonalAccountFlow()`. Only a *personal* login sets a `dataSyncId`; the anonymous flow explicitly clears it.
- **Pull** (`SyncUtils`): gate liked/library/uploaded songs, liked/uploaded albums, artist subscriptions, saved playlists, and `likeSong`. The **Firebase artist-whitelist sync is exempt** (content filtering still works for anon).
- **Writes**: gate like (`SongEntity`), subscribe (`ArtistEntity`), bookmark album/playlist, add/remove-to-playlist, rename/delete playlist, and library/history feedback. `CreatePlaylistDialog` now needs a personal account to create a *synced* playlist; anon still creates **local** playlists.

## Safety (verified)
- **Personal Google login**: every gate is `if (isPersonalAccountSignedIn) { …original… }` → predicate is true → original code runs unchanged (pure no-op for them).
- **Anonymous**: device-verified `isPersonalAccount=false` → remote skipped, local kept, no crash; playback/search/browse untouched; `MusicService.toggleLike` still persists the local like.
- **Logged-out**: same path as anon (no `dataSyncId`) → local-only, no crash.
- `:app:assembleDebug` + `:app:assembleRelease` (R8) both green.

## Known follow-ups (not in this PR)
- **Home feed / Android Auto** (`YouTube.home()`) still serve the pooled account's personalized rows to anon (e.g. a "My top 50" mix) — higher blast radius, deferred.
- Pre-existing rows synced before this change aren't auto-cleared (indistinguishable from anon's own local likes).