### PR TITLE
Unify the download, library, and selection systems into one shared path

### DIFF
--- a/.github/workflows/ui-audit.yml
+++ b/.github/workflows/ui-audit.yml
@@ -1,21 +1,28 @@
 name: UI audit
 
-# Enforces docs/ui/standards.md section 8 (theme & color) with a ratcheting check: it fails
-# only on NEW raw `fontSize`/`Color(0x..)` in ui/ (outside theme/), beyond the committed
-# baseline (scripts/ui-audit-baseline.tsv). Cheap (grep only). Runs when UI code or the audit
-# itself changes.
+# Enforces docs/ui/standards.md with cheap (grep-only) ratcheting/strict checks:
+#  - ui-audit.sh: fails on NEW raw fontSize/Color(0x..)/AlertDialog/menu-ListItem/blur and any new
+#    legacy download read in ui/ (R13), beyond scripts/ui-audit-baseline.tsv.
+#  - check-download-unification.sh: whole-app guard that download/progress state stays on the one
+#    path (no legacy DownloadUtil.downloads/getDownload reads, no Download.STATE_* outside the
+#    download infra, no per-surface Icon.Download). See docs/ui/standards.md §12.
+# Runs when UI/playback code or the checks themselves change.
 
 on:
   push:
     branches: [ main ]
     paths:
       - 'app/src/main/kotlin/com/jtech/zemer/ui/**'
+      - 'app/src/main/kotlin/com/jtech/zemer/playback/**'
       - 'scripts/ui-audit*'
+      - 'scripts/check-download-unification.sh'
   pull_request:
     branches: [ main ]
     paths:
       - 'app/src/main/kotlin/com/jtech/zemer/ui/**'
+      - 'app/src/main/kotlin/com/jtech/zemer/playback/**'
       - 'scripts/ui-audit*'
+      - 'scripts/check-download-unification.sh'
 
 jobs:
   ui-audit:
@@ -24,5 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: UI standards audit (Rule 8, ratcheting)
+      - name: UI standards audit (ratcheting)
         run: bash scripts/ui-audit.sh
+
+      - name: Download unification guard
+        run: bash scripts/check-download-unification.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,16 @@ Every download/progress affordance reads ONE path; do not re-implement per surfa
   it opens; if it's genuinely gone, **stream this play AND re-enqueue a download to self-repair** —
   never crash with ENOENT, and never silently delete the `isDownloaded` flag (that makes downloads
   vanish from the Downloaded playlist).
+- **`database.query {}` is fire-and-forget** (it posts to an executor, doesn't suspend). NEVER split a
+  single logical mutation across two `query {}` blocks that touch the same row — they race and the
+  wrong one can land last. The download-mark bug was exactly this: `markSongAsDownloaded` upserted the
+  row twice (relations with `isDownloaded=false`, then `isDownloaded=true`), so a downloaded song
+  intermittently persisted `isDownloaded=0` with no `mediaStoreUri` — the file saved but it "didn't
+  download" / streamed / vanished. Do the whole mutation in one `database.transaction {}` whose final
+  write is authoritative.
+- **Remove must delete the actual file on EVERY backend.** A custom download path saves a SAF document
+  uri; `ContentResolver.delete` silently no-ops on those, so `MediaStoreHelper.deleteFromMediaStore`
+  routes document uris through `DocumentsContract.deleteDocument`.
 
 Enforcement (so this can't regress): `scripts/check-download-unification.sh` (whole-app, wired into
 the UI-audit workflow) + `scripts/ui-audit.sh` rule **R13** fail CI on any `downloadUtil.downloads` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,14 +124,32 @@ Every download/progress affordance reads ONE path; do not re-implement per surfa
   `playback/DownloadMenuLogic.kt` (`songRow`/`collectionRow`, pure + tested). A download row **never
   dismisses the menu** (it animates Download → progress → Remove in place). Videos use the same path
   (`DOWNLOAD_VIDEO`, hidden when videos blocked).
-- **Downloading a collection** whose songs load async (online album/playlist menus): resolve/fetch the
-  songs **at click time** (fetch-if-empty) so the first tap downloads — a captured-empty list is the
-  "press once does nothing, twice works" bug. For online items aggregate by videoId
-  (`aggregateByIds`) so progress animates without Room entities.
+- **A collection NEVER shows a FAILED/retry row** (`collectionRow` takes only the aggregate status —
+  REMOVE / DOWNLOADING / DOWNLOAD). A failed member just leaves the aggregate NOT_DOWNLOADED, so the
+  collection offers DOWNLOAD again, which re-enqueues only the not-yet-downloaded members (= retry)
+  and stays removable once everything is on disk. A dedicated collection "retry" row is a **dead end**
+  — it hid Download AND Remove and re-failed the dead track forever with no escape. Only *single*
+  songs get a FAILED row (`songRow`). Don't reintroduce an `anyFailed` arg on `collectionRow`.
+- **Downloading a collection** whose songs load async (online album/playlist/selection menus):
+  resolve/fetch the songs **at click time** (fetch-if-empty) so the first tap downloads — a
+  captured-empty list is the "press once does nothing, twice works" bug. **EVERY action in that menu
+  — Download, Remove, *and* the aggregate status — must read the SAME resolved/fetched list, never the
+  original (possibly-empty) `songs` prop.** A Remove that iterates the empty prop while Download
+  iterates the fetched list silently removes nothing (was a real bug on the Home long-press playlist
+  menu). For online items aggregate by videoId (`aggregateByIds` + a persisted-downloaded id set) so
+  progress animates without Room entities, and on Download **persist each `MediaMetadata`
+  (`database.insert`/`transaction { insert(...) }`) THEN download** — a bare `database.song(id).first()`
+  returns null for a not-yet-persisted id and the tap silently no-ops.
 - **Playback of a downloaded file** (`MusicService.createDataSourceFactory`): use the local file when
   it opens; if it's genuinely gone, **stream this play AND re-enqueue a download to self-repair** —
   never crash with ENOENT, and never silently delete the `isDownloaded` flag (that makes downloads
-  vanish from the Downloaded playlist).
+  vanish from the Downloaded playlist). Two non-obvious rules here: (1) the self-repair must **skip
+  re-enqueueing a download whose live state is already FAILED this session** (check
+  `downloadUtil.mediaStoreDownloadState(id)`) — the manager only no-ops for active/complete, not
+  FAILED, so a permanently-unrecoverable source would otherwise fire a fresh full download on *every*
+  play; (2) the file-open probe (`downloadedFileOpens`) returns false on **any** open failure
+  (FileNotFound *or* SecurityException/other) so playback streams — handing ExoPlayer a URI we just
+  failed to open only fails again.
 - **`database.query {}` is fire-and-forget** (it posts to an executor, doesn't suspend). NEVER split a
   single logical mutation across two `query {}` blocks that touch the same row — they race and the
   wrong one can land last. The download-mark bug was exactly this: `markSongAsDownloaded` upserted the
@@ -139,6 +157,19 @@ Every download/progress affordance reads ONE path; do not re-implement per surfa
   intermittently persisted `isDownloaded=0` with no `mediaStoreUri` — the file saved but it "didn't
   download" / streamed / vanished. Do the whole mutation in one `database.transaction {}` whose final
   write is authoritative.
+- **`markSongAsDownloaded` must NOT clobber user state.** It bases the persisted row on the **existing
+  DB row** (read first) and overwrites only the download-owned columns (`isDownloaded`, `dateDownload`,
+  `mediaStoreUri`, `isVideo`) — a full-row `@Upsert` of the caller's `Song` would silently reset
+  `liked` / `inLibrary` / library tokens when the caller handed a stale/partial `Song` (e.g. an
+  album-page entity, or the like-then-auto-download race). It also backfills `duration` AND
+  `thumbnailUrl` only when the existing row lacks them.
+- **Backfill `duration` AND `thumbnailUrl` from the playback response** in `performDownload`
+  (`playbackData.videoDetails`) — songs reached via an album/playlist page, and standalone videos
+  opened from the Video player, often carry neither (showed "0:00" / no artwork in the Downloaded list).
+- **A per-download video bitrate must survive a failed attempt.** `requestedVideoBitrate` is cleared on
+  success / cancel / delete, **never** in the per-attempt `finally` — else `retryDownload` re-issues the
+  download with no bitrate and silently falls back to best/default quality (a large file over a metered
+  connection the user explicitly capped).
 - **Remove must delete the actual file on EVERY backend.** A custom download path saves a SAF document
   uri; `ContentResolver.delete` silently no-ops on those, so `MediaStoreHelper.deleteFromMediaStore`
   routes document uris through `DocumentsContract.deleteDocument`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,42 @@ transport buttons reuse `TransportSkipButton` + the accent focus border; new D-p
 `Modifier.focusBorder()`. `scripts/ui-audit.sh` ratchets raw `Modifier.blur(` in `ui/` (R12) — route
 player blur through the effective style.
 
+### The download system (ONE unified path — never fork it)
+
+Downloads go **exclusively** through `MediaStoreDownloadManager` (file saved to MediaStore, durable
+truth is `SongEntity.isDownloaded` + `mediaStoreUri`; live progress in its in-memory `downloadStates`).
+The legacy ExoPlayer download map (`DownloadUtil.downloads` / `getDownload()`) is **dead** for
+status — nothing the UI reads should touch it.
+
+Every download/progress affordance reads ONE path; do not re-implement per surface:
+- **State (pure, tested):** `playback/DownloadStateResolver.kt` — `forSong`/`aggregateSongs`/
+  `aggregateByIds` combine persisted `isDownloaded` **OR** live MediaStore state (so a download
+  survives a process restart — reading the live map *alone* is the bug that makes downloads "vanish"
+  after relaunch). `songProgress`/`aggregateProgress[ByIds]` for the progress fraction.
+- **UI:** `ui/component/DownloadStatusUi.kt` — `rememberSongDownloadStatus/Progress`,
+  `SongDownloadBadge` (default song-row badge), `AggregateDownloadButton` (album/playlist header),
+  `DownloadStatusIcon`.
+- **Menu rows:** `ui/menu/DownloadMenuItems.kt` `downloadMenuItem(...)`, decided by
+  `playback/DownloadMenuLogic.kt` (`songRow`/`collectionRow`, pure + tested). A download row **never
+  dismisses the menu** (it animates Download → progress → Remove in place). Videos use the same path
+  (`DOWNLOAD_VIDEO`, hidden when videos blocked).
+- **Downloading a collection** whose songs load async (online album/playlist menus): resolve/fetch the
+  songs **at click time** (fetch-if-empty) so the first tap downloads — a captured-empty list is the
+  "press once does nothing, twice works" bug. For online items aggregate by videoId
+  (`aggregateByIds`) so progress animates without Room entities.
+- **Playback of a downloaded file** (`MusicService.createDataSourceFactory`): use the local file when
+  it opens; if it's genuinely gone, **stream this play AND re-enqueue a download to self-repair** —
+  never crash with ENOENT, and never silently delete the `isDownloaded` flag (that makes downloads
+  vanish from the Downloaded playlist).
+
+Enforcement (so this can't regress): `scripts/check-download-unification.sh` (whole-app, wired into
+the UI-audit workflow) + `scripts/ui-audit.sh` rule **R13** fail CI on any `downloadUtil.downloads` /
+`getDownload(` read, any `Download.STATE_*` outside the legacy infra (`DownloadUtil.kt` /
+`ExoDownloadService.kt`), or any per-surface `Icon.Download(`. Full rules: `docs/ui/standards.md §12`.
+When you touch downloads run both scripts and add pure regression tests next to the resolver/menu
+logic (the manager/playback layer needs Robolectric, which the project does not have — say so rather
+than skip silently).
+
 ### tests/ — the hard-data streaming harness
 
 Node ≥20 scripts (deps vendored in `tests/node_modules`, no install needed) that reproduce the app's *exact* stream path (same `/player` request as `InnerTube.kt`, same cipher run in jsdom, same poTokens) against the live CDN — so playback is measured, not guessed. Needs `innertube_cookie.txt` at the repo root (a dumped logged-in session; **gitignored**, never commit).

--- a/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt
@@ -2,15 +2,28 @@ package com.jtech.zemer.latestreleases
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.jtech.zemer.LocalDatabase
+import com.jtech.zemer.R
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.playback.PlayerConnection
+import com.jtech.zemer.ui.component.AlbumBadges
+import com.jtech.zemer.ui.component.SongDownloadBadge
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.YouTubeGridItem
 import com.jtech.zemer.ui.component.YouTubeListItem
@@ -68,6 +81,7 @@ fun LatestReleaseCard(
             isPlaying = isPlaying,
             coroutineScope = coroutineScope,
             thumbnailRatio = 1f,
+            badges = { ReleaseBadges(release) },
             modifier = clickable,
         )
     } else {
@@ -77,7 +91,43 @@ fun LatestReleaseCard(
             centeredPlayButton = release.isPlayableSingle(),
             isActive = release.isNowPlaying(mediaMetadata),
             isPlaying = isPlaying,
+            badges = { ReleaseBadges(release) },
             modifier = clickable,
         )
+    }
+}
+
+/**
+ * Reflects the release's library state on the row, reactively. A single (one-track release) is
+ * downloaded/played as its sample track, so its badge observes THAT song directly — this is why a
+ * single's download progress shows immediately (the live MediaStore map is keyed by the videoId, so
+ * no DB album row is needed). A multi-track release shows the shared album aggregate badge once it's
+ * in the DB. Matches the single-vs-album split the card already uses for tap behaviour.
+ */
+@Composable
+private fun RowScope.ReleaseBadges(release: LatestRelease) {
+    val database = LocalDatabase.current
+    val videoId = release.sampleVideoId
+    if (release.isPlayableSingle() && !videoId.isNullOrEmpty()) {
+        val song by remember(videoId) { database.song(videoId) }.collectAsState(initial = null)
+        if (song?.song?.liked == true) {
+            Icon(
+                painter = painterResource(R.drawable.favorite),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(18.dp).padding(end = 2.dp),
+            )
+        }
+        if (song?.song?.explicit == true) {
+            Icon(
+                painter = painterResource(R.drawable.explicit),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp).padding(end = 2.dp),
+            )
+        }
+        SongDownloadBadge(videoId, song?.song?.isDownloaded == true)
+    } else {
+        val album by remember(release.browseId) { database.album(release.browseId) }.collectAsState(initial = null)
+        album?.let { AlbumBadges(album = it) }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilter.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilter.kt
@@ -1,0 +1,15 @@
+package com.jtech.zemer.latestreleases
+
+/**
+ * The "See all" Latest Releases screen filter. A release is a SONG when it's a playable single
+ * (exactly one track, see [isPlayableSingle]) and an ALBUM otherwise — the same single/album split
+ * the cards already use for tap behaviour, so the filter matches what the user sees on each row.
+ */
+enum class LatestReleaseFilter { ALL, ALBUMS, SONGS }
+
+/** Keeps only the releases matching [filter], preserving feed order. Pure, so it's unit-testable. */
+fun List<LatestRelease>.applyFilter(filter: LatestReleaseFilter): List<LatestRelease> = when (filter) {
+    LatestReleaseFilter.ALL -> this
+    LatestReleaseFilter.ALBUMS -> filter { !it.isPlayableSingle() }
+    LatestReleaseFilter.SONGS -> filter { it.isPlayableSingle() }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt
@@ -1,0 +1,66 @@
+package com.jtech.zemer.playback
+
+/**
+ * Which download row a menu should show for an item or collection. Decoupled from Compose so the
+ * decision is unit-tested without an Android runtime — the row's look/behaviour live in one builder
+ * ([com.jtech.zemer.ui.menu.DownloadMenuItem]) and the decision lives here, so neither can drift.
+ */
+enum class DownloadRowKind {
+    /** Offer "Download to device". */
+    DOWNLOAD,
+
+    /** Offer "Download video to device" (single video item, videos not blocked). */
+    DOWNLOAD_VIDEO,
+
+    /** Show progress + "%", tapping cancels. */
+    DOWNLOADING,
+
+    /** Show "Download failed", tapping retries. */
+    FAILED,
+
+    /** Show "Remove download", tapping removes. */
+    REMOVE,
+
+    /** Show no download row at all (e.g. a video item while videos are blocked). */
+    HIDDEN,
+}
+
+/**
+ * The single rule for what a download menu row should do, given the unified [DownloadStatus]
+ * (from [DownloadStateResolver]) plus whether the live download is in a FAILED state. Used by every
+ * item/collection menu so "Download vs Remove vs progress vs retry" is decided identically.
+ */
+object DownloadMenuLogic {
+
+    /**
+     * Row for a single song. DOWNLOADED wins over a stale FAILED (the file is on disk), then FAILED,
+     * then in-progress, then the download offer — hidden only for a blocked video.
+     */
+    fun songRow(
+        status: DownloadStatus,
+        failed: Boolean,
+        isVideo: Boolean,
+        blockVideos: Boolean,
+    ): DownloadRowKind = when {
+        status == DownloadStatus.DOWNLOADED -> DownloadRowKind.REMOVE
+        failed -> DownloadRowKind.FAILED
+        status == DownloadStatus.DOWNLOADING -> DownloadRowKind.DOWNLOADING
+        isVideo && blockVideos -> DownloadRowKind.HIDDEN
+        isVideo -> DownloadRowKind.DOWNLOAD_VIDEO
+        else -> DownloadRowKind.DOWNLOAD
+    }
+
+    /**
+     * Row for a collection (album / playlist / multi-select). No video variant — collections download
+     * as audio. A failed member only surfaces "retry" while the collection isn't already fully on disk.
+     */
+    fun collectionRow(
+        status: DownloadStatus,
+        anyFailed: Boolean,
+    ): DownloadRowKind = when {
+        status == DownloadStatus.DOWNLOADED -> DownloadRowKind.REMOVE
+        anyFailed -> DownloadRowKind.FAILED
+        status == DownloadStatus.DOWNLOADING -> DownloadRowKind.DOWNLOADING
+        else -> DownloadRowKind.DOWNLOAD
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt
@@ -52,15 +52,17 @@ object DownloadMenuLogic {
 
     /**
      * Row for a collection (album / playlist / multi-select). No video variant — collections download
-     * as audio. A failed member only surfaces "retry" while the collection isn't already fully on disk.
+     * as audio, and there is deliberately NO collection-level FAILED row: a failed member just leaves
+     * the aggregate NOT_DOWNLOADED, so the collection offers DOWNLOAD again (which re-enqueues only the
+     * not-yet-downloaded members — i.e. retries the failed one) and stays removable once everything is
+     * on disk. A dedicated "retry" row here was a dead end — it hid Download/Remove and re-failed the
+     * dead track forever with no escape (single songs still get their own FAILED row via [songRow]).
      */
     fun collectionRow(
         status: DownloadStatus,
-        anyFailed: Boolean,
-    ): DownloadRowKind = when {
-        status == DownloadStatus.DOWNLOADED -> DownloadRowKind.REMOVE
-        anyFailed -> DownloadRowKind.FAILED
-        status == DownloadStatus.DOWNLOADING -> DownloadRowKind.DOWNLOADING
-        else -> DownloadRowKind.DOWNLOAD
+    ): DownloadRowKind = when (status) {
+        DownloadStatus.DOWNLOADED -> DownloadRowKind.REMOVE
+        DownloadStatus.DOWNLOADING -> DownloadRowKind.DOWNLOADING
+        DownloadStatus.NOT_DOWNLOADED -> DownloadRowKind.DOWNLOAD
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
@@ -1,0 +1,71 @@
+package com.jtech.zemer.playback
+
+import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState
+import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status
+
+/**
+ * The three states the whole UI cares about for a song or a collection of songs.
+ */
+enum class DownloadStatus { NOT_DOWNLOADED, DOWNLOADING, DOWNLOADED }
+
+/**
+ * THE single source of truth for "is this downloaded / downloading", used by every download badge,
+ * menu and header in the app. Read this — never the raw flows — so the answer can never drift
+ * between surfaces again.
+ *
+ * Downloads go exclusively through [MediaStoreDownloadManager]. There are two facts to combine:
+ * - the PERSISTED [com.jtech.zemer.db.entities.SongEntity.isDownloaded] flag, which is the only thing
+ *   that survives a process restart, and
+ * - the LIVE in-session [MediaStoreDownloadManager.downloadStates] map, which carries progress and the
+ *   transient QUEUED/DOWNLOADING/FAILED states but is empty on a fresh launch.
+ *
+ * The legacy ExoPlayer download map ([DownloadUtil.downloads] / [DownloadUtil.getDownload]) is
+ * deliberately NOT consulted: nothing writes to it anymore, so reading it always reports "not
+ * downloaded". `scripts/ui-audit.sh` bans new reads of it so this mistake can't come back.
+ */
+object DownloadStateResolver {
+
+    /** Per-song status from the persisted flag + this song's live download state (if any). */
+    fun forSong(isDownloaded: Boolean, live: DownloadState?): DownloadStatus = when {
+        isDownloaded || live?.status == Status.COMPLETED -> DownloadStatus.DOWNLOADED
+        live?.status == Status.QUEUED || live?.status == Status.DOWNLOADING -> DownloadStatus.DOWNLOADING
+        else -> DownloadStatus.NOT_DOWNLOADED
+    }
+
+    fun forSong(song: Song, live: Map<String, DownloadState>): DownloadStatus =
+        forSong(song.song.isDownloaded, live[song.id])
+
+    /**
+     * Aggregate state for a collection (album / playlist header, multi-select):
+     * - DOWNLOADED only when every song is downloaded,
+     * - NOT_DOWNLOADED if any song is neither downloaded nor in progress,
+     * - DOWNLOADING otherwise (everything is downloaded-or-in-progress, with at least one pending).
+     * An empty collection is NOT_DOWNLOADED.
+     */
+    fun aggregate(statuses: List<DownloadStatus>): DownloadStatus = when {
+        statuses.isEmpty() -> DownloadStatus.NOT_DOWNLOADED
+        statuses.all { it == DownloadStatus.DOWNLOADED } -> DownloadStatus.DOWNLOADED
+        statuses.any { it == DownloadStatus.NOT_DOWNLOADED } -> DownloadStatus.NOT_DOWNLOADED
+        else -> DownloadStatus.DOWNLOADING
+    }
+
+    fun aggregateSongs(songs: List<Song>, live: Map<String, DownloadState>): DownloadStatus =
+        aggregate(songs.map { forSong(it, live) })
+
+    /**
+     * Fraction (0..1) of a collection that is on disk, for an aggregate progress bar: a downloaded
+     * song counts as 1, an in-progress song as its live [DownloadState.progress], everything else 0.
+     * Returns 0 for an empty collection.
+     */
+    fun aggregateProgress(songs: List<Song>, live: Map<String, DownloadState>): Float {
+        if (songs.isEmpty()) return 0f
+        return songs.map { song ->
+            when (forSong(song, live)) {
+                DownloadStatus.DOWNLOADED -> 1f
+                DownloadStatus.DOWNLOADING -> live[song.id]?.progress ?: 0f
+                DownloadStatus.NOT_DOWNLOADED -> 0f
+            }
+        }.average().toFloat().coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
@@ -54,6 +54,35 @@ object DownloadStateResolver {
         aggregate(songs.map { forSong(it, live) })
 
     /**
+     * Status of a song known only by id (online items not necessarily in the DB): persisted-downloaded
+     * comes from [persistedDownloaded], live progress/queued from [live]. Lets online album/playlist
+     * menus show live download progress keyed by videoId without holding Room entities.
+     */
+    fun statusForId(id: String, live: Map<String, DownloadState>, persistedDownloaded: Set<String>): DownloadStatus =
+        forSong(id in persistedDownloaded, live[id])
+
+    fun aggregateByIds(
+        ids: List<String>,
+        live: Map<String, DownloadState>,
+        persistedDownloaded: Set<String>,
+    ): DownloadStatus = aggregate(ids.map { statusForId(it, live, persistedDownloaded) })
+
+    fun aggregateProgressByIds(
+        ids: List<String>,
+        live: Map<String, DownloadState>,
+        persistedDownloaded: Set<String>,
+    ): Float {
+        if (ids.isEmpty()) return 0f
+        return ids.map { id ->
+            when (statusForId(id, live, persistedDownloaded)) {
+                DownloadStatus.DOWNLOADED -> 1f
+                DownloadStatus.DOWNLOADING -> live[id]?.progress ?: 0f
+                DownloadStatus.NOT_DOWNLOADED -> 0f
+            }
+        }.average().toFloat().coerceIn(0f, 1f)
+    }
+
+    /**
      * Fraction (0..1) of a collection that is on disk, for an aggregate progress bar: a downloaded
      * song counts as 1, an in-progress song as its live [DownloadState.progress], everything else 0.
      * Returns 0 for an empty collection.

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt
@@ -36,6 +36,12 @@ object DownloadStateResolver {
     fun forSong(song: Song, live: Map<String, DownloadState>): DownloadStatus =
         forSong(song.song.isDownloaded, live[song.id])
 
+    /** Per-song progress fraction (0..1): 1 once downloaded, else the active download's live progress. */
+    fun songProgress(isDownloaded: Boolean, live: DownloadState?): Float = when {
+        isDownloaded || live?.status == Status.COMPLETED -> 1f
+        else -> (live?.progress ?: 0f).coerceIn(0f, 1f)
+    }
+
     /**
      * Aggregate state for a collection (album / playlist header, multi-select):
      * - DOWNLOADED only when every song is downloaded,

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
@@ -255,6 +255,10 @@ constructor(
     fun getAllMediaStoreDownloads(): StateFlow<Map<String, MediaStoreDownloadManager.DownloadState>> =
         mediaStoreDownloadManager.downloadStates
 
+    /** Synchronous snapshot of a song's live download state (null if none this session). */
+    fun mediaStoreDownloadState(songId: String): MediaStoreDownloadManager.DownloadState? =
+        mediaStoreDownloadManager.getDownloadState(songId)
+
     fun downloadToMediaStore(song: com.jtech.zemer.db.entities.Song) {
         mediaStoreDownloadManager.downloadSong(song)
     }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
@@ -263,8 +263,11 @@ constructor(
      * Download a video to MediaStore (Movies/Zemer folder)
      * This downloads the actual video file (mp4), not just audio.
      */
-    fun downloadVideoToMediaStore(song: com.jtech.zemer.db.entities.Song) {
-        mediaStoreDownloadManager.downloadVideo(song)
+    fun downloadVideoToMediaStore(
+        song: com.jtech.zemer.db.entities.Song,
+        maxVideoBitrateKbps: Int? = null,
+    ) {
+        mediaStoreDownloadManager.downloadVideo(song, maxVideoBitrateKbps)
     }
 
     fun cancelMediaStoreDownload(songId: String) {

--- a/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.ConnectivityManager
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
-import androidx.media3.common.C
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
@@ -33,11 +32,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -90,15 +87,10 @@ constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    // Legacy ExoPlayer cache downloads. Still maintained for the download cache + removeDownload, but
+    // the UI no longer reads this map — download/progress state is unified through MediaStore (see
+    // DownloadStateResolver). Do not reintroduce UI reads of this (ui-audit rule R13).
     val downloads = MutableStateFlow<Map<String, Download>>(emptyMap())
-    private val exoDownloadStates: StateFlow<Map<String, MediaStoreDownloadManager.DownloadState>> =
-        downloads
-            .map { downloadMap ->
-                downloadMap.mapValues { (_, download) ->
-                    download.toDownloadState()
-                }
-            }
-            .stateIn(scope, SharingStarted.Eagerly, emptyMap())
 
     private val dataSourceFactory: ResolvingDataSource.Factory by lazy {
         ResolvingDataSource.Factory(
@@ -255,47 +247,6 @@ constructor(
         }
     }
 
-    private fun Download.toDownloadState(): MediaStoreDownloadManager.DownloadState {
-        val status =
-            when (state) {
-                Download.STATE_COMPLETED -> MediaStoreDownloadManager.DownloadState.Status.COMPLETED
-                Download.STATE_DOWNLOADING, Download.STATE_RESTARTING -> MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING
-                Download.STATE_QUEUED -> MediaStoreDownloadManager.DownloadState.Status.QUEUED
-                Download.STATE_FAILED -> MediaStoreDownloadManager.DownloadState.Status.FAILED
-                Download.STATE_REMOVING,
-                Download.STATE_STOPPED -> MediaStoreDownloadManager.DownloadState.Status.CANCELLED
-                else -> MediaStoreDownloadManager.DownloadState.Status.CANCELLED
-            }
-
-        val totalBytes = contentLength.takeIf { it != C.LENGTH_UNSET.toLong() } ?: 0L
-        val downloadedBytes = bytesDownloaded
-        val progress =
-            when {
-                totalBytes > 0 -> downloadedBytes.toFloat() / totalBytes
-                percentDownloaded != C.PERCENTAGE_UNSET.toFloat() -> percentDownloaded / 100f
-                else -> 0f
-            }.coerceIn(0f, 1f)
-
-        val error =
-            if (status == MediaStoreDownloadManager.DownloadState.Status.FAILED &&
-                failureReason != Download.FAILURE_REASON_NONE
-            ) {
-                "Error code $failureReason"
-            } else {
-                null
-            }
-
-        return MediaStoreDownloadManager.DownloadState(
-            songId = request.id,
-            status = status,
-            progress = progress,
-            bytesDownloaded = downloadedBytes,
-            totalBytes = if (totalBytes > 0) totalBytes else downloadedBytes,
-            error = error,
-        )
-    }
-
-    fun getDownload(songId: String): Flow<Download?> = downloads.map { it[songId] }
 
     // MediaStore download methods
     fun getMediaStoreDownload(songId: String): Flow<MediaStoreDownloadManager.DownloadState?> =

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt
@@ -266,7 +266,9 @@ constructor(
 
                     MusicService.PLAYLIST -> {
                         val likedSongCount = database.likedSongsCount().first()
-                        val downloadedSongCount = downloadUtil.downloads.value.size
+                        // Persisted MediaStore downloads (the legacy ExoPlayer `downloads` map is dead) —
+                        // count the same rows the Downloaded playlist shows.
+                        val downloadedSongCount = database.downloadedSongsByCreateDateAsc().first().size
                         listOf(
                             browsableMediaItem(
                                 "${MusicService.PLAYLIST}/${PlaylistEntity.LIKED_PLAYLIST_ID}",
@@ -378,22 +380,10 @@ constructor(
                                         true
                                     )
 
-                                    PlaylistEntity.DOWNLOADED_PLAYLIST_ID -> {
-                                        val downloads = downloadUtil.downloads.value
-                                        database
-                                            .allSongs()
-                                            .flowOn(Dispatchers.IO)
-                                            .map { songs ->
-                                                songs.filter {
-                                                    downloads[it.id]?.state == Download.STATE_COMPLETED
-                                                }
-                                            }.map { songs ->
-                                                songs
-                                                    .map { it to downloads[it.id] }
-                                                    .sortedBy { it.second?.updateTimeMs ?: 0L }
-                                                    .map { it.first }
-                                            }
-                                    }
+                                    // Persisted MediaStore downloads (the same query the Downloaded
+                                    // screen uses) — the legacy ExoPlayer map is dead.
+                                    PlaylistEntity.DOWNLOADED_PLAYLIST_ID ->
+                                        database.downloadedSongsByCreateDateAsc()
 
                                     else ->
                                         database.playlistSongs(playlistId).map { list ->
@@ -618,22 +608,8 @@ constructor(
                     val playlistId = path.getOrNull(1) ?: return@future defaultResult
                     val songs = when (playlistId) {
                         PlaylistEntity.LIKED_PLAYLIST_ID -> database.likedSongs(SongSortType.CREATE_DATE, descending = true)
-                        PlaylistEntity.DOWNLOADED_PLAYLIST_ID -> {
-                            val downloads = downloadUtil.downloads.value
-                            database
-                                .allSongs()
-                                .flowOn(Dispatchers.IO)
-                                .map { songs ->
-                                    songs.filter {
-                                        downloads[it.id]?.state == Download.STATE_COMPLETED
-                                    }
-                                }.map { songs ->
-                                    songs
-                                        .map { it to downloads[it.id] }
-                                        .sortedBy { it.second?.updateTimeMs ?: 0L }
-                                        .map { it.first }
-                                }
-                        }
+                        PlaylistEntity.DOWNLOADED_PLAYLIST_ID ->
+                            database.downloadedSongsByCreateDateAsc()
                         else -> database.playlistSongs(playlistId).map { list ->
                             list.map { it.song }
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -689,17 +689,51 @@ constructor(
     }
 
     /**
-     * Mark a song as downloaded in the database with MediaStore URI
+     * Mark a song as downloaded in the database with its MediaStore URI.
+     *
+     * Persists the row (with isDownloaded = true), its artists and its album in ONE transaction.
+     * This previously called [ensureSongPersisted] (which upserts the row with isDownloaded = false
+     * for a brand-new song) and THEN a separate `query {}` upserting isDownloaded = true. `query {}`
+     * runs on a fire-and-forget executor, so those two writes RACED: intermittently the "false" write
+     * landed last, so a download whose file saved fine still ended up isDownloaded = 0 with no
+     * mediaStoreUri — it vanished from the Downloaded list and played by streaming. A single
+     * transaction whose authoritative write is isDownloaded = true removes the race.
      */
     private suspend fun markSongAsDownloaded(song: Song, mediaStoreUri: String) {
-        ensureSongPersisted(song)
-
-        database.query {
-            database.upsert(
+        database.transaction {
+            upsert(
                 song.song.copy(
+                    isVideo = song.song.isVideo,
                     isDownloaded = true,
                     dateDownload = LocalDateTime.now(),
-                    mediaStoreUri = mediaStoreUri
+                    mediaStoreUri = mediaStoreUri,
+                )
+            )
+            insertSongRelations(song)
+        }
+    }
+
+    /** Insert a song's artists + album relations. Shared by [markSongAsDownloaded] and
+     *  [ensureSongPersisted] so the relation wiring lives in one place. Call inside a query/transaction
+     *  block (receiver is the [MusicDatabase]). */
+    private fun MusicDatabase.insertSongRelations(song: Song) {
+        song.artists.forEachIndexed { index, artist ->
+            insert(artist)
+            insert(
+                SongArtistMap(
+                    songId = song.id,
+                    artistId = artist.id,
+                    position = index,
+                )
+            )
+        }
+        song.album?.let { album ->
+            insert(album)
+            insert(
+                SongAlbumMap(
+                    songId = song.id,
+                    albumId = album.id,
+                    index = 0,
                 )
             )
         }
@@ -722,28 +756,7 @@ constructor(
             )
 
             upsert(mergedSong)
-
-            song.artists.forEachIndexed { index, artist ->
-                insert(artist)
-                insert(
-                    SongArtistMap(
-                        songId = song.id,
-                        artistId = artist.id,
-                        position = index,
-                    )
-                )
-            }
-
-            song.album?.let { album ->
-                insert(album)
-                insert(
-                    SongAlbumMap(
-                        songId = song.id,
-                        albumId = album.id,
-                        index = 0,
-                    )
-                )
-            }
+            insertSongRelations(song)
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -470,7 +470,12 @@ constructor(
                 } else {
                     song.artists.firstOrNull()?.name ?: "Unknown Artist"
                 }
-                val duration = song.song.duration.takeIf { it > 0 }?.times(1000L) // Convert to milliseconds
+                // Songs reached via an album/playlist page often carry no duration (0), which shows as
+                // "0:00" in the Downloaded list — backfill it from the playback response so the saved
+                // file's metadata AND the DB row get a real length.
+                val effectiveDurationSec = song.song.duration.takeIf { it > 0 }
+                    ?: playbackData.videoDetails?.lengthSeconds?.toIntOrNull() ?: 0
+                val duration = effectiveDurationSec.takeIf { it > 0 }?.times(1000L) // ms for MediaStore
 
                 // Embed metadata if format supports it (audio only)
                 if (!isVideoDownload && CoverArtEmbedder.supportsEmbedding(extension)) {
@@ -528,8 +533,15 @@ constructor(
                         )
                     )
 
-                    // Update database with MediaStore URI (preserving isVideo flag)
-                    markSongAsDownloaded(song, uri.toString())
+                    // Update database with MediaStore URI (preserving isVideo flag), backfilling the
+                    // duration if the source had none so the Downloaded list shows a real time.
+                    val songWithDuration =
+                        if (song.song.duration <= 0 && effectiveDurationSec > 0) {
+                            song.copy(song = song.song.copy(duration = effectiveDurationSec))
+                        } else {
+                            song
+                        }
+                    markSongAsDownloaded(songWithDuration, uri.toString())
                 } else {
                     throw Exception("Failed to save file to MediaStore")
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -16,6 +16,7 @@ import com.jtech.zemer.utils.UrlValidator
 import com.jtech.zemer.utils.YTPlayerUtils
 import com.jtech.zemer.utils.enumPreference
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -29,6 +30,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.min
@@ -86,7 +88,9 @@ constructor(
 
     // Download queue
     private val downloadQueue = mutableListOf<Song>()
-    private val activeDownloads = mutableMapOf<String, Job>()
+    // Touched from several coroutines (processQueue, performDownload's finally, cancel/delete) — must be
+    // concurrent or it can corrupt / leak an uncancellable orphan job.
+    private val activeDownloads = ConcurrentHashMap<String, Job>()
 
     companion object {
         private const val MAX_CONCURRENT_DOWNLOADS = 3
@@ -529,6 +533,11 @@ constructor(
                 }
             }
 
+        } catch (e: CancellationException) {
+            // The user cancelled this download (cancelDownload/deleteDownloaded cancelled the job).
+            // Must rethrow — otherwise the retry branch below would swallow it, resurrect the download,
+            // overwrite the CANCELLED state, and pin the foreground notification service open forever.
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "Download failed for song ${song.id}: ${e.message}")
             // Retry logic with exponential backoff

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -256,6 +256,7 @@ constructor(
             // Cancel active download
             activeDownloads[songId]?.cancel()
             activeDownloads.remove(songId)
+            requestedVideoBitrate.remove(songId)
 
             // Remove from queue
             synchronized(downloadQueue) {
@@ -318,6 +319,7 @@ constructor(
         // Cancel active work and purge queue
         activeDownloads[songId]?.cancel()
         activeDownloads.remove(songId)
+        requestedVideoBitrate.remove(songId)
         synchronized(downloadQueue) {
             downloadQueue.removeAll { it.id == songId }
         }
@@ -367,7 +369,11 @@ constructor(
                 } finally {
                     downloadSemaphore.release()
                     activeDownloads.remove(song.id)
-                    requestedVideoBitrate.remove(song.id)
+                    // NOTE: do NOT drop the requested video bitrate here. A failed attempt ends in this
+                    // finally too, and retryDownload() re-issues downloadVideo(song) with no bitrate — if
+                    // we erased it on failure, the retry would silently fall back to best/default quality
+                    // (a large file over a metered connection the user explicitly capped). It is cleared
+                    // on success, cancel and delete instead.
 
                     // Process next item in queue
                     processQueue()
@@ -523,6 +529,8 @@ constructor(
                 Timber.d("MediaStore save result: $uri")
 
                 if (uri != null) {
+                    // Download succeeded — the requested bitrate has served its purpose.
+                    requestedVideoBitrate.remove(song.id)
                     // Mark as completed
                     updateDownloadState(
                         song.id,
@@ -534,14 +542,18 @@ constructor(
                     )
 
                     // Update database with MediaStore URI (preserving isVideo flag), backfilling the
-                    // duration if the source had none so the Downloaded list shows a real time.
-                    val songWithDuration =
-                        if (song.song.duration <= 0 && effectiveDurationSec > 0) {
-                            song.copy(song = song.song.copy(duration = effectiveDurationSec))
-                        } else {
-                            song
-                        }
-                    markSongAsDownloaded(songWithDuration, uri.toString())
+                    // duration AND thumbnail if the source had none so the Downloaded list shows a real
+                    // time and artwork — a standalone video opened from the Video player is built with
+                    // neither, and the old per-screen download set the thumbnail explicitly.
+                    val effectiveThumbnailUrl = song.song.thumbnailUrl?.takeIf { it.isNotBlank() }
+                        ?: playbackData.videoDetails?.thumbnail?.thumbnails?.lastOrNull()?.url
+                    val songWithMeta = song.copy(
+                        song = song.song.copy(
+                            duration = if (song.song.duration > 0) song.song.duration else effectiveDurationSec,
+                            thumbnailUrl = effectiveThumbnailUrl,
+                        ),
+                    )
+                    markSongAsDownloaded(songWithMeta, uri.toString())
                 } else {
                     throw Exception("Failed to save file to MediaStore")
                 }
@@ -700,13 +712,22 @@ constructor(
      * transaction whose authoritative write is isDownloaded = true removes the race.
      */
     private suspend fun markSongAsDownloaded(song: Song, mediaStoreUri: String) {
+        // Base the persisted row on the EXISTING row (if any), not the caller's Song. The caller may
+        // hand us a stale/partial Song (e.g. an album-page entity with liked = false, inLibrary = null);
+        // a full-row @Upsert of that would silently un-like the song / drop it from the library. We only
+        // overwrite the download-owned columns here (+ isVideo, + duration/thumbnail backfill when the
+        // row lacks them) and preserve everything else the user set.
+        val existing = database.song(song.id).first()?.song
         database.transaction {
+            val base = existing ?: song.song
             upsert(
-                song.song.copy(
+                base.copy(
                     isVideo = song.song.isVideo,
                     isDownloaded = true,
                     dateDownload = LocalDateTime.now(),
                     mediaStoreUri = mediaStoreUri,
+                    duration = if (base.duration > 0) base.duration else song.song.duration,
+                    thumbnailUrl = base.thumbnailUrl ?: song.song.thumbnailUrl,
                 )
             )
             insertSongRelations(song)

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -86,6 +86,9 @@ constructor(
     private val _downloadStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
     val downloadStates: StateFlow<Map<String, DownloadState>> = _downloadStates.asStateFlow()
 
+    // Per-download requested video bitrate (kbps), set by downloadVideo, consumed by performDownload.
+    private val requestedVideoBitrate = ConcurrentHashMap<String, Int>()
+
     // Download queue
     private val downloadQueue = mutableListOf<Song>()
     // Touched from several coroutines (processQueue, performDownload's finally, cancel/delete) — must be
@@ -129,7 +132,7 @@ constructor(
      *
      * @param song The song/video to download as video file
      */
-    fun downloadVideo(song: Song) {
+    fun downloadVideo(song: Song, maxVideoBitrateKbps: Int? = null) {
         Timber.d("downloadVideo called: id=${song.id}, title=${song.song.title}, inputIsVideo=${song.song.isVideo}")
         scope.launch {
             // Start notification service
@@ -142,6 +145,8 @@ constructor(
                 Timber.d("downloadVideo skipped - already downloading or completed: status=${currentState?.status}")
                 return@launch
             }
+            // Remember the requested video bitrate for this download (consumed in performDownload).
+            maxVideoBitrateKbps?.let { requestedVideoBitrate[song.id] = it }
 
             // Mark as video FIRST, then persist
             val videoSong = song.copy(song = song.song.copy(isVideo = true))
@@ -362,6 +367,7 @@ constructor(
                 } finally {
                     downloadSemaphore.release()
                     activeDownloads.remove(song.id)
+                    requestedVideoBitrate.remove(song.id)
 
                     // Process next item in queue
                     processQueue()
@@ -402,6 +408,7 @@ constructor(
                 audioQuality = audioQuality,
                 connectivityManager = connectivityManager,
                 preferVideo = isVideoDownload,
+                maxVideoBitrateKbps = if (isVideoDownload) requestedVideoBitrate[song.id] else null,
                 forDownload = true,
             ).getOrThrow()
 

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt
@@ -654,10 +654,26 @@ constructor(
     }
 
     /**
-     * Update the download state for a song
+     * Update the download state for a song. While a download is in progress, progress is clamped to
+     * be monotonic (never decreases): a retry restarts the byte counter at 0 and the per-attempt
+     * "Retrying…" state carries progress 0, which otherwise makes the UI ring jump backwards and
+     * "bounce" up to 100%. Holding the last value until the new attempt catches up keeps it smooth.
      */
     private fun updateDownloadState(songId: String, state: DownloadState) {
-        _downloadStates.value = _downloadStates.value + (songId to state)
+        val prev = _downloadStates.value[songId]
+        val adjusted =
+            if (state.status == DownloadState.Status.DOWNLOADING &&
+                prev?.status == DownloadState.Status.DOWNLOADING &&
+                prev.progress > state.progress
+            ) {
+                state.copy(
+                    progress = prev.progress,
+                    bytesDownloaded = maxOf(prev.bytesDownloaded, state.bytesDownloaded),
+                )
+            } else {
+                state
+            }
+        _downloadStates.value = _downloadStates.value + (songId to adjusted)
     }
 
     /**

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1418,13 +1418,27 @@ class MusicService :
             }
 
             // A downloaded song plays from its local MediaStore file (only at position 0, so we don't
-            // switch sources mid-stream when a download finishes during playback). If that file is
-            // genuinely gone, fall through to streaming instead of crashing with ENOENT — but DON'T
-            // delete the download flag (the file may reappear, e.g. an unmounted SD card).
+            // switch sources mid-stream when a download finishes during playback).
             val mediaStoreUri = song?.song?.mediaStoreUri
-            if (mediaStoreUri != null && dataSpec.position == 0L && downloadedFileOpens(mediaStoreUri)) {
-                scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
-                return@Factory dataSpec.withUri(mediaStoreUri.toUri())
+            if (mediaStoreUri != null && dataSpec.position == 0L) {
+                if (downloadedFileOpens(mediaStoreUri)) {
+                    scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+                    return@Factory dataSpec.withUri(mediaStoreUri.toUri())
+                }
+                // The file is gone (a stale "downloaded" row — e.g. from an interrupted download or an
+                // older build that deleted the file). Self-repair: re-download it so it's local again
+                // next time, and stream THIS play instead of crashing with ENOENT. We don't clear the
+                // flag (no vanishing); the re-download replaces the dead URI on success. The manager
+                // no-ops if a download for this id is already active/complete, so this can't loop.
+                Timber.w("Downloaded file missing for $mediaId; re-downloading to self-repair and streaming this play")
+                song?.let { stale ->
+                    scope.launch(Dispatchers.IO) {
+                        runCatching {
+                            if (stale.song.isVideo) downloadUtil.downloadVideoToMediaStore(stale)
+                            else downloadUtil.downloadToMediaStore(stale)
+                        }
+                    }
+                }
             }
 
             if (downloadCache.isCached(

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1386,10 +1386,12 @@ class MusicService :
             ).setCacheWriteDataSinkFactory(null)
             .setFlags(FLAG_IGNORE_CACHE_ON_ERROR)
 
-    /** Whether the downloaded file at [uriString] actually opens. A genuinely-missing file (ENOENT /
-     *  null descriptor) returns false so playback can fall back to streaming instead of crashing; a
-     *  transient resolver error is treated as present (we don't want to stream a file that's really
-     *  there). We never delete the download here — the flag is the user's, not ours to silently drop. */
+    /** Whether the downloaded file at [uriString] actually opens. Returns false on ANY failure to open
+     *  (ENOENT / null descriptor / FileNotFound / a SecurityException or other resolver error) so that
+     *  playback falls back to STREAMING rather than handing ExoPlayer a URI we just failed to open
+     *  (which would only fail again). Worst case for a present-but-momentarily-unreadable file is one
+     *  streamed play + a self-repair re-download — never a hard playback failure. We never delete the
+     *  download here — the flag is the user's, not ours to silently drop. */
     private fun downloadedFileOpens(uriString: String): Boolean =
         try {
             contentResolver.openFileDescriptor(uriString.toUri(), "r")?.use { true }
@@ -1401,8 +1403,8 @@ class MusicService :
             Timber.w("Downloaded file MISSING (FileNotFound) for uri=$uriString; will stream")
             false
         } catch (e: Exception) {
-            Timber.w(e, "Transient error probing downloaded file $uriString; treating as present")
-            true
+            Timber.w(e, "Could not open downloaded file $uriString; streaming instead of handing over a dead URI")
+            false
         }
 
     private fun createDataSourceFactory(): DataSource.Factory {
@@ -1428,14 +1430,24 @@ class MusicService :
                 // The file is gone (a stale "downloaded" row — e.g. from an interrupted download or an
                 // older build that deleted the file). Self-repair: re-download it so it's local again
                 // next time, and stream THIS play instead of crashing with ENOENT. We don't clear the
-                // flag (no vanishing); the re-download replaces the dead URI on success. The manager
-                // no-ops if a download for this id is already active/complete, so this can't loop.
-                Timber.w("Downloaded file missing for $mediaId; re-downloading to self-repair and streaming this play")
-                song?.let { stale ->
-                    scope.launch(Dispatchers.IO) {
-                        runCatching {
-                            if (stale.song.isVideo) downloadUtil.downloadVideoToMediaStore(stale)
-                            else downloadUtil.downloadToMediaStore(stale)
+                // flag (no vanishing); the re-download replaces the dead URI on success.
+                //
+                // The manager no-ops while a download for this id is active/complete — but NOT once it
+                // has FAILED. So we must skip re-enqueueing a download that already failed this session,
+                // otherwise a permanently-unrecoverable source (deleted upstream / region-blocked) would
+                // fire a fresh full download attempt on EVERY play. A new session (state cleared) gets
+                // one fresh attempt.
+                val liveStatus = downloadUtil.mediaStoreDownloadState(mediaId)?.status
+                if (liveStatus == MediaStoreDownloadManager.DownloadState.Status.FAILED) {
+                    Timber.w("Downloaded file missing for $mediaId but its re-download already FAILED this session; streaming without re-enqueueing")
+                } else {
+                    Timber.w("Downloaded file missing for $mediaId; re-downloading to self-repair and streaming this play")
+                    song?.let { stale ->
+                        scope.launch(Dispatchers.IO) {
+                            runCatching {
+                                if (stale.song.isVideo) downloadUtil.downloadVideoToMediaStore(stale)
+                                else downloadUtil.downloadToMediaStore(stale)
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -1386,6 +1386,25 @@ class MusicService :
             ).setCacheWriteDataSinkFactory(null)
             .setFlags(FLAG_IGNORE_CACHE_ON_ERROR)
 
+    /** Whether the downloaded file at [uriString] actually opens. A genuinely-missing file (ENOENT /
+     *  null descriptor) returns false so playback can fall back to streaming instead of crashing; a
+     *  transient resolver error is treated as present (we don't want to stream a file that's really
+     *  there). We never delete the download here — the flag is the user's, not ours to silently drop. */
+    private fun downloadedFileOpens(uriString: String): Boolean =
+        try {
+            contentResolver.openFileDescriptor(uriString.toUri(), "r")?.use { true }
+                ?: run {
+                    Timber.w("Downloaded file probe returned null descriptor for uri=$uriString; will stream")
+                    false
+                }
+        } catch (e: java.io.FileNotFoundException) {
+            Timber.w("Downloaded file MISSING (FileNotFound) for uri=$uriString; will stream")
+            false
+        } catch (e: Exception) {
+            Timber.w(e, "Transient error probing downloaded file $uriString; treating as present")
+            true
+        }
+
     private fun createDataSourceFactory(): DataSource.Factory {
         return ResolvingDataSource.Factory(createCacheDataSource()) { dataSpec ->
             val mediaId = dataSpec.key ?: error("No media id")
@@ -1398,9 +1417,14 @@ class MusicService :
                 database.song(mediaId).first()
             }
 
-            if (song?.song?.mediaStoreUri != null && dataSpec.position == 0L) {
+            // A downloaded song plays from its local MediaStore file (only at position 0, so we don't
+            // switch sources mid-stream when a download finishes during playback). If that file is
+            // genuinely gone, fall through to streaming instead of crashing with ENOENT — but DON'T
+            // delete the download flag (the file may reappear, e.g. an unmounted SD card).
+            val mediaStoreUri = song?.song?.mediaStoreUri
+            if (mediaStoreUri != null && dataSpec.position == 0L && downloadedFileOpens(mediaStoreUri)) {
                 scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
-                return@Factory dataSpec.withUri(song.song.mediaStoreUri.toUri())
+                return@Factory dataSpec.withUri(mediaStoreUri.toUri())
             }
 
             if (downloadCache.isCached(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt
@@ -92,15 +92,22 @@ fun <E> ChipsRow(
                 onClick = { onValueUpdate(value) },
                 shape = RoundedCornerShape(16.dp),
                 border = null,
-                modifier = (if (index == 0 && firstChipFocusRequester != null) {
-                    Modifier.focusRequester(firstChipFocusRequester)
-                        .focusProperties {
-                            if (upFocusRequester != null) up = upFocusRequester
-                            if (downFocusRequester != null) down = downFocusRequester
+                modifier = Modifier
+                    // EVERY chip routes D-pad up/down to the same target, not just the first — otherwise
+                    // a chip the geometric focus search can't resolve upward from (e.g. the rightmost
+                    // "Songs" chip with nothing directly above it) stays stuck while the leftmost chips
+                    // move focus to the top bar.
+                    .focusProperties {
+                        if (upFocusRequester != null) up = upFocusRequester
+                        if (downFocusRequester != null) down = downFocusRequester
+                    }
+                    .then(
+                        if (index == 0 && firstChipFocusRequester != null) {
+                            Modifier.focusRequester(firstChipFocusRequester)
+                        } else {
+                            Modifier
                         }
-                } else {
-                    Modifier
-                })
+                    )
                     .onFocusChanged { isFocused = it.isFocused }
                     .focusable()
                     .border(width = 1.5.dp, color = borderColor, shape = RoundedCornerShape(16.dp))

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt
@@ -28,7 +28,6 @@ import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.DownloadStatus
-import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status
 
 /**
  * The UI-layer face of [DownloadStateResolver]: a tiny set of composables that EVERY download badge,
@@ -52,10 +51,7 @@ fun rememberSongDownloadStatus(song: Song): DownloadStatus =
 @Composable
 fun rememberSongDownloadProgress(songId: String, isDownloaded: Boolean): Float {
     val live by LocalDownloadUtil.current.getMediaStoreDownload(songId).collectAsState(initial = null)
-    return when {
-        isDownloaded || live?.status == Status.COMPLETED -> 1f
-        else -> (live?.progress ?: 0f).coerceIn(0f, 1f)
-    }
+    return DownloadStateResolver.songProgress(isDownloaded, live)
 }
 
 /** Aggregate status for a collection (album / playlist / multi-select), recomputed live. */

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt
@@ -1,0 +1,174 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.LocalDownloadUtil
+import com.jtech.zemer.R
+import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.playback.DownloadStateResolver
+import com.jtech.zemer.playback.DownloadStatus
+import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status
+
+/**
+ * The UI-layer face of [DownloadStateResolver]: a tiny set of composables that EVERY download badge,
+ * row and menu reads, so download/progress state can never diverge between surfaces again. Each one
+ * combines the persisted `isDownloaded` flag with the live in-session MediaStore map; none of them
+ * touch the dead legacy ExoPlayer download flow.
+ */
+
+/** One song's unified status, recomputed as its live MediaStore state changes. */
+@Composable
+fun rememberSongDownloadStatus(songId: String, isDownloaded: Boolean): DownloadStatus {
+    val live by LocalDownloadUtil.current.getMediaStoreDownload(songId).collectAsState(initial = null)
+    return DownloadStateResolver.forSong(isDownloaded, live)
+}
+
+@Composable
+fun rememberSongDownloadStatus(song: Song): DownloadStatus =
+    rememberSongDownloadStatus(song.id, song.song.isDownloaded)
+
+/** One song's live progress fraction (0..1): 1f once downloaded, else the active download's progress. */
+@Composable
+fun rememberSongDownloadProgress(songId: String, isDownloaded: Boolean): Float {
+    val live by LocalDownloadUtil.current.getMediaStoreDownload(songId).collectAsState(initial = null)
+    return when {
+        isDownloaded || live?.status == Status.COMPLETED -> 1f
+        else -> (live?.progress ?: 0f).coerceIn(0f, 1f)
+    }
+}
+
+/** Aggregate status for a collection (album / playlist / multi-select), recomputed live. */
+@Composable
+fun rememberAggregateDownloadStatus(songs: List<Song>): DownloadStatus {
+    val live by LocalDownloadUtil.current.getAllMediaStoreDownloads().collectAsState()
+    return remember(songs, live) { DownloadStateResolver.aggregateSongs(songs, live) }
+}
+
+/** Aggregate progress (0..1) for a collection, for a determinate header progress bar. */
+@Composable
+fun rememberAggregateDownloadProgress(songs: List<Song>): Float {
+    val live by LocalDownloadUtil.current.getAllMediaStoreDownloads().collectAsState()
+    return remember(songs, live) { DownloadStateResolver.aggregateProgress(songs, live) }
+}
+
+/**
+ * The one download badge: a filled "offline" check when downloaded, a progress ring (determinate when
+ * [progress] is known, indeterminate otherwise) while downloading, nothing when not downloaded.
+ */
+@Composable
+fun RowScope.DownloadStatusIcon(status: DownloadStatus, progress: Float = 0f) {
+    when (status) {
+        DownloadStatus.DOWNLOADED -> Icon(
+            painter = painterResource(R.drawable.offline),
+            contentDescription = null,
+            modifier = Modifier
+                .size(18.dp)
+                .padding(end = 2.dp),
+        )
+        DownloadStatus.DOWNLOADING -> if (progress > 0f) {
+            CircularProgressIndicator(
+                progress = { progress },
+                strokeWidth = 2.dp,
+                modifier = Modifier
+                    .size(16.dp)
+                    .padding(end = 2.dp),
+            )
+        } else {
+            CircularProgressIndicator(
+                strokeWidth = 2.dp,
+                modifier = Modifier
+                    .size(16.dp)
+                    .padding(end = 2.dp),
+            )
+        }
+        DownloadStatus.NOT_DOWNLOADED -> Unit
+    }
+}
+
+/**
+ * Convenience badge for a song row: observes the song's live state and renders the unified
+ * [DownloadStatusIcon] with live progress. The default badge for every song list/grid row.
+ */
+@Composable
+fun RowScope.SongDownloadBadge(songId: String, isDownloaded: Boolean) {
+    val status = rememberSongDownloadStatus(songId, isDownloaded)
+    val progress = rememberSongDownloadProgress(songId, isDownloaded)
+    DownloadStatusIcon(status, progress)
+}
+
+/**
+ * THE aggregate download action button for an album / playlist header (Download → live progress ring →
+ * Remove), shared by every screen header so look, behaviour and D-pad focus border can't drift. Reads
+ * the unified [rememberAggregateDownloadStatus]; tapping while downloading runs [onCancelAll] (defaults
+ * to [onRemoveAll]). Carries the standard focus-border treatment so it stays D-pad navigable.
+ */
+@Composable
+fun AggregateDownloadButton(
+    songs: List<Song>,
+    onDownloadAll: () -> Unit,
+    onRemoveAll: () -> Unit,
+    modifier: Modifier = Modifier,
+    onCancelAll: () -> Unit = onRemoveAll,
+) {
+    val status = rememberAggregateDownloadStatus(songs)
+    val progress = rememberAggregateDownloadProgress(songs)
+    val focused = remember { mutableStateOf(false) }
+    val borderColor by animateColorAsState(
+        targetValue = if (focused.value) MaterialTheme.colorScheme.primary else Color.Transparent,
+        label = "download_button_focus_border",
+    )
+    androidx.compose.foundation.layout.Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .border(3.dp, borderColor, RoundedCornerShape(8.dp))
+            .focusable()
+            .onFocusChanged { focused.value = it.isFocused },
+    ) {
+        when (status) {
+            DownloadStatus.DOWNLOADED -> IconButton(onClick = onRemoveAll) {
+                Icon(
+                    painter = painterResource(R.drawable.offline),
+                    contentDescription = stringResource(R.string.remove_download),
+                )
+            }
+            DownloadStatus.DOWNLOADING -> IconButton(onClick = onCancelAll) {
+                if (progress > 0f) {
+                    CircularProgressIndicator(
+                        progress = { progress },
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(24.dp),
+                    )
+                } else {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(24.dp))
+                }
+            }
+            DownloadStatus.NOT_DOWNLOADED -> IconButton(onClick = onDownloadAll) {
+                Icon(
+                    painter = painterResource(R.drawable.download),
+                    contentDescription = stringResource(R.string.action_download),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -33,7 +32,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.media3.exoplayer.offline.Download
 import com.jtech.zemer.R
 import com.jtech.zemer.utils.makeTimeString
 
@@ -116,43 +114,6 @@ fun LazyGridScope.GridMenuItem(
     }
 }
 
-
-fun LazyGridScope.DownloadGridMenu(
-    @Download.State state: Int?,
-    onRemoveDownload: () -> Unit,
-    onDownload: () -> Unit,
-) {
-    when (state) {
-        Download.STATE_COMPLETED -> {
-            GridMenuItem(
-                icon = R.drawable.offline,
-                title = R.string.remove_download,
-                onClick = onRemoveDownload
-            )
-        }
-
-        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-            GridMenuItem(
-                icon = {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp
-                    )
-                },
-                title = R.string.downloading,
-                onClick = onRemoveDownload
-            )
-        }
-
-        else -> {
-            GridMenuItem(
-                icon = R.drawable.download,
-                title = R.string.action_download,
-                onClick = onDownload
-            )
-        }
-    }
-}
 
 fun LazyGridScope.SleepTimerGridMenu(
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -49,7 +49,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -76,10 +75,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.zIndex
 import androidx.media3.common.MediaItem
-import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.Download.STATE_COMPLETED
-import androidx.media3.exoplayer.offline.Download.STATE_DOWNLOADING
-import androidx.media3.exoplayer.offline.Download.STATE_QUEUED
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import com.jtech.zemer.LocalDatabase
@@ -304,14 +299,7 @@ fun SongListItem(
             Icon.Library()
         }
         if (showDownloadIcon) {
-            // Check database for downloaded status (persisted) or live download state (in-progress)
-            if (song.song.isDownloaded) {
-                Icon.Download(com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED)
-            } else {
-                val downloadState by LocalDownloadUtil.current.getMediaStoreDownload(song.id)
-                    .collectAsState(initial = null)
-                Icon.Download(downloadState?.status)
-            }
+            SongDownloadBadge(song.id, song.song.isDownloaded)
         }
     },
     isSelected: Boolean = false,
@@ -374,13 +362,7 @@ fun SongGridItem(
             Icon.Library()
         }
         if (showDownloadIcon) {
-            // Check database for downloaded status (persisted) or live download state (in-progress)
-            if (song.song.isDownloaded) {
-                Icon.Download(com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED)
-            } else {
-                val downloadState by LocalDownloadUtil.current.getMediaStoreDownload(song.id).collectAsState(initial = null)
-                Icon.Download(downloadState?.status)
-            }
+            SongDownloadBadge(song.id, song.song.isDownloaded)
         }
     },
     isActive: Boolean = false,
@@ -500,47 +482,43 @@ fun ArtistGridItem(
     modifier = modifier
 )
 
+/**
+ * The standard library badges for an album row — bookmarked / explicit / aggregate download state
+ * (downloaded when every track is, downloading when any is). Single source of truth shared by the
+ * library album rows and any other surface that renders an album (e.g. the Latest Releases rows).
+ */
+@Composable
+fun RowScope.AlbumBadges(
+    album: Album,
+    showLikedIcon: Boolean = true,
+) {
+    val database = LocalDatabase.current
+
+    val songs by produceState(initialValue = emptyList(), album.id) {
+        withContext(Dispatchers.IO) {
+            value = database.albumSongs(album.id).first()
+        }
+    }
+
+    val downloadStatus = rememberAggregateDownloadStatus(songs)
+    val downloadProgress = rememberAggregateDownloadProgress(songs)
+
+    if (showLikedIcon && album.album.bookmarkedAt != null) {
+        Icon.Favorite()
+    }
+    if (album.album.explicit) {
+        Icon.Explicit()
+    }
+    DownloadStatusIcon(downloadStatus, downloadProgress)
+}
+
 @Composable
 fun AlbumListItem(
     album: Album,
     modifier: Modifier = Modifier,
     showLikedIcon: Boolean = true,
-    @SuppressLint("AutoboxingStateCreation") badges: @Composable RowScope.() -> Unit = {
-        val downloadUtil = LocalDownloadUtil.current
-        val database = LocalDatabase.current
-
-        val songs by produceState(initialValue = emptyList(), album.id) {
-            withContext(Dispatchers.IO) {
-                value = database.albumSongs(album.id).first()
-            }
-        }
-
-        val allMediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
-
-        val downloadState by remember(songs, allMediaStoreDownloads) {
-            mutableStateOf(
-                if (songs.isEmpty()) {
-                    Download.STATE_STOPPED
-                } else {
-                    when {
-                        songs.all { allMediaStoreDownloads[it.id]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED } -> STATE_COMPLETED
-                        songs.any { allMediaStoreDownloads[it.id]?.status in listOf(
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING
-                        ) } -> STATE_DOWNLOADING
-                        else -> Download.STATE_STOPPED
-                    }
-                }
-            )
-        }
-
-        if (showLikedIcon && album.album.bookmarkedAt != null) {
-            Icon.Favorite()
-        }
-        if (album.album.explicit) {
-            Icon.Explicit()
-        }
-        Icon.Download(downloadState)
+    badges: @Composable RowScope.() -> Unit = {
+        AlbumBadges(album = album, showLikedIcon = showLikedIcon)
     },
     isActive: Boolean = false,
     isPlaying: Boolean = false,
@@ -572,7 +550,6 @@ fun AlbumGridItem(
     modifier: Modifier = Modifier,
     coroutineScope: CoroutineScope,
     badges: @Composable RowScope.() -> Unit = {
-        val downloadUtil = LocalDownloadUtil.current
         val database = LocalDatabase.current
 
         val songs by produceState(initialValue = emptyList(), album.id) {
@@ -581,24 +558,8 @@ fun AlbumGridItem(
             }
         }
 
-        val allMediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
-
-        val downloadState by remember(songs, allMediaStoreDownloads) {
-            mutableIntStateOf(
-                if (songs.isEmpty()) {
-                    Download.STATE_STOPPED
-                } else {
-                    when {
-                        songs.all { allMediaStoreDownloads[it.id]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED } -> STATE_COMPLETED
-                        songs.any { allMediaStoreDownloads[it.id]?.status in listOf(
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING
-                        ) } -> STATE_DOWNLOADING
-                        else -> Download.STATE_STOPPED
-                    }
-                }
-            )
-        }
+        val downloadStatus = rememberAggregateDownloadStatus(songs)
+        val downloadProgress = rememberAggregateDownloadProgress(songs)
 
         if (album.album.bookmarkedAt != null) {
             Icon.Favorite()
@@ -606,7 +567,7 @@ fun AlbumGridItem(
         if (album.album.explicit) {
             Icon.Explicit()
         }
-        Icon.Download(downloadState)
+        DownloadStatusIcon(downloadStatus, downloadProgress)
     },
     isActive: Boolean = false,
     isPlaying: Boolean = false,
@@ -847,6 +808,11 @@ fun YouTubeListItem(
         val album by produceState<Album?>(initialValue = null, item.id) {
             if (item is AlbumItem) value = database.album(item.id).firstOrNull()
         }
+        val albumSongs by produceState(initialValue = emptyList<Song>(), item.id) {
+            if (item is AlbumItem) withContext(Dispatchers.IO) {
+                value = database.albumSongs(item.id).first()
+            }
+        }
 
         if ((item is SongItem && song?.song?.liked == true) ||
             (item is AlbumItem && album?.album?.bookmarkedAt != null)
@@ -857,9 +823,13 @@ fun YouTubeListItem(
         if (item is SongItem && song?.song?.inLibrary != null) {
             Icon.Library()
         }
-        if (item is SongItem) {
-            val download by LocalDownloadUtil.current.getDownload(item.id).collectAsState(null)
-            Icon.Download(download?.state)
+        when (item) {
+            is SongItem -> SongDownloadBadge(item.id, song?.song?.isDownloaded == true)
+            is AlbumItem -> DownloadStatusIcon(
+                rememberAggregateDownloadStatus(albumSongs),
+                rememberAggregateDownloadProgress(albumSongs),
+            )
+            else -> Unit
         }
     },
 ) {
@@ -923,6 +893,11 @@ fun YouTubeGridItem(
         val album by produceState<Album?>(initialValue = null, item.id) {
             if (item is AlbumItem) value = database.album(item.id).firstOrNull()
         }
+        val albumSongs by produceState(initialValue = emptyList<Song>(), item.id) {
+            if (item is AlbumItem) withContext(Dispatchers.IO) {
+                value = database.albumSongs(item.id).first()
+            }
+        }
 
         if (item is SongItem && song?.song?.liked == true ||
             item is AlbumItem && album?.album?.bookmarkedAt != null
@@ -931,9 +906,13 @@ fun YouTubeGridItem(
         }
         if (item.explicit) Icon.Explicit()
         if (item is SongItem && song?.song?.inLibrary != null) Icon.Library()
-        if (item is SongItem) {
-            val download by LocalDownloadUtil.current.getDownload(item.id).collectAsState(null)
-            Icon.Download(download?.state)
+        when (item) {
+            is SongItem -> SongDownloadBadge(item.id, song?.song?.isDownloaded == true)
+            is AlbumItem -> DownloadStatusIcon(
+                rememberAggregateDownloadStatus(albumSongs),
+                rememberAggregateDownloadProgress(albumSongs),
+            )
+            else -> Unit
         }
     },
     thumbnailRatio: Float = if (item is SongItem) 16f / 9 else 1f,
@@ -1576,46 +1555,8 @@ private object Icon {
         )
     }
 
-    @Composable
-    fun Download(state: Int?) {
-        when (state) {
-            STATE_COMPLETED -> Icon(
-                painter = painterResource(R.drawable.offline),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(18.dp)
-                    .padding(end = 2.dp)
-            )
-            STATE_QUEUED, STATE_DOWNLOADING -> CircularProgressIndicator(
-                strokeWidth = 2.dp,
-                modifier = Modifier
-                    .size(16.dp)
-                    .padding(end = 2.dp)
-            )
-            else -> { /* no icon */ }
-        }
-    }
-
-    @Composable
-    fun Download(status: com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status?) {
-        when (status) {
-            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> Icon(
-                painter = painterResource(R.drawable.offline),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(18.dp)
-                    .padding(end = 2.dp)
-            )
-            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING -> CircularProgressIndicator(
-                strokeWidth = 2.dp,
-                modifier = Modifier
-                    .size(16.dp)
-                    .padding(end = 2.dp)
-            )
-            else -> { /* no icon */ }
-        }
-    }
+    // Download badge lives in DownloadStatusUi.kt (DownloadStatusIcon / SongDownloadBadge) — the one
+    // place download/progress state is rendered, so it can't drift between surfaces.
 
     @Composable
     fun Explicit() {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt
@@ -1,0 +1,77 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.jtech.zemer.R
+import com.jtech.zemer.ui.utils.ItemWrapper
+
+/**
+ * THE select-mode top-bar action cluster, shared by every screen that supports multi-select (library
+ * songs/videos, the playlist screens, album, etc.) so the close / count / select-all / overflow row
+ * is identical everywhere and can't drift. Drop it inside the screen's `TopAppBar` title `Row` for the
+ * `selection == true` branch.
+ *
+ * The screen keeps owning its selection state ([wrapped] is its `List<ItemWrapper<T>>`); this only
+ * renders the actions. [countLabel] formats the selected count (e.g. `n_song` vs `n_video` plural),
+ * [onExit] leaves selection mode, and [onMore] opens the screen's selection menu with the chosen items.
+ */
+@Composable
+fun <T> RowScope.SelectionTopActions(
+    wrapped: List<ItemWrapper<T>>,
+    countLabel: @Composable (count: Int) -> String,
+    onExit: () -> Unit,
+    onMore: () -> Unit,
+) {
+    val count = wrapped.count { it.isSelected }
+    val allSelected = count == wrapped.size
+
+    IconButton(onClick = onExit) {
+        Icon(painterResource(R.drawable.close), contentDescription = null)
+    }
+    Text(
+        text = countLabel(count),
+        modifier = Modifier.weight(1f),
+    )
+    IconButton(
+        onClick = { wrapped.forEach { it.isSelected = !allSelected } },
+    ) {
+        Icon(
+            painterResource(if (allSelected) R.drawable.deselect else R.drawable.select_all),
+            contentDescription = null,
+        )
+    }
+    IconButton(onClick = onMore) {
+        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
+    }
+}
+
+/**
+ * The select-all/deselect + overflow pair for the `actions` slot of a `TopAppBar`-based select mode
+ * (the playlist screens, downloaded videos, …). Those screens keep their own `navigationIcon` (close,
+ * with per-screen long-press/search behaviour) and `title` (the count); only this action pair is
+ * identical, so it lives here. [onMore] opens the screen's selection menu with the chosen items.
+ */
+@Composable
+fun <T> RowScope.SelectionActions(
+    wrapped: List<ItemWrapper<T>>,
+    onMore: () -> Unit,
+) {
+    val count = wrapped.count { it.isSelected }
+    val allSelected = count == wrapped.size
+    IconButton(
+        onClick = { wrapped.forEach { it.isSelected = !allSelected } },
+    ) {
+        Icon(
+            painterResource(if (allSelected) R.drawable.deselect else R.drawable.select_all),
+            contentDescription = null,
+        )
+    }
+    IconButton(onClick = onMore) {
+        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
@@ -311,12 +311,8 @@ fun AlbumMenu(
                     )
                     val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
                     val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
-                    val anyFailed = songs.any {
-                        mediaStoreDownloads[it.id]?.status ==
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
-                    }
                     downloadMenuItem(
-                        kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                        kind = DownloadMenuLogic.collectionRow(dlStatus),
                         progress = dlProgress,
                         onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
                         onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -47,6 +46,8 @@ import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Album
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.AlbumListItem
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
@@ -88,31 +89,7 @@ fun AlbumMenu(
         }
     }
 
-    var mediaStoreDownloadState by remember {
-        mutableStateOf<AlbumMediaStoreDownloadStatus>(AlbumMediaStoreDownloadStatus.NotDownloaded)
-    }
-
-    LaunchedEffect(songs) {
-        if (songs.isEmpty()) return@LaunchedEffect
-        downloadUtil.getAllMediaStoreDownloads().collect { states ->
-            val songStates = songs.mapNotNull { states[it.id] }
-            mediaStoreDownloadState = when {
-                songStates.isEmpty() -> AlbumMediaStoreDownloadStatus.NotDownloaded
-                songStates.all { it.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED } ->
-                    AlbumMediaStoreDownloadStatus.Completed
-                songStates.any {
-                    it.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING ||
-                    it.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED
-                } -> {
-                    val totalProgress = songStates.sumOf { it.progress.toDouble() } / songs.size
-                    AlbumMediaStoreDownloadStatus.Downloading(totalProgress.toFloat())
-                }
-                songStates.any { it.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED } ->
-                    AlbumMediaStoreDownloadStatus.Failed
-                else -> AlbumMediaStoreDownloadStatus.NotDownloaded
-            }
-        }
-    }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
 
     var refetchIconDegree by remember { mutableFloatStateOf(0f) }
 
@@ -332,72 +309,20 @@ fun AlbumMenu(
                             onClick = { showChoosePlaylistDialog = true },
                         )
                     )
-                    add(
-                        when (mediaStoreDownloadState) {
-                            is AlbumMediaStoreDownloadStatus.Completed ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            text = stringResource(R.string.downloaded_to_device),
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
-                                    },
-                                    onClick = {
-                                        // TODO: Option to remove from MediaStore
-                                        onDismiss()
-                                    },
-                                )
-                            is AlbumMediaStoreDownloadStatus.Downloading -> {
-                                val progress = (mediaStoreDownloadState as AlbumMediaStoreDownloadStatus.Downloading).progress
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            progress = { progress },
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp
-                                        )
-                                    },
-                                    title = { Text(text = stringResource(R.string.downloading_to_device)) },
-                                    description = { Text(text = "${(progress * 100).toInt()}%") },
-                                    onClick = {
-                                        songs.forEach { song ->
-                                            downloadUtil.cancelMediaStoreDownload(song.id)
-                                        }
-                                        onDismiss()
-                                    },
-                                )
-                            }
-                            is AlbumMediaStoreDownloadStatus.Failed ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.info), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            text = stringResource(R.string.download_failed),
-                                            color = MaterialTheme.colorScheme.error
-                                        )
-                                    },
-                                    description = { Text(text = stringResource(R.string.retry_download)) },
-                                    onClick = {
-                                        songs.forEach { song ->
-                                            downloadUtil.retryMediaStoreDownload(song.id)
-                                        }
-                                        onDismiss()
-                                    },
-                                )
-                            AlbumMediaStoreDownloadStatus.NotDownloaded ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = { Text(text = stringResource(R.string.download_to_device)) },
-                                    onClick = {
-                                        songs.forEach { song ->
-                                            downloadUtil.downloadToMediaStore(song)
-                                        }
-                                        onDismiss()
-                                    },
-                                )
-                        }
-                    )
+                    val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
+                    val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
+                    val anyFailed = songs.any {
+                        mediaStoreDownloads[it.id]?.status ==
+                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
+                    }
+                    downloadMenuItem(
+                        kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                        progress = dlProgress,
+                        onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
+                        onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                        onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                        onRemove = { coroutineScope.launch { songs.forEach { downloadUtil.removeDownload(it.id) } } },
+                    )?.let { add(it) }
                     add(
                         Material3MenuItemData(
                             icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },
@@ -441,11 +366,4 @@ fun AlbumMenu(
         }
 
     }
-}
-
-private sealed class AlbumMediaStoreDownloadStatus {
-    object NotDownloaded : AlbumMediaStoreDownloadStatus()
-    object Completed : AlbumMediaStoreDownloadStatus()
-    data class Downloading(val progress: Float) : AlbumMediaStoreDownloadStatus()
-    object Failed : AlbumMediaStoreDownloadStatus()
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItems.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItems.kt
@@ -1,0 +1,71 @@
+package com.jtech.zemer.ui.menu
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+import com.jtech.zemer.playback.DownloadRowKind
+import com.jtech.zemer.ui.component.Material3MenuItemData
+
+/**
+ * THE download row for every Material3 item/collection menu. One builder means identical icon, label,
+ * progress display and — crucially — identical behaviour: tapping a download row NEVER dismisses the
+ * menu, so the row animates straight from "Download" → live progress ring + "%" → "Remove download"
+ * while the sheet stays open. (This is the fix for the old inconsistency where some menus dismissed on
+ * download and some didn't.) Pass the [DownloadRowKind] decided by
+ * [com.jtech.zemer.playback.DownloadMenuLogic]; [progress] is the 0..1 fraction for the DOWNLOADING
+ * ring. Returns null for [DownloadRowKind.HIDDEN] so callers can `?.let(::add)`.
+ */
+fun downloadMenuItem(
+    kind: DownloadRowKind,
+    progress: Float = 0f,
+    error: String? = null,
+    onDownload: () -> Unit = {},
+    onCancel: () -> Unit = {},
+    onRetry: () -> Unit = {},
+    onRemove: () -> Unit = {},
+): Material3MenuItemData? {
+    val pct = progress.coerceIn(0f, 1f)
+    return when (kind) {
+        DownloadRowKind.HIDDEN -> null
+        DownloadRowKind.REMOVE -> Material3MenuItemData(
+            icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
+            title = { Text(stringResource(R.string.remove_download), color = MaterialTheme.colorScheme.error) },
+            onClick = onRemove,
+        )
+        DownloadRowKind.DOWNLOADING -> Material3MenuItemData(
+            icon = {
+                CircularProgressIndicator(
+                    progress = { pct },
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
+            },
+            title = { Text(stringResource(R.string.downloading_to_device)) },
+            description = { Text("${(pct * 100).toInt()}%") },
+            onClick = onCancel,
+        )
+        DownloadRowKind.FAILED -> Material3MenuItemData(
+            icon = { Icon(painterResource(R.drawable.info), null, Modifier.size(24.dp)) },
+            title = { Text(stringResource(R.string.download_failed), color = MaterialTheme.colorScheme.error) },
+            description = { Text(error ?: stringResource(R.string.retry_download)) },
+            onClick = onRetry,
+        )
+        DownloadRowKind.DOWNLOAD_VIDEO -> Material3MenuItemData(
+            icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
+            title = { Text(stringResource(R.string.download_video_to_device)) },
+            onClick = onDownload,
+        )
+        DownloadRowKind.DOWNLOAD -> Material3MenuItemData(
+            icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
+            title = { Text(stringResource(R.string.download_to_device)) },
+            onClick = onDownload,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/LibraryMenuItems.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/LibraryMenuItems.kt
@@ -1,0 +1,34 @@
+package com.jtech.zemer.ui.menu
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.Material3MenuItemData
+
+/**
+ * THE Add/Remove-from-library menu row, shared by every item/collection menu so the icon and label
+ * can't drift between surfaces. `inLibrary` is derived from the single source of truth
+ * (`SongEntity.inLibrary != null`); the caller's [onToggle] performs the DB write and gates the remote
+ * library-feedback call on a personal account (anonymous = local-only, per the pooled-account rule).
+ */
+fun libraryMenuItem(
+    inLibrary: Boolean,
+    onToggle: () -> Unit,
+): Material3MenuItemData = Material3MenuItemData(
+    icon = {
+        Icon(
+            painterResource(if (inLibrary) R.drawable.library_add_check else R.drawable.library_add),
+            null,
+            Modifier.size(24.dp),
+        )
+    },
+    title = {
+        Text(stringResource(if (inLibrary) R.string.remove_from_library else R.string.add_to_library))
+    },
+    onClick = onToggle,
+)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -45,14 +44,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.PlaybackParameters
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalDownloadUtil
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
+import com.jtech.zemer.constants.BlockVideosKey
 import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.BigSeekBar
@@ -63,6 +64,7 @@ import com.jtech.zemer.ui.component.NewAction
 import com.jtech.zemer.ui.component.NewActionGrid
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
+import com.jtech.zemer.utils.rememberPreference
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -93,8 +95,9 @@ fun PlayerMenu(
     val mediaStoreDownload by downloadUtil.getMediaStoreDownload(mediaMetadata.id)
         .collectAsState(initial = null)
 
-    val download by downloadUtil.getDownload(mediaMetadata.id)
-        .collectAsState(initial = null)
+    val librarySong by database.song(mediaMetadata.id).collectAsState(initial = null)
+
+    val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
 
     val artists =
         remember(mediaMetadata.artists) {
@@ -297,58 +300,35 @@ fun PlayerMenu(
                             )
                         )
                     }
-                    add(
-                        when (mediaStoreDownload?.status) {
-                            MediaStoreDownloadManager.DownloadState.Status.COMPLETED ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                    title = { Text(stringResource(R.string.remove_download), color = MaterialTheme.colorScheme.error) },
-                                    onClick = { coroutineScope.launch { downloadUtil.removeDownload(mediaMetadata.id) } },
-                                )
-                            MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-                            MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING -> {
-                                val progress = mediaStoreDownload?.progress ?: 0f
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            progress = { progress.coerceIn(0f, 1f) },
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    description = { Text("${(progress * 100).toInt()}%") },
-                                    onClick = { coroutineScope.launch { downloadUtil.cancelMediaStoreDownload(mediaMetadata.id) } },
-                                )
+                    // Unified download row: persisted-or-live state, live progress, video-aware, and the
+                    // menu stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
+                    val songIsVideo = librarySong?.song?.isVideo == true || mediaMetadata.isVideo
+                    val downloadStatus = DownloadStateResolver.forSong(librarySong?.song?.isDownloaded == true, mediaStoreDownload)
+                    val downloadProgress = when {
+                        librarySong?.song?.isDownloaded == true ||
+                            mediaStoreDownload?.status == MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> 1f
+                        else -> mediaStoreDownload?.progress ?: 0f
+                    }
+                    val downloadFailed =
+                        mediaStoreDownload?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
+                    downloadMenuItem(
+                        kind = DownloadMenuLogic.songRow(downloadStatus, downloadFailed, songIsVideo, blockVideos),
+                        progress = downloadProgress,
+                        error = mediaStoreDownload?.error,
+                        onDownload = {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                database.transaction { insert(mediaMetadata) }
+                                val song = database.song(mediaMetadata.id).first()
+                                song?.let {
+                                    if (songIsVideo) downloadUtil.downloadVideoToMediaStore(it)
+                                    else downloadUtil.downloadToMediaStore(it)
+                                }
                             }
-                            else -> when (download?.state) {
-                                Download.STATE_COMPLETED ->
-                                    Material3MenuItemData(
-                                        icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                        title = { Text(stringResource(R.string.remove_download), color = MaterialTheme.colorScheme.error) },
-                                        onClick = { coroutineScope.launch { downloadUtil.removeDownload(mediaMetadata.id) } },
-                                    )
-                                Download.STATE_QUEUED, Download.STATE_DOWNLOADING ->
-                                    Material3MenuItemData(
-                                        icon = { CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp) },
-                                        title = { Text(stringResource(R.string.downloading)) },
-                                        onClick = { coroutineScope.launch { downloadUtil.removeDownload(mediaMetadata.id) } },
-                                    )
-                                else ->
-                                    Material3MenuItemData(
-                                        icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                        title = { Text(stringResource(R.string.action_download)) },
-                                        onClick = {
-                                            coroutineScope.launch(Dispatchers.IO) {
-                                                database.transaction { insert(mediaMetadata) }
-                                                val song = database.song(mediaMetadata.id).first()
-                                                song?.let { downloadUtil.downloadToMediaStore(it) }
-                                            }
-                                        },
-                                    )
-                            }
-                        }
-                    )
+                        },
+                        onCancel = { coroutineScope.launch { downloadUtil.cancelMediaStoreDownload(mediaMetadata.id) } },
+                        onRetry = { downloadUtil.retryMediaStoreDownload(mediaMetadata.id) },
+                        onRemove = { coroutineScope.launch { downloadUtil.removeDownload(mediaMetadata.id) } },
+                    )?.let { add(it) }
                     add(
                         Material3MenuItemData(
                             icon = { Icon(painterResource(R.drawable.info), null, Modifier.size(24.dp)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt
@@ -211,12 +211,8 @@ fun PlaylistMenu(
                     run {
                         val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
                         val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
-                        val anyFailed = songs.any {
-                            mediaStoreDownloads[it.id]?.status ==
-                                MediaStoreDownloadManager.DownloadState.Status.FAILED
-                        }
                         downloadMenuItem(
-                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            kind = DownloadMenuLogic.collectionRow(dlStatus),
                             progress = dlProgress,
                             onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
                             onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,6 +39,10 @@ import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.PlaylistSong
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
+import kotlinx.coroutines.launch
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
+import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
@@ -62,6 +67,8 @@ fun PlaylistMenu(
     val dbPlaylist by database.playlist(playlist.id).collectAsState(initial = playlist)
     var songs by remember { mutableStateOf(emptyList<Song>()) }
     var showReportDialog by remember { mutableStateOf(false) }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
+    val downloadScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         if (autoPlaylist == false) {
@@ -201,6 +208,22 @@ fun PlaylistMenu(
                             },
                         )
                     )
+                    run {
+                        val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
+                        val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
+                        val anyFailed = songs.any {
+                            mediaStoreDownloads[it.id]?.status ==
+                                MediaStoreDownloadManager.DownloadState.Status.FAILED
+                        }
+                        downloadMenuItem(
+                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            progress = dlProgress,
+                            onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
+                            onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                            onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                            onRemove = { downloadScope.launch { songs.forEach { downloadUtil.removeDownload(it.id) } } },
+                        )?.let { add(it) }
+                    }
                     add(
                         Material3MenuItemData(
                             icon = { Icon(painterResource(R.drawable.warning), null, Modifier.size(24.dp)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
@@ -316,11 +316,8 @@ fun SelectionSongMenu(
                     run {
                         val dlStatus = DownloadStateResolver.aggregateSongs(songSelection, mediaStoreDownloads)
                         val dlProgress = DownloadStateResolver.aggregateProgress(songSelection, mediaStoreDownloads)
-                        val anyFailed = songSelection.any {
-                            mediaStoreDownloads[it.id]?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
-                        }
                         downloadMenuItem(
-                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            kind = DownloadMenuLogic.collectionRow(dlStatus),
                             progress = dlProgress,
                             onDownload = { songSelection.forEach { downloadUtil.downloadToMediaStore(it) } },
                             onCancel = { songSelection.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
@@ -552,19 +549,26 @@ fun SelectionMediaMetadataMenu(
                     // Unified download row: aggregate over the persisted Room rows + live progress,
                     // menu stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
                     run {
-                        val dlStatus = DownloadStateResolver.aggregateSongs(dbSongs, mediaStoreDownloads)
-                        val dlProgress = DownloadStateResolver.aggregateProgress(dbSongs, mediaStoreDownloads)
-                        val anyFailed = songSelection.any {
-                            mediaStoreDownloads[it.id]?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
-                        }
+                        // Aggregate over EVERY selected id off the live map (+ the persisted-downloaded
+                        // snapshot), not just the rows already in Room — otherwise online songs not yet
+                        // in the DB are invisible to the all/any check and the status reads wrong.
+                        val ids = songSelection.map { it.id }
+                        val persistedDownloaded = dbSongs.filter { it.song.isDownloaded }.map { it.id }.toSet()
+                        val dlStatus = DownloadStateResolver.aggregateByIds(ids, mediaStoreDownloads, persistedDownloaded)
+                        val dlProgress = DownloadStateResolver.aggregateProgressByIds(ids, mediaStoreDownloads, persistedDownloaded)
                         downloadMenuItem(
-                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            kind = DownloadMenuLogic.collectionRow(dlStatus),
                             progress = dlProgress,
                             onDownload = {
+                                // Online MediaMetadata aren't Room entities yet — persist each, then
+                                // download, so the first tap downloads (a bare database.song() lookup
+                                // returns null for a not-yet-persisted id and silently does nothing).
                                 coroutineScope.launch(Dispatchers.IO) {
                                     songSelection.forEach { mediaMetadata ->
-                                        val song = database.song(mediaMetadata.id).first()
-                                        song?.let { downloadUtil.downloadToMediaStore(it) }
+                                        database.transaction { insert(mediaMetadata) }
+                                        database.song(mediaMetadata.id).first()?.let {
+                                            downloadUtil.downloadToMediaStore(it)
+                                        }
                                     }
                                 }
                             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
@@ -8,16 +8,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -29,7 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
-import androidx.media3.exoplayer.offline.Download
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalDownloadUtil
 import com.jtech.zemer.LocalPlayerConnection
@@ -41,8 +38,10 @@ import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
+import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.playback.queues.ListQueue
-import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
 import com.jtech.zemer.ui.component.NewAction
@@ -89,28 +88,7 @@ fun SelectionSongMenu(
         )
     }
 
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
-
-    LaunchedEffect(songSelection) {
-        if (songSelection.isEmpty()) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songSelection.all { downloads[it.id]?.state == Download.STATE_COMPLETED }) {
-                    Download.STATE_COMPLETED
-                } else if (songSelection.all {
-                        downloads[it.id]?.state == Download.STATE_QUEUED ||
-                                downloads[it.id]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it.id]?.state == Download.STATE_COMPLETED
-                    }
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
-        }
-    }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
 
     var showChoosePlaylistDialog by rememberSaveable {
         mutableStateOf(false)
@@ -135,45 +113,6 @@ fun SelectionSongMenu(
             showChoosePlaylistDialog = false
         },
     )
-
-    var showRemoveDownloadDialog by remember {
-        mutableStateOf(false)
-    }
-
-    if (showRemoveDownloadDialog) {
-        DefaultDialog(
-            onDismiss = { showRemoveDownloadDialog = false },
-            content = {
-                Text(
-                    text = stringResource(R.string.remove_download_playlist_confirm, "selection"),
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 18.dp),
-                )
-            },
-            buttons = {
-                TextButton(
-                    onClick = {
-                        showRemoveDownloadDialog = false
-                    },
-                ) {
-                    Text(text = stringResource(android.R.string.cancel))
-                }
-
-                TextButton(
-                    onClick = {
-                        showRemoveDownloadDialog = false
-                        songSelection.forEach { song ->
-                            coroutineScope.launch {
-                                downloadUtil.removeDownload(song.song.id)
-                            }
-                        }
-                    },
-                ) {
-                    Text(text = stringResource(android.R.string.ok))
-                }
-            },
-        )
-    }
 
     val reportTarget = targetSong
     if (showReportDialog && reportTarget != null) {
@@ -387,42 +326,27 @@ fun SelectionSongMenu(
                             },
                         )
                     )
-                    add(
-                        when (downloadState) {
-                            Download.STATE_COMPLETED ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            stringResource(R.string.remove_download),
-                                            color = MaterialTheme.colorScheme.error,
-                                        )
-                                    },
-                                    onClick = { showRemoveDownloadDialog = true },
-                                )
-                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING ->
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    onClick = { showRemoveDownloadDialog = true },
-                                )
-                            else ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = { Text(stringResource(R.string.action_download)) },
-                                    onClick = {
-                                        songSelection.forEach { song ->
-                                            downloadUtil.downloadToMediaStore(song)
-                                        }
-                                    },
-                                )
+                    // Unified download row: persisted-or-live aggregate state + live progress, menu
+                    // stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
+                    run {
+                        val dlStatus = DownloadStateResolver.aggregateSongs(songSelection, mediaStoreDownloads)
+                        val dlProgress = DownloadStateResolver.aggregateProgress(songSelection, mediaStoreDownloads)
+                        val anyFailed = songSelection.any {
+                            mediaStoreDownloads[it.id]?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
                         }
-                    )
+                        downloadMenuItem(
+                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            progress = dlProgress,
+                            onDownload = { songSelection.forEach { downloadUtil.downloadToMediaStore(it) } },
+                            onCancel = { songSelection.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                            onRetry = { songSelection.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                            onRemove = {
+                                coroutineScope.launch {
+                                    songSelection.forEach { downloadUtil.removeDownload(it.id) }
+                                }
+                            },
+                        )?.let { add(it) }
+                    }
                     add(
                         Material3MenuItemData(
                             icon = {
@@ -519,66 +443,16 @@ fun SelectionMediaMetadataMenu(
         onDismiss = { showChoosePlaylistDialog = false }
     )
 
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
 
-    LaunchedEffect(songSelection) {
-        if (songSelection.isEmpty()) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songSelection.all { downloads[it.id]?.state == Download.STATE_COMPLETED }) {
-                    Download.STATE_COMPLETED
-                } else if (songSelection.all {
-                        downloads[it.id]?.state == Download.STATE_QUEUED ||
-                                downloads[it.id]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it.id]?.state == Download.STATE_COMPLETED
-                    }
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
-        }
-    }
-
-    var showRemoveDownloadDialog by remember {
-        mutableStateOf(false)
-    }
-
-    if (showRemoveDownloadDialog) {
-        DefaultDialog(
-            onDismiss = { showRemoveDownloadDialog = false },
-            content = {
-                Text(
-                    text = stringResource(R.string.remove_download_playlist_confirm, "selection"),
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 18.dp),
-                )
-            },
-            buttons = {
-                TextButton(
-                    onClick = {
-                        showRemoveDownloadDialog = false
-                    },
-                ) {
-                    Text(text = stringResource(android.R.string.cancel))
-                }
-
-                TextButton(
-                    onClick = {
-                        showRemoveDownloadDialog = false
-                        songSelection.forEach { song ->
-                            coroutineScope.launch {
-                                downloadUtil.removeDownload(song.id)
-                            }
-                        }
-                    },
-                ) {
-                    Text(text = stringResource(android.R.string.ok))
-                }
-            },
-        )
+    // The selection is online MediaMetadata; load the persisted Room rows so the aggregate state can
+    // honor songs downloaded in a previous session (which aren't in the live session map).
+    val selectionIds = songSelection.map { it.id }
+    val dbSongs by produceState(
+        initialValue = emptyList<com.jtech.zemer.db.entities.Song>(),
+        key1 = selectionIds,
+    ) {
+        value = database.getSongsByIds(selectionIds)
     }
 
     LazyColumn(
@@ -690,45 +564,34 @@ fun SelectionMediaMetadataMenu(
                             },
                         )
                     )
-                    add(
-                        when (downloadState) {
-                            Download.STATE_COMPLETED ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            stringResource(R.string.remove_download),
-                                            color = MaterialTheme.colorScheme.error,
-                                        )
-                                    },
-                                    onClick = { showRemoveDownloadDialog = true },
-                                )
-                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING ->
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    onClick = { showRemoveDownloadDialog = true },
-                                )
-                            else ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = { Text(stringResource(R.string.action_download)) },
-                                    onClick = {
-                                        coroutineScope.launch(Dispatchers.IO) {
-                                            songSelection.forEach { mediaMetadata ->
-                                                val song = database.song(mediaMetadata.id).first()
-                                                song?.let { downloadUtil.downloadToMediaStore(it) }
-                                            }
-                                        }
-                                    },
-                                )
+                    // Unified download row: aggregate over the persisted Room rows + live progress,
+                    // menu stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
+                    run {
+                        val dlStatus = DownloadStateResolver.aggregateSongs(dbSongs, mediaStoreDownloads)
+                        val dlProgress = DownloadStateResolver.aggregateProgress(dbSongs, mediaStoreDownloads)
+                        val anyFailed = songSelection.any {
+                            mediaStoreDownloads[it.id]?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
                         }
-                    )
+                        downloadMenuItem(
+                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            progress = dlProgress,
+                            onDownload = {
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    songSelection.forEach { mediaMetadata ->
+                                        val song = database.song(mediaMetadata.id).first()
+                                        song?.let { downloadUtil.downloadToMediaStore(it) }
+                                    }
+                                }
+                            },
+                            onCancel = { songSelection.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                            onRetry = { songSelection.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                            onRemove = {
+                                coroutineScope.launch {
+                                    songSelection.forEach { downloadUtil.removeDownload(it.id) }
+                                }
+                            },
+                        )?.let { add(it) }
+                    }
                 },
             )
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt
@@ -273,24 +273,9 @@ fun SelectionSongMenu(
                         )
                     )
                     add(
-                        Material3MenuItemData(
-                            icon = {
-                                Icon(
-                                    painterResource(
-                                        if (allInLibrary) R.drawable.library_add_check else R.drawable.library_add
-                                    ),
-                                    null,
-                                    Modifier.size(24.dp),
-                                )
-                            },
-                            title = {
-                                Text(
-                                    stringResource(
-                                        if (allInLibrary) R.string.remove_from_library else R.string.add_to_library
-                                    )
-                                )
-                            },
-                            onClick = {
+                        libraryMenuItem(
+                            inLibrary = allInLibrary,
+                            onToggle = {
                                 if (allInLibrary) {
                                     database.query {
                                         songSelection.forEach { song ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -57,6 +57,8 @@ import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
 import com.jtech.zemer.ui.component.ArtistChoice
@@ -469,95 +471,33 @@ fun SongMenu(
                             },
                         )
                     )
-                    when (mediaStoreDownload?.status) {
-                        com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> add(
-                            Material3MenuItemData(
-                                icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                title = {
-                                    Text(
-                                        stringResource(R.string.downloaded_to_device),
-                                        color = MaterialTheme.colorScheme.primary,
-                                    )
-                                },
-                                onClick = {
-                                    // TODO: Option to remove from MediaStore
-                                    onDismiss()
-                                },
-                            )
-                        )
-                        com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING,
-                        com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED -> {
-                            val downloadState = mediaStoreDownload!!
-                            add(
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            progress = { downloadState.progress },
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading_to_device)) },
-                                    description = { Text("${(downloadState.progress * 100).toInt()}%") },
-                                    onClick = {
-                                        downloadUtil.cancelMediaStoreDownload(song.id)
-                                        onDismiss()
-                                    },
-                                )
-                            )
-                        }
-                        com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED -> {
-                            val downloadState = mediaStoreDownload!!
-                            add(
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.info), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            stringResource(R.string.download_failed),
-                                            color = MaterialTheme.colorScheme.error,
-                                        )
-                                    },
-                                    description = { Text(downloadState.error ?: stringResource(R.string.error_unknown)) },
-                                    onClick = {
-                                        downloadUtil.retryMediaStoreDownload(song.id)
-                                        onDismiss()
-                                    },
-                                )
-                            )
-                        }
-                        else -> {
-                            // Check if this is a video - if so, offer video download (unless videos are blocked)
-                            val isVideo = song.song.isVideo
-
-                            // Skip showing download option for videos when blocked
-                            if (!(isVideo && blockVideos)) add(
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            if (isVideo) stringResource(R.string.download_video_to_device)
-                                            else stringResource(R.string.download_to_device)
-                                        )
-                                    },
-                                    onClick = {
-                                        // Track the user's download choice for permission callback
-                                        pendingVideoDownload = isVideo
-                                        if (PermissionHelper.hasMediaStoreWritePermission(context)) {
-                                            if (isVideo) {
-                                                downloadUtil.downloadVideoToMediaStore(song)
-                                            } else {
-                                                downloadUtil.downloadToMediaStore(song)
-                                            }
-                                            onDismiss()
-                                        } else {
-                                            val permissions = PermissionHelper.getRequiredWritePermissions()
-                                            permissionLauncher.launch(permissions)
-                                        }
-                                    },
-                                )
-                            )
-                        }
+                    // Unified download row: persisted-or-live state, live progress, video-aware, and the
+                    // menu stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
+                    val downloadStatus = DownloadStateResolver.forSong(song.song.isDownloaded, mediaStoreDownload)
+                    val downloadProgress = when {
+                        song.song.isDownloaded ||
+                            mediaStoreDownload?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> 1f
+                        else -> mediaStoreDownload?.progress ?: 0f
                     }
+                    val downloadFailed =
+                        mediaStoreDownload?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
+                    downloadMenuItem(
+                        kind = DownloadMenuLogic.songRow(downloadStatus, downloadFailed, song.song.isVideo, blockVideos),
+                        progress = downloadProgress,
+                        error = mediaStoreDownload?.error,
+                        onDownload = {
+                            pendingVideoDownload = song.song.isVideo
+                            if (PermissionHelper.hasMediaStoreWritePermission(context)) {
+                                if (song.song.isVideo) downloadUtil.downloadVideoToMediaStore(song)
+                                else downloadUtil.downloadToMediaStore(song)
+                            } else {
+                                permissionLauncher.launch(PermissionHelper.getRequiredWritePermissions())
+                            }
+                        },
+                        onCancel = { downloadUtil.cancelMediaStoreDownload(song.id) },
+                        onRetry = { downloadUtil.retryMediaStoreDownload(song.id) },
+                        onRemove = { scope.launch { downloadUtil.removeDownload(song.id) } },
+                    )?.let { add(it) }
                     add(
                         Material3MenuItemData(
                             icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -377,26 +377,9 @@ fun SongMenu(
                         )
                     )
                     add(
-                        Material3MenuItemData(
-                            icon = {
-                                Icon(
-                                    painterResource(
-                                        if (song.song.inLibrary == null) R.drawable.library_add
-                                        else R.drawable.library_add_check
-                                    ),
-                                    null,
-                                    Modifier.size(24.dp),
-                                )
-                            },
-                            title = {
-                                Text(
-                                    stringResource(
-                                        if (song.song.inLibrary == null) R.string.add_to_library
-                                        else R.string.remove_from_library
-                                    )
-                                )
-                            },
-                            onClick = {
+                        libraryMenuItem(
+                            inLibrary = song.song.inLibrary != null,
+                            onToggle = {
                                 val currentSong = song.song
                                 val isInLibrary = currentSong.inLibrary != null
                                 val token = if (isInLibrary) currentSong.libraryRemoveToken else currentSong.libraryAddToken

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -56,6 +56,7 @@ import com.jtech.zemer.utils.reportException
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -308,7 +309,21 @@ fun YouTubeAlbumMenu(
                     downloadMenuItem(
                         kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
                         progress = dlProgress,
-                        onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
+                        // Fetch-if-empty: the album loads async, so a first tap before it arrived used
+                        // to be a no-op ("press once does nothing, twice works"). Resolve the songs at
+                        // click time, fetching the album page if the DB doesn't have it yet.
+                        onDownload = {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                var toDownload = database.albumWithSongs(albumItem.id).first()?.songs.orEmpty()
+                                if (toDownload.isEmpty()) {
+                                    YouTube.album(albumItem.id)
+                                        .onSuccess { page -> database.transaction { insert(page) } }
+                                        .onFailure { reportException(it) }
+                                    toDownload = database.albumWithSongs(albumItem.id).first()?.songs.orEmpty()
+                                }
+                                toDownload.forEach { downloadUtil.downloadToMediaStore(it) }
+                            }
+                        },
                         onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
                         onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
                         onRemove = { coroutineScope.launch { songs.forEach { downloadUtil.removeDownload(it.id) } } },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -302,12 +302,8 @@ fun YouTubeAlbumMenu(
                     val songs = album?.songs.orEmpty()
                     val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
                     val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
-                    val anyFailed = songs.any {
-                        mediaStoreDownloads[it.id]?.status ==
-                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
-                    }
                     downloadMenuItem(
-                        kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                        kind = DownloadMenuLogic.collectionRow(dlStatus),
                         progress = dlProgress,
                         // Fetch-if-empty: the album loads async, so a first tap before it arrived used
                         // to be a no-op ("press once does nothing, twice works"). Resolve the songs at

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -24,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -35,7 +33,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalDownloadUtil
@@ -43,6 +40,8 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
 import com.jtech.zemer.ui.component.ArtistChoice
@@ -90,28 +89,7 @@ fun YouTubeAlbumMenu(
         }
     }
 
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
-
-    LaunchedEffect(album) {
-        val songs = album?.songs?.map { it.id } ?: return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songs.all { downloads[it]?.state == Download.STATE_COMPLETED }) {
-                    Download.STATE_COMPLETED
-                } else if (songs.all {
-                        downloads[it]?.state == Download.STATE_QUEUED ||
-                                downloads[it]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it]?.state == Download.STATE_COMPLETED
-                    }
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
-        }
-    }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
 
     var showChoosePlaylistDialog by rememberSaveable {
         mutableStateOf(false)
@@ -320,54 +298,21 @@ fun YouTubeAlbumMenu(
                             onClick = { showReportDialog = true },
                         )
                     )
-                    add(
-                        when (downloadState) {
-                            Download.STATE_COMPLETED ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            text = stringResource(R.string.remove_download),
-                                            color = MaterialTheme.colorScheme.error
-                                        )
-                                    },
-                                    onClick = {
-                                        album?.songs?.forEach { song ->
-                                            coroutineScope.launch {
-                                                downloadUtil.removeDownload(song.id)
-                                            }
-                                        }
-                                    },
-                                )
-                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING ->
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    onClick = {
-                                        album?.songs?.forEach { song ->
-                                            coroutineScope.launch {
-                                                downloadUtil.removeDownload(song.id)
-                                            }
-                                        }
-                                    },
-                                )
-                            else ->
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = { Text(stringResource(R.string.action_download)) },
-                                    onClick = {
-                                        album?.songs?.forEach { song ->
-                                            downloadUtil.downloadToMediaStore(song)
-                                        }
-                                    },
-                                )
-                        }
-                    )
+                    val songs = album?.songs.orEmpty()
+                    val dlStatus = DownloadStateResolver.aggregateSongs(songs, mediaStoreDownloads)
+                    val dlProgress = DownloadStateResolver.aggregateProgress(songs, mediaStoreDownloads)
+                    val anyFailed = songs.any {
+                        mediaStoreDownloads[it.id]?.status ==
+                            com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
+                    }
+                    downloadMenuItem(
+                        kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                        progress = dlProgress,
+                        onDownload = { songs.forEach { downloadUtil.downloadToMediaStore(it) } },
+                        onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                        onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                        onRemove = { coroutineScope.launch { songs.forEach { downloadUtil.removeDownload(it.id) } } },
+                    )?.let { add(it) }
                     albumItem.artists?.let { artists ->
                         add(
                             Material3MenuItemData(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -215,7 +215,10 @@ fun YouTubePlaylistMenu(
                 TextButton(
                     onClick = {
                         showRemoveDownloadDialog = false
-                        songs.forEach { song ->
+                        // Remove what the Download row actually downloaded — resolvedSongs, NOT the
+                        // `songs` prop (empty when opened from the Home long-press menu, which would
+                        // otherwise make Remove a silent no-op).
+                        resolvedSongs.forEach { song ->
                             coroutineScope.launch {
                                 downloadUtil.removeDownload(song.id)
                             }
@@ -421,12 +424,8 @@ fun YouTubePlaylistMenu(
                         val persistedDownloaded = dbSongs.filter { it.song.isDownloaded }.map { it.id }.toSet()
                         val dlStatus = DownloadStateResolver.aggregateByIds(ids, mediaStoreDownloads, persistedDownloaded)
                         val dlProgress = DownloadStateResolver.aggregateProgressByIds(ids, mediaStoreDownloads, persistedDownloaded)
-                        val anyFailed = ids.any {
-                            mediaStoreDownloads[it]?.status ==
-                                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
-                        }
                         downloadMenuItem(
-                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            kind = DownloadMenuLogic.collectionRow(dlStatus),
                             progress = dlProgress,
                             onDownload = {
                                 // Online SongItems aren't Room entities yet — persist each, then download.

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -24,11 +23,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -39,7 +37,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.media3.exoplayer.offline.Download
 import coil3.compose.AsyncImage
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalDownloadUtil
@@ -52,6 +49,8 @@ import com.jtech.zemer.db.entities.PlaylistSongMap
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
 import com.jtech.zemer.ui.component.DefaultDialog
@@ -178,24 +177,12 @@ fun YouTubePlaylistMenu(
     )
     HorizontalDivider()
 
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
-    LaunchedEffect(songs) {
-        if (songs.isEmpty()) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songs.all { downloads[it.id]?.state == Download.STATE_COMPLETED })
-                    Download.STATE_COMPLETED
-                else if (songs.all {
-                        downloads[it.id]?.state == Download.STATE_QUEUED
-                                || downloads[it.id]?.state == Download.STATE_DOWNLOADING
-                                || downloads[it.id]?.state == Download.STATE_COMPLETED
-                    })
-                    Download.STATE_DOWNLOADING
-                else
-                    Download.STATE_STOPPED
-        }
+    val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
+    val dbSongs by produceState(
+        initialValue = emptyList<com.jtech.zemer.db.entities.Song>(),
+        songs,
+    ) {
+        value = database.getSongsByIds(songs.map { it.id })
     }
     var showRemoveDownloadDialog by remember {
         mutableStateOf(false)
@@ -420,55 +407,32 @@ fun YouTubePlaylistMenu(
                         )
                     )
                     if (songs.isNotEmpty()) {
-                        when (downloadState) {
-                            Download.STATE_COMPLETED -> add(
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                    title = {
-                                        Text(
-                                            text = stringResource(R.string.remove_download),
-                                            color = MaterialTheme.colorScheme.error
-                                        )
-                                    },
-                                    onClick = {
-                                        showRemoveDownloadDialog = true
-                                    },
-                                )
-                            )
-                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> add(
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    onClick = {
-                                        showRemoveDownloadDialog = true
-                                    },
-                                )
-                            )
-                            else -> add(
-                                Material3MenuItemData(
-                                    icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                    title = { Text(stringResource(R.string.action_download)) },
-                                    onClick = {
-                                        coroutineScope.launch(Dispatchers.IO) {
-                                            songs.forEach { song ->
-                                                database.transaction {
-                                                    insert(song.toMediaMetadata())
-                                                }
-                                                val dbSong = database.song(song.id).first()
-                                                dbSong?.let {
-                                                    downloadUtil.downloadToMediaStore(it)
-                                                }
-                                            }
-                                        }
-                                    },
-                                )
-                            )
+                        val dlStatus = DownloadStateResolver.aggregateSongs(dbSongs, mediaStoreDownloads)
+                        val dlProgress = DownloadStateResolver.aggregateProgress(dbSongs, mediaStoreDownloads)
+                        val anyFailed = dbSongs.any {
+                            mediaStoreDownloads[it.id]?.status ==
+                                com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
                         }
+                        downloadMenuItem(
+                            kind = DownloadMenuLogic.collectionRow(dlStatus, anyFailed),
+                            progress = dlProgress,
+                            onDownload = {
+                                // Online SongItems aren't Room entities yet — persist each, then download.
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    songs.forEach { song ->
+                                        database.transaction {
+                                            insert(song.toMediaMetadata())
+                                        }
+                                        database.song(song.id).first()?.let {
+                                            downloadUtil.downloadToMediaStore(it)
+                                        }
+                                    }
+                                }
+                            },
+                            onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                            onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                            onRemove = { showRemoveDownloadDialog = true },
+                        )?.let { add(it) }
                     }
                     add(
                         Material3MenuItemData(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -178,11 +178,17 @@ fun YouTubePlaylistMenu(
     HorizontalDivider()
 
     val mediaStoreDownloads by downloadUtil.getAllMediaStoreDownloads().collectAsState()
+    // The playlist may be opened without its tracks loaded (e.g. the Home long-press menu passes no
+    // songs) — fetch them so the Download row appears and downloads the whole playlist.
+    val resolvedSongs by produceState(initialValue = songs, songs, playlist.id) {
+        value = if (songs.isNotEmpty()) songs
+        else YouTube.playlist(playlist.id).getOrNull()?.songs.orEmpty()
+    }
     val dbSongs by produceState(
         initialValue = emptyList<com.jtech.zemer.db.entities.Song>(),
-        songs,
+        resolvedSongs,
     ) {
-        value = database.getSongsByIds(songs.map { it.id })
+        value = database.getSongsByIds(resolvedSongs.map { it.id })
     }
     var showRemoveDownloadDialog by remember {
         mutableStateOf(false)
@@ -406,12 +412,12 @@ fun YouTubePlaylistMenu(
                             },
                         )
                     )
-                    if (songs.isNotEmpty()) {
+                    if (resolvedSongs.isNotEmpty()) {
                         // Aggregate by videoId off the LIVE map so progress animates during download
                         // (online SongItems aren't Room entities yet, so a one-shot dbSongs snapshot
                         // stays empty/stale and never showed progress). Persisted-downloaded comes from
                         // the dbSongs snapshot for the across-restart "downloaded" state.
-                        val ids = songs.map { it.id }
+                        val ids = resolvedSongs.map { it.id }
                         val persistedDownloaded = dbSongs.filter { it.song.isDownloaded }.map { it.id }.toSet()
                         val dlStatus = DownloadStateResolver.aggregateByIds(ids, mediaStoreDownloads, persistedDownloaded)
                         val dlProgress = DownloadStateResolver.aggregateProgressByIds(ids, mediaStoreDownloads, persistedDownloaded)
@@ -425,7 +431,7 @@ fun YouTubePlaylistMenu(
                             onDownload = {
                                 // Online SongItems aren't Room entities yet — persist each, then download.
                                 coroutineScope.launch(Dispatchers.IO) {
-                                    songs.forEach { song ->
+                                    resolvedSongs.forEach { song ->
                                         database.transaction {
                                             insert(song.toMediaMetadata())
                                         }
@@ -435,8 +441,8 @@ fun YouTubePlaylistMenu(
                                     }
                                 }
                             },
-                            onCancel = { songs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
-                            onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
+                            onCancel = { resolvedSongs.forEach { downloadUtil.cancelMediaStoreDownload(it.id) } },
+                            onRetry = { resolvedSongs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
                             onRemove = { showRemoveDownloadDialog = true },
                         )?.let { add(it) }
                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -407,10 +407,16 @@ fun YouTubePlaylistMenu(
                         )
                     )
                     if (songs.isNotEmpty()) {
-                        val dlStatus = DownloadStateResolver.aggregateSongs(dbSongs, mediaStoreDownloads)
-                        val dlProgress = DownloadStateResolver.aggregateProgress(dbSongs, mediaStoreDownloads)
-                        val anyFailed = dbSongs.any {
-                            mediaStoreDownloads[it.id]?.status ==
+                        // Aggregate by videoId off the LIVE map so progress animates during download
+                        // (online SongItems aren't Room entities yet, so a one-shot dbSongs snapshot
+                        // stays empty/stale and never showed progress). Persisted-downloaded comes from
+                        // the dbSongs snapshot for the across-restart "downloaded" state.
+                        val ids = songs.map { it.id }
+                        val persistedDownloaded = dbSongs.filter { it.song.isDownloaded }.map { it.id }.toSet()
+                        val dlStatus = DownloadStateResolver.aggregateByIds(ids, mediaStoreDownloads, persistedDownloaded)
+                        val dlProgress = DownloadStateResolver.aggregateProgressByIds(ids, mediaStoreDownloads, persistedDownloaded)
+                        val anyFailed = ids.any {
+                            mediaStoreDownloads[it]?.status ==
                                 com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.FAILED
                         }
                         downloadMenuItem(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -347,18 +347,9 @@ fun YouTubeSongMenu(
                         )
                     }
                     add(
-                        Material3MenuItemData(
-                            icon = {
-                                Icon(
-                                    painterResource(if (librarySong?.song?.inLibrary != null) R.drawable.library_add_check else R.drawable.library_add),
-                                    null,
-                                    Modifier.size(24.dp),
-                                )
-                            },
-                            title = {
-                                Text(text = if (librarySong?.song?.inLibrary != null) stringResource(R.string.remove_from_library) else stringResource(R.string.add_to_library))
-                            },
-                            onClick = {
+                        libraryMenuItem(
+                            inLibrary = librarySong?.song?.inLibrary != null,
+                            onToggle = {
                                 val isInLibrary = librarySong?.song?.inLibrary != null
                                 val token = if (isInLibrary) song.libraryRemoveToken else song.libraryAddToken
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,7 +38,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.jtech.zemer.LocalDatabase
@@ -55,6 +53,8 @@ import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.DownloadMenuLogic
+import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.ui.component.ArtistChoice
@@ -93,7 +93,6 @@ fun YouTubeSongMenu(
     val downloadUtil = LocalDownloadUtil.current
     val librarySong by database.song(song.id).collectAsState(initial = null)
     val mediaStoreDownload by downloadUtil.getMediaStoreDownload(song.id).collectAsState(initial = null)
-    val download by downloadUtil.getDownload(song.id).collectAsState(initial = null)
     val coroutineScope = rememberCoroutineScope()
     val syncUtils = LocalSyncUtils.current
     var showReportDialog by remember { mutableStateOf(false) }
@@ -394,119 +393,44 @@ fun YouTubeSongMenu(
                             },
                         )
                     )
-                    when (mediaStoreDownload?.status) {
-                        MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> add(
-                            Material3MenuItemData(
-                                icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                title = {
-                                    Text(
-                                        stringResource(R.string.remove_download),
-                                        color = MaterialTheme.colorScheme.error,
-                                    )
-                                },
-                                onClick = {
-                                    coroutineScope.launch {
-                                        downloadUtil.removeDownload(song.id)
+                    // Unified download row: persisted-or-live state, live progress, video-aware, and the
+                    // menu stays open so it animates Download -> progress -> Remove. (DownloadMenuItems.kt)
+                    val songIsVideo = librarySong?.song?.isVideo == true || isVideo
+                    val downloadStatus = DownloadStateResolver.forSong(librarySong?.song?.isDownloaded == true, mediaStoreDownload)
+                    val downloadProgress = when {
+                        librarySong?.song?.isDownloaded == true ||
+                            mediaStoreDownload?.status == MediaStoreDownloadManager.DownloadState.Status.COMPLETED -> 1f
+                        else -> mediaStoreDownload?.progress ?: 0f
+                    }
+                    val downloadFailed =
+                        mediaStoreDownload?.status == MediaStoreDownloadManager.DownloadState.Status.FAILED
+                    downloadMenuItem(
+                        kind = DownloadMenuLogic.songRow(downloadStatus, downloadFailed, songIsVideo, blockVideos),
+                        progress = downloadProgress,
+                        error = mediaStoreDownload?.error,
+                        onDownload = {
+                            coroutineScope.launch(Dispatchers.IO) {
+                                // Insert with correct isVideo flag
+                                val metadata = song.toMediaMetadata().copy(isVideo = isVideo)
+                                database.transaction {
+                                    insert(metadata)
+                                    // Always set isVideo to match the download context
+                                    setIsVideo(song.id, isVideo)
+                                }
+                                val dbSong = database.song(song.id).first()
+                                dbSong?.let {
+                                    if (isVideo) {
+                                        downloadUtil.downloadVideoToMediaStore(it)
+                                    } else {
+                                        downloadUtil.downloadToMediaStore(it)
                                     }
-                                },
-                            )
-                        )
-
-                        MediaStoreDownloadManager.DownloadState.Status.QUEUED,
-                        MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING -> {
-                            val progress = mediaStoreDownload?.progress ?: 0f
-                            add(
-                                Material3MenuItemData(
-                                    icon = {
-                                        CircularProgressIndicator(
-                                            progress = { progress.coerceIn(0f, 1f) },
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    },
-                                    title = { Text(stringResource(R.string.downloading)) },
-                                    description = { Text("${(progress * 100).toInt()}%") },
-                                    onClick = {
-                                        coroutineScope.launch {
-                                            downloadUtil.cancelMediaStoreDownload(song.id)
-                                        }
-                                    },
-                                )
-                            )
-                        }
-
-                        MediaStoreDownloadManager.DownloadState.Status.FAILED,
-                        MediaStoreDownloadManager.DownloadState.Status.CANCELLED,
-                        null -> {
-                            when (download?.state) {
-                                Download.STATE_COMPLETED -> add(
-                                    Material3MenuItemData(
-                                        icon = { Icon(painterResource(R.drawable.offline), null, Modifier.size(24.dp)) },
-                                        title = {
-                                            Text(
-                                                stringResource(R.string.remove_download),
-                                                color = MaterialTheme.colorScheme.error,
-                                            )
-                                        },
-                                        onClick = {
-                                            coroutineScope.launch {
-                                                downloadUtil.removeDownload(song.id)
-                                            }
-                                        },
-                                    )
-                                )
-                                Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> add(
-                                    Material3MenuItemData(
-                                        icon = {
-                                            CircularProgressIndicator(
-                                                modifier = Modifier.size(24.dp),
-                                                strokeWidth = 2.dp,
-                                            )
-                                        },
-                                        title = { Text(stringResource(R.string.downloading)) },
-                                        onClick = {
-                                            coroutineScope.launch {
-                                                downloadUtil.removeDownload(song.id)
-                                            }
-                                        },
-                                    )
-                                )
-                                else -> {
-                                    // Skip showing download option for videos when blocked
-                                    if (!(isVideo && blockVideos)) add(
-                                        Material3MenuItemData(
-                                            icon = { Icon(painterResource(R.drawable.download), null, Modifier.size(24.dp)) },
-                                            title = {
-                                                Text(text = if (isVideo)
-                                                    stringResource(R.string.download_video_to_device)
-                                                else
-                                                    stringResource(R.string.action_download))
-                                            },
-                                            onClick = {
-                                                coroutineScope.launch(Dispatchers.IO) {
-                                                    // Insert with correct isVideo flag
-                                                    val metadata = song.toMediaMetadata().copy(isVideo = isVideo)
-                                                    database.transaction {
-                                                        insert(metadata)
-                                                        // Always set isVideo to match the download context
-                                                        setIsVideo(song.id, isVideo)
-                                                    }
-                                                    val dbSong = database.song(song.id).first()
-                                                    dbSong?.let {
-                                                        if (isVideo) {
-                                                            downloadUtil.downloadVideoToMediaStore(it)
-                                                        } else {
-                                                            downloadUtil.downloadToMediaStore(it)
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                        )
-                                    )
                                 }
                             }
-                        }
-                    }
+                        },
+                        onCancel = { coroutineScope.launch { downloadUtil.cancelMediaStoreDownload(song.id) } },
+                        onRetry = { downloadUtil.retryMediaStoreDownload(song.id) },
+                        onRemove = { coroutineScope.launch { downloadUtil.removeDownload(song.id) } },
+                    )?.let { add(it) }
                     if (artists.isNotEmpty()) {
                         add(
                             Material3MenuItemData(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -81,6 +81,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.Album
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.LocalAlbumRadio
+import com.jtech.zemer.ui.component.AggregateDownloadButton
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
@@ -139,9 +140,6 @@ fun AlbumScreen(
     }
 
     val downloadUtil = LocalDownloadUtil.current
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
 
     // Focus state for TopAppBar buttons
     val isBackButtonFocused = remember { mutableStateOf(false) }
@@ -192,26 +190,6 @@ fun AlbumScreen(
 
     LaunchedEffect(Unit) {
         firstHeaderItemFocusRequester.requestFocus()
-    }
-
-    LaunchedEffect(albumWithSongs) {
-        val songs = albumWithSongs?.songs?.map { it.id }
-        if (songs.isNullOrEmpty()) return@LaunchedEffect
-        downloadUtil.getAllMediaStoreDownloads().collect { downloads ->
-            downloadState =
-                if (songs.all { downloads[it]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED }) {
-                    Download.STATE_COMPLETED
-                } else if (songs.all {
-                        downloads[it]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.QUEUED ||
-                                downloads[it]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.DOWNLOADING ||
-                                downloads[it]?.status == com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status.COMPLETED
-                    }
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
-        }
     }
 
     LazyColumn(
@@ -334,83 +312,17 @@ fun AlbumScreen(
                                     }
                                 }
 
-                                val downloadButtonFocused = remember { mutableStateOf(false) }
-                                val downloadButtonBorderColor = animateColorAsState(
-                                    targetValue = if (downloadButtonFocused.value) MaterialTheme.colorScheme.primary else Color.Transparent,
-                                    label = "download_button_focus_border"
+                                AggregateDownloadButton(
+                                    songs = albumWithSongs.songs,
+                                    onDownloadAll = {
+                                        albumWithSongs.songs.forEach { downloadUtil.downloadToMediaStore(it) }
+                                    },
+                                    onRemoveAll = {
+                                        albumWithSongs.songs.forEach { song ->
+                                            coroutineScope.launch { downloadUtil.removeDownload(song.id) }
+                                        }
+                                    },
                                 )
-
-                                when (downloadState) {
-                                    Download.STATE_COMPLETED -> {
-                                        Box(
-                                            modifier = Modifier
-                                                .border(3.dp, downloadButtonBorderColor.value, RoundedCornerShape(8.dp))
-                                                .focusable()
-                                                .onFocusChanged { downloadButtonFocused.value = it.isFocused }
-                                        ) {
-                                            IconButton(
-                                                onClick = {
-                                                    albumWithSongs.songs.forEach { song ->
-                                                        coroutineScope.launch {
-                                                            downloadUtil.removeDownload(song.id)
-                                                        }
-                                                    }
-                                                },
-                                            ) {
-                                                Icon(
-                                                    painter = painterResource(R.drawable.offline),
-                                                    contentDescription = null,
-                                                )
-                                            }
-                                        }
-                                    }
-
-                                    Download.STATE_DOWNLOADING -> {
-                                        Box(
-                                            modifier = Modifier
-                                                .border(3.dp, downloadButtonBorderColor.value, RoundedCornerShape(8.dp))
-                                                .focusable()
-                                                .onFocusChanged { downloadButtonFocused.value = it.isFocused }
-                                        ) {
-                                            IconButton(
-                                                onClick = {
-                                                    albumWithSongs.songs.forEach { song ->
-                                                        coroutineScope.launch {
-                                                            downloadUtil.removeDownload(song.id)
-                                                        }
-                                                    }
-                                                },
-                                            ) {
-                                                CircularProgressIndicator(
-                                                    strokeWidth = 2.dp,
-                                                    modifier = Modifier.size(24.dp),
-                                                )
-                                            }
-                                        }
-                                    }
-
-                                    else -> {
-                                        Box(
-                                            modifier = Modifier
-                                                .border(3.dp, downloadButtonBorderColor.value, RoundedCornerShape(8.dp))
-                                                .focusable()
-                                                .onFocusChanged { downloadButtonFocused.value = it.isFocused }
-                                        ) {
-                                            IconButton(
-                                                onClick = {
-                                                    albumWithSongs.songs.forEach { song ->
-                                                        downloadUtil.downloadToMediaStore(song)
-                                                    }
-                                                },
-                                            ) {
-                                                Icon(
-                                                    painter = painterResource(R.drawable.download),
-                                                    contentDescription = null,
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
 
                                 val headerMenuButtonFocused = remember { mutableStateOf(false) }
                                 val headerMenuButtonBorderColor = animateColorAsState(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
@@ -14,6 +14,10 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -25,7 +29,10 @@ import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.latestreleases.LatestReleaseCard
+import com.jtech.zemer.latestreleases.LatestReleaseFilter
+import com.jtech.zemer.latestreleases.applyFilter
 import com.jtech.zemer.latestreleases.shufflePlay
+import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.utils.backToMain
@@ -52,14 +59,29 @@ fun LatestReleasesScreen(
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val releases by viewModel.releases.collectAsState()
     val lazyListState = rememberLazyListState()
+    var filter by rememberSaveable { mutableStateOf(LatestReleaseFilter.ALL) }
+    val visibleReleases = remember(releases, filter) { releases.applyFilter(filter) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             state = lazyListState,
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
         ) {
+            // All / Albums / Songs filter — scrolls with the list so it never steals vertical space
+            // on small screens.
+            item(key = "filter") {
+                ChipsRow(
+                    chips = listOf(
+                        LatestReleaseFilter.ALL to stringResource(R.string.filter_all),
+                        LatestReleaseFilter.ALBUMS to stringResource(R.string.filter_albums),
+                        LatestReleaseFilter.SONGS to stringResource(R.string.filter_songs),
+                    ),
+                    currentValue = filter,
+                    onValueUpdate = { filter = it },
+                )
+            }
             items(
-                items = releases,
+                items = visibleReleases,
                 key = { it.browseId },
             ) { release ->
                 LatestReleaseCard(
@@ -75,10 +97,10 @@ fun LatestReleasesScreen(
         }
 
         HideOnScrollFAB(
-            visible = releases.isNotEmpty(),
+            visible = visibleReleases.isNotEmpty(),
             lazyListState = lazyListState,
             icon = R.drawable.shuffle,
-            onClick = { releases.shufflePlay(playerConnection, context.getString(R.string.latest_releases)) },
+            onClick = { visibleReleases.shufflePlay(playerConnection, context.getString(R.string.latest_releases)) },
         )
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
@@ -61,6 +61,7 @@ import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
+import com.jtech.zemer.ui.component.SelectionTopActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.ItemWrapper
@@ -186,36 +187,11 @@ fun LibrarySongsScreen(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (selection) {
-                        val count = wrappedSongs.count { it.isSelected }
-                        IconButton(
-                            onClick = { selection = false },
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.close),
-                                contentDescription = null,
-                            )
-                        }
-                        Text(
-                            text = pluralStringResource(R.plurals.n_song, count, count),
-                            modifier = Modifier.weight(1f)
-                        )
-                        IconButton(
-                            onClick = {
-                                if (count == wrappedSongs.size) {
-                                    wrappedSongs.forEach { it.isSelected = false }
-                                } else {
-                                    wrappedSongs.forEach { it.isSelected = true }
-                                }
-                            },
-                        ) {
-                            Icon(
-                                painter = painterResource(if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all),
-                                contentDescription = null,
-                            )
-                        }
-
-                        IconButton(
-                            onClick = {
+                        SelectionTopActions(
+                            wrapped = wrappedSongs,
+                            countLabel = { pluralStringResource(R.plurals.n_song, it, it) },
+                            onExit = { selection = false },
+                            onMore = {
                                 menuState.show {
                                     SelectionSongMenu(
                                         songSelection = wrappedSongs.filter { it.isSelected }
@@ -225,12 +201,7 @@ fun LibrarySongsScreen(
                                     )
                                 }
                             },
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.more_vert),
-                                contentDescription = null,
-                            )
-                        }
+                        )
                     } else {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
@@ -92,14 +92,17 @@ import com.jtech.zemer.R
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.AudioQuality
 import com.jtech.zemer.constants.BlockVideosKey
+import androidx.compose.runtime.collectAsState
+import com.jtech.zemer.LocalDownloadUtil
+import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.db.entities.SongEntity
-import com.jtech.zemer.utils.MediaStoreHelper
+import com.jtech.zemer.playback.DownloadStatus
+import com.jtech.zemer.ui.component.rememberSongDownloadProgress
+import com.jtech.zemer.ui.component.rememberSongDownloadStatus
 import com.jtech.zemer.utils.UrlValidator
 import com.jtech.zemer.utils.VideoLinkBuilder
 import com.jtech.zemer.utils.YTPlayerUtils
-import com.jtech.zemer.utils.reportException
 import com.jtech.zemer.utils.rememberPreference
-import com.metrolist.innertube.utils.ResilientDns
 import io.sanghun.compose.video.RepeatMode
 import io.sanghun.compose.video.VideoPlayer
 import io.sanghun.compose.video.controller.VideoPlayerControllerConfig
@@ -109,10 +112,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.io.File
-import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -168,7 +167,11 @@ fun VideoPlayerScreen(
     val clipboard = remember { context.getSystemService(ClipboardManager::class.java) }
     val connectivityManager = remember { context.getSystemService(ConnectivityManager::class.java) }
     val database = LocalDatabase.current
+    val downloadUtil = LocalDownloadUtil.current
     val scope = rememberCoroutineScope()
+    val downloadedSong by remember(videoId) { database.song(videoId) }.collectAsState(initial = null)
+    val videoDownloadStatus = rememberSongDownloadStatus(videoId, downloadedSong?.song?.isDownloaded == true)
+    val videoDownloadProgress = rememberSongDownloadProgress(videoId, downloadedSong?.song?.isDownloaded == true)
     val playerConnection = LocalPlayerConnection.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -211,12 +214,6 @@ fun VideoPlayerScreen(
                 artistName = artistDisplay.ifBlank { null }
             }
         }
-    }
-
-    val httpClient = remember {
-        OkHttpClient.Builder()
-            .dns(ResilientDns())
-            .build()
     }
 
     DisposableEffect(Unit) {
@@ -394,86 +391,22 @@ fun VideoPlayerScreen(
         }
     }
 
-    val mediaStoreHelper = remember { MediaStoreHelper(context) }
-
+    // Unified video download: go through the same MediaStoreDownloadManager every other surface uses
+    // (tracked state, live progress, correct mediaStoreUri, retry/cancel) — not a per-screen
+    // re-implementation. The selected bitrate is forwarded through the manager.
     val downloadVideo: (Int) -> Unit = { targetBitrate ->
         showDownloadDialog = false
         scope.launch {
-            try {
-                val playback = withContext(Dispatchers.IO) {
-                    val cm = connectivityManager ?: error("No connectivity manager")
-                    YTPlayerUtils.playerResponseForPlayback(
-                        videoId = videoId,
-                        audioQuality = AudioQuality.HIGH,
-                        connectivityManager = cm,
-                        preferVideo = true,
-                        maxVideoBitrateKbps = targetBitrate,
-                    ).getOrThrow()
-                }
-
-                val stream = UrlValidator.validateAndParseUrl(playback.streamUrl)?.toString()
-                    ?: error("Invalid stream URL")
-
-                // Get video metadata
-                val videoTitle = playback.videoDetails?.title ?: currentTitle ?: "Video"
-                val videoArtist = artistName ?: "Unknown Artist"
-                val videoDuration = playback.videoDetails?.lengthSeconds?.toIntOrNull() ?: 0
-
-                // Download to temp file first
-                val tempFile = File(context.cacheDir, "temp_video_$videoId.mp4")
-
-                val uri = withContext(Dispatchers.IO) {
-                    val request = Request.Builder().url(stream).build()
-                    httpClient.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) error("HTTP ${response.code}")
-                        response.body?.byteStream()?.use { input ->
-                            tempFile.outputStream().use { output ->
-                                input.copyTo(output)
-                            }
-                        }
-                    }
-
-                    // Save to MediaStore (Movies/Zemer folder)
-                    val fileName = "$videoArtist - $videoTitle.mp4"
-                    val savedUri = mediaStoreHelper.saveVideoFileToMediaStore(
-                        tempFile = tempFile,
-                        fileName = fileName,
-                        mimeType = "video/mp4",
-                        title = videoTitle,
-                        artist = videoArtist,
-                        durationMs = videoDuration * 1000L
-                    )
-
-                    // Clean up temp file
-                    tempFile.delete()
-
-                    savedUri
-                }
-
-                if (uri != null) {
-                    database.query {
-                        upsert(
-                            SongEntity(
-                                id = videoId,
-                                title = videoTitle,
-                                duration = videoDuration,
-                                thumbnailUrl = playback.videoDetails?.thumbnail?.thumbnails?.lastOrNull()?.url,
-                                explicit = false,
-                                dateDownload = LocalDateTime.now(),
-                                isDownloaded = true,
-                                isVideo = true,
-                                mediaStoreUri = uri.toString()
-                            )
-                        )
-                    }
-                    Toast.makeText(context, context.getString(R.string.video_saved), Toast.LENGTH_LONG).show()
-                } else {
-                    error("Failed to save video to MediaStore")
-                }
-            } catch (e: Exception) {
-                reportException(e, "VideoPlayerScreen download")
-                Toast.makeText(context, context.getString(R.string.video_download_failed), Toast.LENGTH_SHORT).show()
-            }
+            val existing = withContext(Dispatchers.IO) { database.getSongById(videoId) }
+            val songToDownload = existing?.copy(song = existing.song.copy(isVideo = true)) ?: Song(
+                song = SongEntity(
+                    id = videoId,
+                    title = currentTitle ?: videoId,
+                    isVideo = true,
+                ),
+                artists = emptyList(),
+            )
+            downloadUtil.downloadVideoToMediaStore(songToDownload, targetBitrate)
         }
     }
 
@@ -808,12 +741,34 @@ fun VideoPlayerScreen(
                                             ) {
                                                 IconButton(onClick = {
                                                     markInteraction()
-                                                    showDownloadDialog = true
+                                                    when (videoDownloadStatus) {
+                                                        DownloadStatus.DOWNLOADED -> scope.launch { downloadUtil.removeDownload(videoId) }
+                                                        DownloadStatus.DOWNLOADING -> downloadUtil.cancelMediaStoreDownload(videoId)
+                                                        DownloadStatus.NOT_DOWNLOADED -> showDownloadDialog = true
+                                                    }
                                                 }) {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.download),
-                                                        contentDescription = stringResource(R.string.action_download)
-                                                    )
+                                                    when (videoDownloadStatus) {
+                                                        DownloadStatus.DOWNLOADED -> Icon(
+                                                            painter = painterResource(R.drawable.offline),
+                                                            contentDescription = stringResource(R.string.remove_download),
+                                                        )
+                                                        DownloadStatus.DOWNLOADING -> if (videoDownloadProgress > 0f) {
+                                                            CircularProgressIndicator(
+                                                                progress = { videoDownloadProgress },
+                                                                modifier = Modifier.size(24.dp),
+                                                                strokeWidth = 2.dp,
+                                                            )
+                                                        } else {
+                                                            CircularProgressIndicator(
+                                                                modifier = Modifier.size(24.dp),
+                                                                strokeWidth = 2.dp,
+                                                            )
+                                                        }
+                                                        DownloadStatus.NOT_DOWNLOADED -> Icon(
+                                                            painter = painterResource(R.drawable.download),
+                                                            contentDescription = stringResource(R.string.action_download),
+                                                        )
+                                                    }
                                                 }
                                             }
                                             Surface(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,7 +38,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastSumBy
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.jtech.zemer.LocalDownloadUtil
@@ -84,6 +81,7 @@ import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.ui.component.AggregateDownloadButton
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -185,9 +183,6 @@ fun AutoPlaylistScreen(
     val (sortDescending, onSortDescendingChange) = rememberPreference(SongSortDescendingKey, true)
 
     val downloadUtil = LocalDownloadUtil.current
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
 
     LaunchedEffect(Unit) {
         if (ytmSync) {
@@ -202,22 +197,6 @@ fun AutoPlaylistScreen(
         mutableSongs.apply {
             clear()
             songs?.let { addAll(it) }
-        }
-        if (songs?.isEmpty() == true) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songs?.all { downloads[it.song.id]?.state == Download.STATE_COMPLETED } == true) {
-                    Download.STATE_COMPLETED
-                } else if (songs?.all {
-                        downloads[it.song.id]?.state == Download.STATE_QUEUED ||
-                                downloads[it.song.id]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it.song.id]?.state == Download.STATE_COMPLETED
-                    } == true
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
         }
     }
 
@@ -340,52 +319,20 @@ fun AutoPlaylistScreen(
                                         )
 
                                         Row {
-                                            when (downloadState) {
-                                                Download.STATE_COMPLETED -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            showRemoveDownloadDialog = true
-                                                        },
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.offline),
-                                                            contentDescription = null,
-                                                        )
+                                            AggregateDownloadButton(
+                                                songs = songs.orEmpty(),
+                                                onDownloadAll = {
+                                                    songs?.forEach { downloadUtil.downloadToMediaStore(it) }
+                                                },
+                                                onRemoveAll = { showRemoveDownloadDialog = true },
+                                                onCancelAll = {
+                                                    songs?.forEach { song ->
+                                                        coroutineScope.launch {
+                                                            downloadUtil.removeDownload(song.song.id)
+                                                        }
                                                     }
-                                                }
-
-                                                Download.STATE_DOWNLOADING -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            songs!!.forEach { song ->
-                                                                coroutineScope.launch {
-                                                                    downloadUtil.removeDownload(song.song.id)
-                                                                }
-                                                            }
-                                                        },
-                                                    ) {
-                                                        CircularProgressIndicator(
-                                                            strokeWidth = 2.dp,
-                                                            modifier = Modifier.size(24.dp),
-                                                        )
-                                                    }
-                                                }
-
-                                                else -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            songs!!.forEach { song ->
-                                                                downloadUtil.downloadToMediaStore(song)
-                                                            }
-                                                        },
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.download),
-                                                            contentDescription = null,
-                                                        )
-                                                    }
-                                                }
-                                            }
+                                                },
+                                            )
 
                                             IconButton(
                                                 onClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -89,6 +89,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.SelectionSongMenu
@@ -573,26 +574,9 @@ fun AutoPlaylistScreen(
             },
             actions = {
                 if (selection) {
-                    val count = wrappedSongs.count { it.isSelected }
-                    IconButton(
-                        onClick = {
-                            if (count == wrappedSongs.size) {
-                                wrappedSongs.forEach { it.isSelected = false }
-                            } else {
-                                wrappedSongs.forEach { it.isSelected = true }
-                            }
-                        },
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all
-                            ),
-                            contentDescription = null
-                        )
-                    }
-
-                    IconButton(
-                        onClick = {
+                    SelectionActions(
+                        wrapped = wrappedSongs,
+                        onMore = {
                             menuState.show {
                                 SelectionSongMenu(
                                     songSelection = wrappedSongs.filter { it.isSelected }
@@ -602,12 +586,7 @@ fun AutoPlaylistScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 } else if (!isSearching) {
                     IconButton(
                         onClick = { isSearching = true }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
@@ -78,6 +78,7 @@ import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
+import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.ItemWrapper
@@ -447,36 +448,18 @@ fun CachePlaylistScreen(
             },
             actions = {
                 if (selection) {
-                    val count = wrappedSongs.count { it.isSelected }
-                    IconButton(onClick = {
-                        if (count == wrappedSongs.size) {
-                            wrappedSongs.forEach { it.isSelected = false }
-                        } else {
-                            wrappedSongs.forEach { it.isSelected = true }
-                        }
-                    }) {
-                        Icon(
-                            painter = painterResource(
-                                if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all
-                            ),
-                            contentDescription = null
-                        )
-                    }
-
-                    IconButton(onClick = {
-                        menuState.show {
-                            SelectionSongMenu(
-                                songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
-                                onDismiss = menuState::dismiss,
-                                clearAction = { selection = false }
-                            )
-                        }
-                    }) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    SelectionActions(
+                        wrapped = wrappedSongs,
+                        onMore = {
+                            menuState.show {
+                                SelectionSongMenu(
+                                    songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
+                                    onDismiss = menuState::dismiss,
+                                    clearAction = { selection = false }
+                                )
+                            }
+                        },
+                    )
                 } else if (!isSearching) {
                     IconButton(onClick = { isSearching = true }) {
                         Icon(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
@@ -81,6 +81,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.SelectionSongMenu
@@ -459,26 +460,9 @@ fun DownloadedVideosScreen(
             },
             actions = {
                 if (selection) {
-                    val count = wrappedVideos.count { it.isSelected }
-                    IconButton(
-                        onClick = {
-                            if (count == wrappedVideos.size) {
-                                wrappedVideos.forEach { it.isSelected = false }
-                            } else {
-                                wrappedVideos.forEach { it.isSelected = true }
-                            }
-                        },
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (count == wrappedVideos.size) R.drawable.deselect else R.drawable.select_all
-                            ),
-                            contentDescription = null
-                        )
-                    }
-
-                    IconButton(
-                        onClick = {
+                    SelectionActions(
+                        wrapped = wrappedVideos,
+                        onMore = {
                             menuState.show {
                                 SelectionSongMenu(
                                     songSelection = wrappedVideos.filter { it.isSelected }
@@ -488,12 +472,7 @@ fun DownloadedVideosScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 } else if (!isSearching) {
                     IconButton(
                         onClick = { isSearching = true }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -60,7 +59,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -96,7 +94,6 @@ import androidx.compose.ui.util.fastSumBy
 import androidx.core.content.FileProvider
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -124,6 +121,7 @@ import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.ActionPromptDialog
+import com.jtech.zemer.ui.component.AggregateDownloadButton
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -248,9 +246,6 @@ fun LocalPlaylistScreen(
         mutableSongs.apply {
             clear()
             addAll(songs)
-        }
-        if (songs.isEmpty()) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
         }
     }
 
@@ -943,9 +938,6 @@ fun LocalPlaylistHeader(
         }
 
     val downloadUtil = LocalDownloadUtil.current
-    var downloadState by remember {
-        mutableIntStateOf(Download.STATE_STOPPED)
-    }
 
     val liked = playlist.playlist.bookmarkedAt != null
     val editable: Boolean = playlist.playlist.isEditable
@@ -1042,25 +1034,6 @@ fun LocalPlaylistHeader(
                     }
                 }
             }
-        }
-    }
-
-    LaunchedEffect(songs) {
-        if (songs.isEmpty()) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songs.all { downloads[it.song.id]?.state == Download.STATE_COMPLETED }) {
-                    Download.STATE_COMPLETED
-                } else if (songs.all {
-                        downloads[it.song.id]?.state == Download.STATE_QUEUED ||
-                                downloads[it.song.id]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it.song.id]?.state == Download.STATE_COMPLETED
-                    }
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
         }
     }
 
@@ -1390,55 +1363,18 @@ fun LocalPlaylistHeader(
                         }
                     }
 
-                    when (downloadState) {
-                        Download.STATE_COMPLETED -> {
-                            IconButton(
-                                onClick = onShowRemoveDownloadDialog,
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.offline),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp)
-                                )
+                    AggregateDownloadButton(
+                        songs = songs.map { it.song },
+                        onDownloadAll = {
+                            songs.forEach { downloadUtil.downloadToMediaStore(it.song) }
+                        },
+                        onRemoveAll = onShowRemoveDownloadDialog,
+                        onCancelAll = {
+                            songs.forEach { s ->
+                                scope.launch { downloadUtil.removeDownload(s.song.id) }
                             }
-                        }
-
-                        Download.STATE_DOWNLOADING -> {
-                            IconButton(
-                                onClick = {
-                                    songs.forEach { song ->
-                                        scope.launch {
-                                            downloadUtil.removeDownload(song.song.id)
-                                        }
-                                    }
-                                },
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                CircularProgressIndicator(
-                                    strokeWidth = 2.dp,
-                                    modifier = Modifier.size(24.dp),
-                                )
-                            }
-                        }
-
-                        else -> {
-                            IconButton(
-                                onClick = {
-                                    songs.forEach { song ->
-                                        downloadUtil.downloadToMediaStore(song.song)
-                                    }
-                                },
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.download),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                            }
-                        }
-                    }
+                        },
+                    )
 
                     IconButton(
                         onClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -134,6 +134,7 @@ import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.TextFieldDialog
 import com.jtech.zemer.ui.menu.CustomThumbnailMenu
+import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.screens.settings.DarkMode
@@ -852,26 +853,9 @@ fun LocalPlaylistScreen(
             },
             actions = {
                 if (selection) {
-                    val count = wrappedSongs.count { it.isSelected }
-                    IconButton(
-                        onClick = {
-                            if (count == wrappedSongs.size) {
-                                wrappedSongs.forEach { it.isSelected = false }
-                            } else {
-                                wrappedSongs.forEach { it.isSelected = true }
-                            }
-                        },
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all
-                            ),
-                            contentDescription = null
-                        )
-                    }
-
-                    IconButton(
-                        onClick = {
+                    SelectionActions(
+                        wrapped = wrappedSongs,
+                        onMore = {
                             menuState.show {
                                 SelectionSongMenu(
                                     songSelection = wrappedSongs.filter { it.isSelected }
@@ -886,12 +870,7 @@ fun LocalPlaylistScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 } else if (!isSearching) {
                     IconButton(
                         onClick = { isSearching = true }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -88,6 +88,7 @@ import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
+import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.ItemWrapper
@@ -530,26 +531,9 @@ fun TopPlaylistScreen(
             },
             actions = {
                 if (selection) {
-                    val count = wrappedSongs.count { it.isSelected }
-                    IconButton(
-                        onClick = {
-                            if (count == wrappedSongs.size) {
-                                wrappedSongs.forEach { it.isSelected = false }
-                            } else {
-                                wrappedSongs.forEach { it.isSelected = true }
-                            }
-                        },
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all
-                            ),
-                            contentDescription = null
-                        )
-                    }
-
-                    IconButton(
-                        onClick = {
+                    SelectionActions(
+                        wrapped = wrappedSongs,
+                        onMore = {
                             menuState.show {
                                 SelectionSongMenu(
                                     songSelection = wrappedSongs.filter { it.isSelected }
@@ -559,12 +543,7 @@ fun TopPlaylistScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 } else if (!isSearching) {
                     IconButton(
                         onClick = { isSearching = true }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,7 +38,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastSumBy
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.jtech.zemer.LocalDownloadUtil
@@ -81,6 +78,7 @@ import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.ui.component.AggregateDownloadButton
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -154,28 +152,11 @@ fun TopPlaylistScreen(
     val name = stringResource(R.string.my_top) + " $maxSize"
 
     val downloadUtil = LocalDownloadUtil.current
-    var downloadState by remember { mutableIntStateOf(Download.STATE_STOPPED) }
 
     LaunchedEffect(songs) {
         mutableSongs.apply {
             clear()
             songs?.let { addAll(it) }
-        }
-        if (songs?.isEmpty() == true) return@LaunchedEffect
-        downloadUtil.downloads.collect { downloads ->
-            downloadState =
-                if (songs?.all { downloads[it.song.id]?.state == Download.STATE_COMPLETED } == true) {
-                    Download.STATE_COMPLETED
-                } else if (songs?.all {
-                        downloads[it.song.id]?.state == Download.STATE_QUEUED ||
-                                downloads[it.song.id]?.state == Download.STATE_DOWNLOADING ||
-                                downloads[it.song.id]?.state == Download.STATE_COMPLETED
-                    } == true
-                ) {
-                    Download.STATE_DOWNLOADING
-                } else {
-                    Download.STATE_STOPPED
-                }
         }
     }
 
@@ -294,52 +275,20 @@ fun TopPlaylistScreen(
                                         )
 
                                         Row {
-                                            when (downloadState) {
-                                                Download.STATE_COMPLETED -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            showRemoveDownloadDialog = true
-                                                        },
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.offline),
-                                                            contentDescription = null,
-                                                        )
+                                            AggregateDownloadButton(
+                                                songs = songs.orEmpty(),
+                                                onDownloadAll = {
+                                                    songs?.forEach { downloadUtil.downloadToMediaStore(it) }
+                                                },
+                                                onRemoveAll = { showRemoveDownloadDialog = true },
+                                                onCancelAll = {
+                                                    songs?.forEach { song ->
+                                                        coroutineScope.launch {
+                                                            downloadUtil.removeDownload(song.song.id)
+                                                        }
                                                     }
-                                                }
-
-                                                Download.STATE_DOWNLOADING -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            songs!!.forEach { song ->
-                                                                coroutineScope.launch {
-                                                                    downloadUtil.removeDownload(song.song.id)
-                                                                }
-                                                            }
-                                                        },
-                                                    ) {
-                                                        CircularProgressIndicator(
-                                                            strokeWidth = 2.dp,
-                                                            modifier = Modifier.size(24.dp),
-                                                        )
-                                                    }
-                                                }
-
-                                                else -> {
-                                                    IconButton(
-                                                        onClick = {
-                                                            songs!!.forEach { song ->
-                                                                downloadUtil.downloadToMediaStore(song)
-                                                            }
-                                                        },
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.download),
-                                                            contentDescription = null,
-                                                        )
-                                                    }
-                                                }
-                                            }
+                                                },
+                                            )
 
                                             IconButton(
                                                 onClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
@@ -435,10 +435,18 @@ class MediaStoreHelper(private val context: Context) {
 
                             val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
                             val id = cursor.getLong(idColumn)
-                            Uri.withAppendedPath(
+                            val candidate = Uri.withAppendedPath(
                                 MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY),
                                 id.toString()
                             )
+                            // The size column can lie for a stale entry whose backing file is gone — if
+                            // we returned that, the song would be marked "downloaded" while pointing at a
+                            // missing file (no real download, then ENOENT/streaming on play). Only treat
+                            // it as existing if it actually opens.
+                            val opens = runCatching {
+                                context.contentResolver.openFileDescriptor(candidate, "r")?.use { true } ?: false
+                            }.getOrDefault(false)
+                            if (opens) candidate else null
                         } else {
                             null
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.provider.DocumentsContract
 import android.provider.MediaStore
 import androidx.documentfile.provider.DocumentFile
 import com.jtech.zemer.constants.CustomDownloadPathKey
@@ -510,11 +511,21 @@ class MediaStoreHelper(private val context: Context) {
      * @return true if deletion was successful, false otherwise
      */
     suspend fun deleteFromMediaStore(uri: Uri): Boolean = withContext(Dispatchers.IO) {
+        // A custom download path saves the file as a SAF DOCUMENT uri (saveToCustomPath); those can't
+        // be removed with ContentResolver.delete (that's for MediaStore content uris) — they need
+        // DocumentsContract.deleteDocument, or the file is left behind on "Remove download".
+        if (DocumentsContract.isDocumentUri(context, uri)) {
+            return@withContext runCatching {
+                DocumentsContract.deleteDocument(context.contentResolver, uri)
+            }.recoverCatching {
+                DocumentFile.fromSingleUri(context, uri)?.delete() == true
+            }.getOrDefault(false)
+        }
         try {
-            val deleted = context.contentResolver.delete(uri, null, null)
-            deleted > 0
+            context.contentResolver.delete(uri, null, null) > 0
         } catch (e: Exception) {
-            false
+            // Last resort for tree/document uris that aren't reported as document uris.
+            runCatching { DocumentFile.fromSingleUri(context, uri)?.delete() == true }.getOrDefault(false)
         }
     }
 

--- a/app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt
@@ -1,0 +1,46 @@
+package com.jtech.zemer.latestreleases
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the Latest Releases "See all" filter: ALBUMS keeps multi-track releases, SONGS keeps playable
+ * singles, ALL keeps everything — and feed order is preserved. Pure JVM.
+ */
+class LatestReleaseFilterTest {
+    private fun release(id: String, trackCount: Int?, sampleVideoId: String? = "vid") = LatestRelease(
+        artistId = "UC1",
+        artistName = "Artist",
+        title = id,
+        browseId = id,
+        playlistId = "OLAK_$id",
+        thumbnail = "thumb",
+        year = 2026,
+        uploadDate = "2026-06-17T00:00:00-07:00",
+        trackCount = trackCount,
+        sampleVideoId = sampleVideoId,
+    )
+
+    private val single = release("single", trackCount = 1)
+    private val album = release("album", trackCount = 8)
+    private val unknown = release("unknown", trackCount = null) // older cached feed -> treated as album
+    private val all = listOf(single, album, unknown)
+
+    @Test fun all_keepsEverythingInOrder() {
+        assertEquals(all, all.applyFilter(LatestReleaseFilter.ALL))
+    }
+
+    @Test fun albums_keepsMultiTrackAndUnknown() {
+        assertEquals(listOf(album, unknown), all.applyFilter(LatestReleaseFilter.ALBUMS))
+    }
+
+    @Test fun songs_keepsOnlyPlayableSingles() {
+        assertEquals(listOf(single), all.applyFilter(LatestReleaseFilter.SONGS))
+    }
+
+    @Test fun songs_excludesOneTrackReleaseWithNoVideoId() {
+        val noVid = release("noVid", trackCount = 1, sampleVideoId = null)
+        assertEquals(emptyList<LatestRelease>(), listOf(noVid).applyFilter(LatestReleaseFilter.SONGS))
+        assertEquals(listOf(noVid), listOf(noVid).applyFilter(LatestReleaseFilter.ALBUMS))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadCancellationContractTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadCancellationContractTest.kt
@@ -1,0 +1,75 @@
+package com.jtech.zemer.playback
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Locks the control-flow contract that `MediaStoreDownloadManager.performDownload` depends on. That
+ * method cannot be instantiated in a plain JVM test (it needs a Context, MediaStoreHelper and the Room
+ * DB — Robolectric-level infrastructure), so instead of faking it we pin the exact exception-handling
+ * shape it uses, which would regress silently if someone "simplified" the dedicated
+ * `catch (CancellationException)` rethrow away.
+ *
+ * The bug this guards: `performDownload` retries inside `catch (e: Exception) { ... }`. Because
+ * kotlinx's [CancellationException] IS an [Exception], a naive single catch SWALLOWS cancellation —
+ * a cancelled download then resurrects itself, overwrites the CANCELLED state and pins the foreground
+ * service open forever. The fix is to rethrow cancellation before the retry branch.
+ */
+class DownloadCancellationContractTest {
+
+    @Test
+    fun cancellationException_isAnException_soABareCatchWouldSwallowIt() {
+        // Documents WHY the dedicated rethrow is required.
+        assertTrue(CancellationException("x") is Exception)
+    }
+
+    /** The FIXED shape: rethrow cancellation, then retry other failures. */
+    private suspend fun retryingWork(attempts: AtomicInteger, work: suspend () -> Unit) {
+        try {
+            work()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            attempts.incrementAndGet()
+            delay(1)
+            retryingWork(attempts, work)
+        }
+    }
+
+    @Test
+    fun cancelling_doesNotTriggerRetries() = runBlocking {
+        val retries = AtomicInteger(0)
+        val started = AtomicInteger(0)
+        val job = launch(Dispatchers.Default) {
+            retryingWork(retries) {
+                started.incrementAndGet()
+                delay(10_000) // suspends until cancelled
+            }
+        }
+        while (started.get() == 0) yield()
+        job.cancel()
+        job.join()
+        // The fixed structure must NOT have entered the retry branch on cancellation.
+        assertEquals(0, retries.get())
+    }
+
+    @Test
+    fun realFailures_stillRetry() = runBlocking {
+        val retries = AtomicInteger(0)
+        var calls = 0
+        retryingWork(retries) {
+            calls++
+            if (calls < 3) throw RuntimeException("transient")
+            // succeeds on the 3rd attempt
+        }
+        assertEquals(2, retries.get())
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
@@ -1,6 +1,7 @@
 package com.jtech.zemer.playback
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
@@ -84,5 +85,42 @@ class DownloadMenuLogicTest {
 
     @Test fun collection_none_offersDownload() {
         assertEquals(DownloadRowKind.DOWNLOAD, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED, anyFailed = false))
+    }
+
+    // ---- exhaustive invariants over the full input space ----
+
+    @Test fun songRow_downloadedAlwaysRemove_regardlessOfFlags() {
+        for (failed in listOf(true, false)) for (isVideo in listOf(true, false)) for (block in listOf(true, false)) {
+            assertEquals(
+                "downloaded must always offer Remove (failed=$failed video=$isVideo block=$block)",
+                DownloadRowKind.REMOVE,
+                DownloadMenuLogic.songRow(DownloadStatus.DOWNLOADED, failed, isVideo, block),
+            )
+        }
+    }
+
+    @Test fun songRow_blockedVideoNeverOffersAVideoDownload() {
+        for (status in DownloadStatus.entries) for (failed in listOf(true, false)) {
+            val kind = DownloadMenuLogic.songRow(status, failed, isVideo = true, blockVideos = true)
+            assertNotEquals(DownloadRowKind.DOWNLOAD_VIDEO, kind)
+            assertNotEquals(DownloadRowKind.DOWNLOAD, kind)
+        }
+    }
+
+    @Test fun songRow_neverReturnsDownloadVideoForNonVideo() {
+        for (status in DownloadStatus.entries) for (failed in listOf(true, false)) for (block in listOf(true, false)) {
+            assertNotEquals(
+                DownloadRowKind.DOWNLOAD_VIDEO,
+                DownloadMenuLogic.songRow(status, failed, isVideo = false, blockVideos = block),
+            )
+        }
+    }
+
+    @Test fun collectionRow_neverHiddenOrVideo() {
+        for (status in DownloadStatus.entries) for (failed in listOf(true, false)) {
+            val kind = DownloadMenuLogic.collectionRow(status, failed)
+            assertNotEquals(DownloadRowKind.HIDDEN, kind)
+            assertNotEquals(DownloadRowKind.DOWNLOAD_VIDEO, kind)
+        }
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
@@ -68,23 +68,37 @@ class DownloadMenuLogicTest {
     // ---- collection ----
 
     @Test fun collection_allDownloaded_offersRemove() {
-        assertEquals(DownloadRowKind.REMOVE, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADED, anyFailed = false))
-    }
-
-    @Test fun collection_downloaded_winsOverFailedMember() {
-        assertEquals(DownloadRowKind.REMOVE, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADED, anyFailed = true))
-    }
-
-    @Test fun collection_failedMember_offersRetry() {
-        assertEquals(DownloadRowKind.FAILED, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED, anyFailed = true))
+        assertEquals(DownloadRowKind.REMOVE, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADED))
     }
 
     @Test fun collection_inProgress_showsProgress() {
-        assertEquals(DownloadRowKind.DOWNLOADING, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADING, anyFailed = false))
+        assertEquals(DownloadRowKind.DOWNLOADING, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADING))
     }
 
     @Test fun collection_none_offersDownload() {
-        assertEquals(DownloadRowKind.DOWNLOAD, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED, anyFailed = false))
+        assertEquals(DownloadRowKind.DOWNLOAD, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED))
+    }
+
+    /**
+     * Regression: a collection with one failed member among downloaded ones must NOT dead-end on a
+     * retry-only row. The aggregate of [DOWNLOADED, DOWNLOADED, NOT_DOWNLOADED(failed)] is
+     * NOT_DOWNLOADED, which must offer DOWNLOAD (re-enqueues/retries the missing member) — never a
+     * FAILED row that hides Download and Remove.
+     */
+    @Test fun collection_partialWithFailedMember_offersDownloadNotDeadEnd() {
+        val aggregate = DownloadStateResolver.aggregate(
+            listOf(DownloadStatus.DOWNLOADED, DownloadStatus.DOWNLOADED, DownloadStatus.NOT_DOWNLOADED),
+        )
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, aggregate)
+        val kind = DownloadMenuLogic.collectionRow(aggregate)
+        assertEquals(DownloadRowKind.DOWNLOAD, kind)
+        assertNotEquals(DownloadRowKind.FAILED, kind)
+    }
+
+    @Test fun collectionRow_neverFailed() {
+        for (status in DownloadStatus.entries) {
+            assertNotEquals(DownloadRowKind.FAILED, DownloadMenuLogic.collectionRow(status))
+        }
     }
 
     // ---- exhaustive invariants over the full input space ----
@@ -117,8 +131,8 @@ class DownloadMenuLogicTest {
     }
 
     @Test fun collectionRow_neverHiddenOrVideo() {
-        for (status in DownloadStatus.entries) for (failed in listOf(true, false)) {
-            val kind = DownloadMenuLogic.collectionRow(status, failed)
+        for (status in DownloadStatus.entries) {
+            val kind = DownloadMenuLogic.collectionRow(status)
             assertNotEquals(DownloadRowKind.HIDDEN, kind)
             assertNotEquals(DownloadRowKind.DOWNLOAD_VIDEO, kind)
         }

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt
@@ -1,0 +1,88 @@
+package com.jtech.zemer.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Strict lock on the menu decision so "Download vs Remove vs progress vs retry" can never differ
+ * between menus again. The two historical bugs this guards: (1) a downloaded item still offering
+ * "Download" because the menu read a live-only source, and (2) a blocked video still showing a
+ * download row.
+ */
+class DownloadMenuLogicTest {
+
+    // ---- single song ----
+
+    @Test fun downloaded_song_offersRemove_evenIfLiveFailed() {
+        // Persisted DOWNLOADED must win over a stale FAILED live flag — the file is on disk.
+        assertEquals(
+            DownloadRowKind.REMOVE,
+            DownloadMenuLogic.songRow(DownloadStatus.DOWNLOADED, failed = true, isVideo = false, blockVideos = false),
+        )
+    }
+
+    @Test fun failed_song_offersRetry() {
+        assertEquals(
+            DownloadRowKind.FAILED,
+            DownloadMenuLogic.songRow(DownloadStatus.NOT_DOWNLOADED, failed = true, isVideo = false, blockVideos = false),
+        )
+    }
+
+    @Test fun downloading_song_showsProgress() {
+        assertEquals(
+            DownloadRowKind.DOWNLOADING,
+            DownloadMenuLogic.songRow(DownloadStatus.DOWNLOADING, failed = false, isVideo = false, blockVideos = false),
+        )
+    }
+
+    @Test fun notDownloaded_audio_offersDownload() {
+        assertEquals(
+            DownloadRowKind.DOWNLOAD,
+            DownloadMenuLogic.songRow(DownloadStatus.NOT_DOWNLOADED, failed = false, isVideo = false, blockVideos = false),
+        )
+    }
+
+    @Test fun notDownloaded_video_offersVideoDownload() {
+        assertEquals(
+            DownloadRowKind.DOWNLOAD_VIDEO,
+            DownloadMenuLogic.songRow(DownloadStatus.NOT_DOWNLOADED, failed = false, isVideo = true, blockVideos = false),
+        )
+    }
+
+    @Test fun blockedVideo_isHidden() {
+        assertEquals(
+            DownloadRowKind.HIDDEN,
+            DownloadMenuLogic.songRow(DownloadStatus.NOT_DOWNLOADED, failed = false, isVideo = true, blockVideos = true),
+        )
+    }
+
+    @Test fun blockedVideo_thatIsDownloaded_stillOffersRemove() {
+        // A blocked video already on disk must still be removable.
+        assertEquals(
+            DownloadRowKind.REMOVE,
+            DownloadMenuLogic.songRow(DownloadStatus.DOWNLOADED, failed = false, isVideo = true, blockVideos = true),
+        )
+    }
+
+    // ---- collection ----
+
+    @Test fun collection_allDownloaded_offersRemove() {
+        assertEquals(DownloadRowKind.REMOVE, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADED, anyFailed = false))
+    }
+
+    @Test fun collection_downloaded_winsOverFailedMember() {
+        assertEquals(DownloadRowKind.REMOVE, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADED, anyFailed = true))
+    }
+
+    @Test fun collection_failedMember_offersRetry() {
+        assertEquals(DownloadRowKind.FAILED, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED, anyFailed = true))
+    }
+
+    @Test fun collection_inProgress_showsProgress() {
+        assertEquals(DownloadRowKind.DOWNLOADING, DownloadMenuLogic.collectionRow(DownloadStatus.DOWNLOADING, anyFailed = false))
+    }
+
+    @Test fun collection_none_offersDownload() {
+        assertEquals(DownloadRowKind.DOWNLOAD, DownloadMenuLogic.collectionRow(DownloadStatus.NOT_DOWNLOADED, anyFailed = false))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
@@ -131,4 +131,35 @@ class DownloadStateResolverTest {
         // Persisted flag wins over a stale live FAILED (the file is on disk).
         assertEquals(DownloadStatus.DOWNLOADED, DownloadStateResolver.forSong(isDownloaded = true, live = live(Status.FAILED)))
     }
+
+    // ---- id-based (online album/playlist menus) ----
+
+    @Test
+    fun aggregateByIds_showsDownloadingFromLiveMapWithoutDbEntities() {
+        // The bug: online playlist progress was computed over an empty/stale dbSongs snapshot, so it
+        // never moved. By id off the live map it must reflect in-progress downloads.
+        val ids = listOf("a", "b")
+        val liveMap = mapOf(
+            "a" to live(Status.DOWNLOADING, progress = 0.4f),
+            "b" to live(Status.DOWNLOADING, progress = 0.6f),
+        )
+        assertEquals(DownloadStatus.DOWNLOADING, DownloadStateResolver.aggregateByIds(ids, liveMap, emptySet()))
+        assertEquals(0.5f, DownloadStateResolver.aggregateProgressByIds(ids, liveMap, emptySet()), 0.0001f)
+    }
+
+    @Test
+    fun aggregateByIds_persistedDownloadedCountsAsDownloaded() {
+        val ids = listOf("a", "b")
+        assertEquals(
+            DownloadStatus.DOWNLOADED,
+            DownloadStateResolver.aggregateByIds(ids, emptyMap(), persistedDownloaded = setOf("a", "b")),
+        )
+        assertEquals(1f, DownloadStateResolver.aggregateProgressByIds(ids, emptyMap(), setOf("a", "b")), 0.0001f)
+    }
+
+    @Test
+    fun aggregateByIds_empty_isNotDownloaded() {
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.aggregateByIds(emptyList(), emptyMap(), emptySet()))
+        assertEquals(0f, DownloadStateResolver.aggregateProgressByIds(emptyList(), emptyMap(), emptySet()), 0.0001f)
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
@@ -1,0 +1,134 @@
+package com.jtech.zemer.playback
+
+import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.db.entities.SongEntity
+import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState
+import com.jtech.zemer.playback.MediaStoreDownloadManager.DownloadState.Status
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks down the one true download-state rule used by every badge/menu/header. The bug this guards
+ * against: surfaces that read only the live in-session map show "not downloaded" after a restart even
+ * though the persisted flag says the file is on disk — so [forSong] must treat the persisted flag as
+ * authoritative for DOWNLOADED.
+ */
+class DownloadStateResolverTest {
+
+    private fun live(status: Status, progress: Float = 0f) =
+        DownloadState(songId = "x", status = status, progress = progress)
+
+    private fun song(id: String, isDownloaded: Boolean) =
+        Song(song = SongEntity(id = id, title = id, isDownloaded = isDownloaded), artists = emptyList())
+
+    @Test
+    fun persistedFlag_aloneMeansDownloaded_evenWithNoLiveState() {
+        // The restart case: in-memory map is empty, but the DB says downloaded.
+        assertEquals(DownloadStatus.DOWNLOADED, DownloadStateResolver.forSong(isDownloaded = true, live = null))
+    }
+
+    @Test
+    fun liveCompleted_meansDownloaded_evenIfFlagNotYetPersisted() {
+        assertEquals(
+            DownloadStatus.DOWNLOADED,
+            DownloadStateResolver.forSong(isDownloaded = false, live = live(Status.COMPLETED)),
+        )
+    }
+
+    @Test
+    fun queuedOrDownloading_meansDownloading() {
+        assertEquals(DownloadStatus.DOWNLOADING, DownloadStateResolver.forSong(false, live(Status.QUEUED)))
+        assertEquals(DownloadStatus.DOWNLOADING, DownloadStateResolver.forSong(false, live(Status.DOWNLOADING)))
+    }
+
+    @Test
+    fun failedOrCancelledOrNone_meansNotDownloaded() {
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.forSong(false, null))
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.forSong(false, live(Status.FAILED)))
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.forSong(false, live(Status.CANCELLED)))
+    }
+
+    @Test
+    fun aggregate_allDownloaded_isDownloaded() {
+        assertEquals(
+            DownloadStatus.DOWNLOADED,
+            DownloadStateResolver.aggregate(listOf(DownloadStatus.DOWNLOADED, DownloadStatus.DOWNLOADED)),
+        )
+    }
+
+    @Test
+    fun aggregate_anyNotDownloaded_isNotDownloaded() {
+        assertEquals(
+            DownloadStatus.NOT_DOWNLOADED,
+            DownloadStateResolver.aggregate(
+                listOf(DownloadStatus.DOWNLOADED, DownloadStatus.DOWNLOADING, DownloadStatus.NOT_DOWNLOADED),
+            ),
+        )
+    }
+
+    @Test
+    fun aggregate_mixOfDownloadedAndInProgress_isDownloading() {
+        assertEquals(
+            DownloadStatus.DOWNLOADING,
+            DownloadStateResolver.aggregate(listOf(DownloadStatus.DOWNLOADED, DownloadStatus.DOWNLOADING)),
+        )
+    }
+
+    @Test
+    fun aggregate_empty_isNotDownloaded() {
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.aggregate(emptyList()))
+    }
+
+    @Test
+    fun aggregateSongs_persistedAlbumStaysDownloadedAfterRestart() {
+        // Two songs flagged downloaded in DB, live map empty (fresh launch) -> album reads DOWNLOADED.
+        val songs = listOf(song("a", true), song("b", true))
+        assertEquals(DownloadStatus.DOWNLOADED, DownloadStateResolver.aggregateSongs(songs, emptyMap()))
+    }
+
+    @Test
+    fun aggregateProgress_averagesDownloadedAsOneAndInProgressByFraction() {
+        val songs = listOf(song("a", true), song("b", false))
+        val live = mapOf("b" to live(Status.DOWNLOADING, progress = 0.5f))
+        // (1.0 + 0.5) / 2
+        assertEquals(0.75f, DownloadStateResolver.aggregateProgress(songs, live), 0.0001f)
+    }
+
+    @Test
+    fun aggregateProgress_empty_isZero() {
+        assertEquals(0f, DownloadStateResolver.aggregateProgress(emptyList(), emptyMap()), 0.0001f)
+    }
+
+    @Test
+    fun aggregateProgress_allDownloaded_isOne() {
+        val songs = listOf(song("a", true), song("b", true))
+        assertEquals(1f, DownloadStateResolver.aggregateProgress(songs, emptyMap()), 0.0001f)
+    }
+
+    @Test
+    fun aggregateProgress_noneDownloaded_isZero() {
+        val songs = listOf(song("a", false), song("b", false))
+        assertEquals(0f, DownloadStateResolver.aggregateProgress(songs, emptyMap()), 0.0001f)
+    }
+
+    @Test
+    fun aggregateSongs_failedMemberMakesCollectionNotDownloaded() {
+        // A FAILED song counts as NOT_DOWNLOADED for the aggregate (resolver maps FAILED -> not).
+        val songs = listOf(song("a", true), song("b", false))
+        val live = mapOf("b" to live(Status.FAILED))
+        assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.aggregateSongs(songs, live))
+    }
+
+    @Test
+    fun aggregateSongs_downloadedPlusDownloading_isDownloading() {
+        val songs = listOf(song("a", true), song("b", false))
+        val live = mapOf("b" to live(Status.DOWNLOADING, progress = 0.3f))
+        assertEquals(DownloadStatus.DOWNLOADING, DownloadStateResolver.aggregateSongs(songs, live))
+    }
+
+    @Test
+    fun forSong_failedButPersistedDownloaded_staysDownloaded() {
+        // Persisted flag wins over a stale live FAILED (the file is on disk).
+        assertEquals(DownloadStatus.DOWNLOADED, DownloadStateResolver.forSong(isDownloaded = true, live = live(Status.FAILED)))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt
@@ -162,4 +162,25 @@ class DownloadStateResolverTest {
         assertEquals(DownloadStatus.NOT_DOWNLOADED, DownloadStateResolver.aggregateByIds(emptyList(), emptyMap(), emptySet()))
         assertEquals(0f, DownloadStateResolver.aggregateProgressByIds(emptyList(), emptyMap(), emptySet()), 0.0001f)
     }
+
+    // ---- per-song progress ----
+
+    @Test fun songProgress_downloaded_isOne() {
+        assertEquals(1f, DownloadStateResolver.songProgress(isDownloaded = true, live = null), 0.0001f)
+        assertEquals(1f, DownloadStateResolver.songProgress(false, live(Status.COMPLETED)), 0.0001f)
+    }
+
+    @Test fun songProgress_downloading_isLiveFraction() {
+        assertEquals(0.42f, DownloadStateResolver.songProgress(false, live(Status.DOWNLOADING, 0.42f)), 0.0001f)
+    }
+
+    @Test fun songProgress_notDownloaded_isZero() {
+        assertEquals(0f, DownloadStateResolver.songProgress(false, null), 0.0001f)
+        assertEquals(0f, DownloadStateResolver.songProgress(false, live(Status.QUEUED)), 0.0001f)
+    }
+
+    @Test fun songProgress_clampsOutOfRange() {
+        assertEquals(1f, DownloadStateResolver.songProgress(false, live(Status.DOWNLOADING, 1.5f)), 0.0001f)
+        assertEquals(0f, DownloadStateResolver.songProgress(false, live(Status.DOWNLOADING, -0.3f)), 0.0001f)
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt
@@ -1,0 +1,71 @@
+package com.jtech.zemer.ui.menu
+
+import com.jtech.zemer.playback.DownloadRowKind
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Locks the unified download menu row builder so every menu wires the SAME action to the SAME row,
+ * and so the "menu stays open" contract can't silently regress (the builder must never attach a
+ * dismiss). Compose lambdas are stored, not invoked, so this runs as a plain JVM test.
+ */
+class DownloadMenuItemsTest {
+
+    @Test fun hidden_producesNoRow() {
+        assertNull(downloadMenuItem(DownloadRowKind.HIDDEN))
+    }
+
+    @Test fun remove_firesOnRemoveOnly() {
+        val onDownload = {}; val onCancel = {}; val onRetry = {}; val onRemove = {}
+        val item = downloadMenuItem(
+            DownloadRowKind.REMOVE,
+            onDownload = onDownload, onCancel = onCancel, onRetry = onRetry, onRemove = onRemove,
+        )
+        assertNotNull(item)
+        assertSame(onRemove, item!!.onClick)
+    }
+
+    @Test fun downloading_firesOnCancel() {
+        val onDownload = {}; val onCancel = {}; val onRetry = {}; val onRemove = {}
+        val item = downloadMenuItem(
+            DownloadRowKind.DOWNLOADING, progress = 0.5f,
+            onDownload = onDownload, onCancel = onCancel, onRetry = onRetry, onRemove = onRemove,
+        )
+        assertSame(onCancel, item!!.onClick)
+    }
+
+    @Test fun failed_firesOnRetry() {
+        val onDownload = {}; val onCancel = {}; val onRetry = {}; val onRemove = {}
+        val item = downloadMenuItem(
+            DownloadRowKind.FAILED,
+            onDownload = onDownload, onCancel = onCancel, onRetry = onRetry, onRemove = onRemove,
+        )
+        assertSame(onRetry, item!!.onClick)
+    }
+
+    @Test fun download_firesOnDownload() {
+        val onDownload = {}; val onCancel = {}; val onRetry = {}; val onRemove = {}
+        val item = downloadMenuItem(
+            DownloadRowKind.DOWNLOAD,
+            onDownload = onDownload, onCancel = onCancel, onRetry = onRetry, onRemove = onRemove,
+        )
+        assertSame(onDownload, item!!.onClick)
+    }
+
+    @Test fun downloadVideo_firesOnDownload() {
+        val onDownload = {}; val onCancel = {}; val onRetry = {}; val onRemove = {}
+        val item = downloadMenuItem(
+            DownloadRowKind.DOWNLOAD_VIDEO,
+            onDownload = onDownload, onCancel = onCancel, onRetry = onRetry, onRemove = onRemove,
+        )
+        assertSame(onDownload, item!!.onClick)
+    }
+
+    @Test fun everyNonHiddenKind_producesARow() {
+        DownloadRowKind.entries.filter { it != DownloadRowKind.HIDDEN }.forEach { kind ->
+            assertNotNull("expected a row for $kind", downloadMenuItem(kind))
+        }
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (350)
+## `app` Kotlin files (362)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -70,8 +70,9 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/extensions/QueueExt.kt` | 112 | `com.jtech.zemer.extensions` | no | 9 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/extensions/StringExt.kt` | 23 | `com.jtech.zemer.extensions` | no | 3 | 4 | androidx.sqlite, java.net |
 | `app/src/main/kotlin/com/jtech/zemer/extensions/UtilExt.kt` | 8 | `com.jtech.zemer.extensions` | no | 0 | 0 |  |
-| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt` | 83 | `com.jtech.zemer.latestreleases` | yes | 17 | 7 | androidx.compose, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt` | 133 | `com.jtech.zemer.latestreleases` | yes | 30 | 12 | androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseDate.kt` | 16 | `com.jtech.zemer.latestreleases` | no | 2 | 2 | android.text, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilter.kt` | 15 | `com.jtech.zemer.latestreleases` | no | 0 | 2 |  |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseMapping.kt` | 19 | `com.jtech.zemer.latestreleases` | no | 2 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlayback.kt` | 80 | `com.jtech.zemer.latestreleases` | no | 7 | 10 | androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt` | 256 | `com.jtech.zemer.latestreleases` | no | 17 | 65 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
@@ -90,12 +91,14 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistPlayerState.kt` | 14 | `com.jtech.zemer.models` | no | 1 | 9 | java.io |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistQueue.kt` | 54 | `com.jtech.zemer.models` | no | 1 | 31 | java.io |
 | `app/src/main/kotlin/com/jtech/zemer/playback/AudioOnlyRenderersFactory.kt` | 25 | `com.jtech.zemer.playback` | no | 7 | 2 | android.content, android.os, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt` | 361 | `com.jtech.zemer.playback` | no | 49 | 51 | android.content, android.net, androidx.core, androidx.media3, dagger.hilt, java.time, java.util, javax.inject, kotlinx.coroutines, okhttp3.OkHttpClient |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt` | 68 | `com.jtech.zemer.playback` | no | 0 | 4 |  |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt` | 106 | `com.jtech.zemer.playback` | no | 3 | 11 |  |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt` | 319 | `com.jtech.zemer.playback` | no | 46 | 44 | android.content, android.net, androidx.core, androidx.media3, dagger.hilt, java.time, java.util, javax.inject, kotlinx.coroutines, okhttp3.OkHttpClient |
 | `app/src/main/kotlin/com/jtech/zemer/playback/ExoDownloadService.kt` | 111 | `com.jtech.zemer.playback` | no | 17 | 16 | android.app, android.content, android.graphics, androidx.media3, dagger.hilt, javax.inject |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 832 | `com.jtech.zemer.playback` | no | 59 | 82 | android.content, android.net, android.os, androidx.annotation, androidx.core, androidx.media3, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 728 | `com.jtech.zemer.playback` | no | 38 | 93 | android.content, android.net, androidx.core, dagger.hilt, java.io, java.time, javax.inject, kotlin.math, kotlinx.coroutines, okhttp3.OkHttpClient, okhttp3.Request, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 808 | `com.jtech.zemer.playback` | no | 59 | 80 | android.content, android.net, android.os, androidx.annotation, androidx.core, androidx.media3, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 806 | `com.jtech.zemer.playback` | no | 40 | 102 | android.content, android.net, androidx.core, dagger.hilt, java.io, java.time, java.util, javax.inject, kotlin.math, kotlinx.coroutines, okhttp3.OkHttpClient, okhttp3.Request, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadService.kt` | 306 | `com.jtech.zemer.playback` | no | 27 | 49 | android.app, android.content, android.os, androidx.core, dagger.hilt, javax.inject, kotlin.math, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 1694 | `com.jtech.zemer.playback` | no | 162 | 188 | android.app, android.content, android.media, android.net, android.os, android.widget, androidx.core, androidx.datastore, androidx.media3, com.zemer, dagger.hilt, java.io, java.sql, java.time, java.util, javax.inject, kotlin.time, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 1744 | `com.jtech.zemer.playback` | no | 162 | 191 | android.app, android.content, android.media, android.net, android.os, android.widget, androidx.core, androidx.datastore, androidx.media3, com.zemer, dagger.hilt, java.io, java.sql, java.time, java.util, javax.inject, kotlin.time, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt` | 207 | `com.jtech.zemer.playback` | no | 25 | 40 | android.content, androidx.media3, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/playback/SleepTimer.kt` | 68 | `com.jtech.zemer.playback` | no | 11 | 11 | androidx.compose, androidx.media3, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/playback/queues/EmptyQueue.kt` | 14 | `com.jtech.zemer.playback.queues` | no | 2 | 5 | androidx.media3 |
@@ -128,16 +131,17 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheet.kt` | 348 | `com.jtech.zemer.ui.component` | yes | 47 | 45 | androidx.activity, androidx.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetMenu.kt` | 86 | `com.jtech.zemer.ui.component` | yes | 23 | 8 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetPage.kt` | 166 | `com.jtech.zemer.ui.component` | yes | 47 | 10 | androidx.activity, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 247 | `com.jtech.zemer.ui.component` | yes | 56 | 9 | android.annotation, androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 254 | `com.jtech.zemer.ui.component` | yes | 56 | 9 | android.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/CreatePlaylistDialog.kt` | 131 | `com.jtech.zemer.ui.component` | yes | 34 | 8 | android.widget, androidx.compose, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Dialog.kt` | 389 | `com.jtech.zemer.ui.component` | yes | 50 | 9 | androidx.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt` | 170 | `com.jtech.zemer.ui.component` | yes | 28 | 18 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/DraggableScrollBarOverlay.kt` | 242 | `com.jtech.zemer.ui.component` | yes | 34 | 51 | androidx.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/EmptyPlaceholder.kt` | 47 | `com.jtech.zemer.ui.component` | yes | 16 | 1 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 50 | `com.jtech.zemer.ui.component` | no | 17 | 4 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 197 | `com.jtech.zemer.ui.component` | yes | 34 | 6 | androidx.annotation, androidx.compose, androidx.media3 |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 158 | `com.jtech.zemer.ui.component` | yes | 32 | 5 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 | `com.jtech.zemer.ui.component` | yes | 36 | 6 | androidx.annotation, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1630 | `com.jtech.zemer.ui.component` | yes | 114 | 92 | android.annotation, android.widget, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1571 | `com.jtech.zemer.ui.component` | yes | 109 | 87 | android.annotation, android.widget, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 410 | `com.jtech.zemer.ui.component` | yes | 33 | 8 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 970 | `com.jtech.zemer.ui.component` | yes | 117 | 112 | android.annotation, android.content, android.os, android.widget, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
@@ -153,6 +157,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 | `com.jtech.zemer.ui.component` | yes | 47 | 12 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 | `com.jtech.zemer.ui.component` | yes | 79 | 32 | androidx.activity, androidx.compose, kotlin.math |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
@@ -164,21 +169,23 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/TextPlaceholder.kt` | 33 | `com.jtech.zemer.ui.component.shimmer` | yes | 15 | 1 | androidx.compose, kotlin.random |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialog.kt` | 195 | `com.jtech.zemer.ui.menu` | yes | 36 | 10 | androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialogOnline.kt` | 207 | `com.jtech.zemer.ui.menu` | yes | 42 | 15 | androidx.compose, java.net, java.nio, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt` | 451 | `com.jtech.zemer.ui.menu` | yes | 58 | 28 | android.annotation, android.content, androidx.compose, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt` | 365 | `com.jtech.zemer.ui.menu` | yes | 59 | 21 | android.annotation, android.content, androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ArtistMenu.kt` | 266 | `com.jtech.zemer.ui.menu` | yes | 52 | 10 | android.content, androidx.compose, coil3.compose, coil3.request, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/CustomThumbnailMenu.kt` | 63 | `com.jtech.zemer.ui.menu` | yes | 17 | 1 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItems.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 12 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ImportPlaylistDialog.kt` | 63 | `com.jtech.zemer.ui.menu` | yes | 18 | 7 | androidx.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/LibraryMenuItems.kt` | 34 | `com.jtech.zemer.ui.menu` | no | 9 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/LoadingScreen.kt` | 23 | `com.jtech.zemer.ui.menu` | yes | 6 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/LyricsMenu.kt` | 372 | `com.jtech.zemer.ui.menu` | yes | 58 | 16 | android.app, android.content, android.widget, androidx.compose, androidx.hilt |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt` | 508 | `com.jtech.zemer.ui.menu` | yes | 70 | 25 | android.content, android.media, android.widget, androidx.activity, androidx.annotation, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt` | 215 | `com.jtech.zemer.ui.menu` | yes | 43 | 9 | android.content, androidx.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt` | 488 | `com.jtech.zemer.ui.menu` | yes | 72 | 30 | android.content, android.media, android.widget, androidx.activity, androidx.annotation, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt` | 234 | `com.jtech.zemer.ui.menu` | yes | 48 | 13 | android.content, androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ReportContentDialog.kt` | 130 | `com.jtech.zemer.ui.menu` | yes | 31 | 8 | android.widget, androidx.compose, androidx.hilt, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt` | 736 | `com.jtech.zemer.ui.menu` | yes | 53 | 35 | android.annotation, androidx.compose, androidx.media3, java.time, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt` | 628 | `com.jtech.zemer.ui.menu` | yes | 73 | 40 | android.content, android.widget, androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt` | 392 | `com.jtech.zemer.ui.menu` | yes | 58 | 15 | android.annotation, android.content, androidx.compose, androidx.media3, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt` | 588 | `com.jtech.zemer.ui.menu` | yes | 52 | 40 | android.annotation, androidx.compose, androidx.media3, java.time, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt` | 550 | `com.jtech.zemer.ui.menu` | yes | 74 | 39 | android.content, android.widget, androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt` | 348 | `com.jtech.zemer.ui.menu` | yes | 58 | 18 | android.annotation, android.content, androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeArtistMenu.kt` | 204 | `com.jtech.zemer.ui.menu` | yes | 37 | 8 | android.content, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 502 | `com.jtech.zemer.ui.menu` | yes | 72 | 18 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 554 | `com.jtech.zemer.ui.menu` | yes | 77 | 26 | android.annotation, android.content, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, java.time, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 477 | `com.jtech.zemer.ui.menu` | yes | 71 | 23 | android.annotation, android.content, androidx.compose, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 469 | `com.jtech.zemer.ui.menu` | yes | 77 | 28 | android.annotation, android.content, androidx.compose, androidx.navigation, coil3.compose, java.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 748 | `com.jtech.zemer.ui.player` | yes | 90 | 28 | android.app, android.content, android.view, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, dagger.hilt, kotlinx.coroutines, me.saket |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1040 | `com.jtech.zemer.ui.player` | yes | 96 | 109 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
@@ -187,14 +194,14 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1130 | `com.jtech.zemer.ui.player` | yes | 116 | 48 | android.annotation, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines, sh.calvin |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 481 | `com.jtech.zemer.ui.player` | yes | 76 | 57 | androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt` | 200 | `com.jtech.zemer.ui.screens` | yes | 39 | 8 | androidx.compose, androidx.hilt, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 723 | `com.jtech.zemer.ui.screens` | yes | 98 | 46 | androidx.activity, androidx.compose, androidx.hilt, androidx.media3, androidx.navigation, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 635 | `com.jtech.zemer.ui.screens` | yes | 99 | 42 | androidx.activity, androidx.compose, androidx.hilt, androidx.media3, androidx.navigation, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/BrowseScreen.kt` | 143 | `com.jtech.zemer.ui.screens` | yes | 37 | 7 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt` | 307 | `com.jtech.zemer.ui.screens` | yes | 74 | 16 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ExploreScreen.kt` | 400 | `com.jtech.zemer.ui.screens` | yes | 75 | 20 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 517 | `com.jtech.zemer.ui.screens` | yes | 75 | 31 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 924 | `com.jtech.zemer.ui.screens` | yes | 104 | 62 | androidx.compose, androidx.hilt, androidx.navigation, kotlin.math, kotlin.random, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 336 | `com.jtech.zemer.ui.screens` | yes | 63 | 19 | androidx.compose, androidx.hilt, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 100 | `com.jtech.zemer.ui.screens` | yes | 30 | 8 | androidx.compose, androidx.hilt, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 122 | `com.jtech.zemer.ui.screens` | yes | 37 | 10 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt` | 253 | `com.jtech.zemer.ui.screens` | yes | 53 | 23 | android.widget, androidx.compose, androidx.navigation, io.ktor, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt` | 227 | `com.jtech.zemer.ui.screens` | yes | 41 | 20 | android.annotation, android.content, android.webkit, android.widget, androidx.activity, androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/MoodAndGenresScreen.kt` | 171 | `com.jtech.zemer.ui.screens` | yes | 40 | 8 | android.content, androidx.compose, androidx.hilt, androidx.navigation |
@@ -216,16 +223,16 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 797 | `com.jtech.zemer.ui.screens.library` | yes | 96 | 38 | android.widget, androidx.compose, androidx.hilt, androidx.navigation, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 545 | `com.jtech.zemer.ui.screens.library` | yes | 77 | 32 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 87 | `com.jtech.zemer.ui.screens.library` | yes | 16 | 6 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 356 | `com.jtech.zemer.ui.screens.library` | yes | 68 | 23 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 327 | `com.jtech.zemer.ui.screens.library` | yes | 69 | 22 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 156 | `com.jtech.zemer.ui.screens.library` | yes | 42 | 10 | androidx.compose, androidx.hilt, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt` | 1105 | `com.jtech.zemer.ui.screens.player` | yes | 114 | 127 | android.app, android.content, android.net, android.os, android.util, android.view, android.widget, androidx.activity, androidx.compose, androidx.lifecycle, androidx.media3, androidx.navigation, io.sanghun, java.io, java.time, java.util, kotlinx.coroutines, okhttp3.OkHttpClient, okhttp3.Request |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt` | 681 | `com.jtech.zemer.ui.screens.playlist` | yes | 104 | 35 | androidx.activity, androidx.compose, androidx.hilt, androidx.media3, androidx.navigation, coil3.compose, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt` | 491 | `com.jtech.zemer.ui.screens.playlist` | yes | 86 | 24 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt` | 1060 | `com.jtech.zemer.ui.screens.player` | yes | 113 | 120 | android.app, android.content, android.net, android.os, android.util, android.view, android.widget, androidx.activity, androidx.compose, androidx.lifecycle, androidx.media3, androidx.navigation, io.sanghun, java.util, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt` | 607 | `com.jtech.zemer.ui.screens.playlist` | yes | 103 | 33 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt` | 474 | `com.jtech.zemer.ui.screens.playlist` | yes | 87 | 23 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedContentScreen.kt` | 182 | `com.jtech.zemer.ui.screens.playlist` | yes | 41 | 5 | androidx.compose, androidx.hilt, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt` | 510 | `com.jtech.zemer.ui.screens.playlist` | yes | 92 | 27 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt` | 1513 | `com.jtech.zemer.ui.screens.playlist` | yes | 158 | 89 | android.annotation, android.content, android.graphics, android.net, androidx.activity, androidx.compose, androidx.core, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.request, com.yalantis, io.ktor, java.time, kotlinx.coroutines, sh.calvin |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt` | 489 | `com.jtech.zemer.ui.screens.playlist` | yes | 93 | 26 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt` | 1428 | `com.jtech.zemer.ui.screens.playlist` | yes | 157 | 87 | android.annotation, android.content, android.graphics, android.net, androidx.activity, androidx.compose, androidx.core, androidx.hilt, androidx.lifecycle, androidx.navigation, coil3.compose, coil3.request, com.yalantis, io.ktor, java.time, kotlinx.coroutines, sh.calvin |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt` | 730 | `com.jtech.zemer.ui.screens.playlist` | yes | 111 | 30 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, coil3.request |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 632 | `com.jtech.zemer.ui.screens.playlist` | yes | 97 | 29 | androidx.activity, androidx.compose, androidx.hilt, androidx.media3, androidx.navigation, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 | `com.jtech.zemer.ui.screens.playlist` | yes | 96 | 27 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 | `com.jtech.zemer.ui.screens.recognition` | yes | 51 | 6 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 | `com.jtech.zemer.ui.screens.recognition` | yes | 65 | 19 | android.content, android.os, androidx.activity, androidx.compose, androidx.core, androidx.hilt, coil3.compose, dagger.hilt |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 441 | `com.jtech.zemer.ui.screens.search` | yes | 76 | 28 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
@@ -278,7 +285,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/FirestoreUtils.kt` | 41 | `com.jtech.zemer.utils` | no | 0 | 2 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/FutureUtils.kt` | 43 | `com.jtech.zemer.utils` | no | 8 | 3 | androidx.concurrent, com.google, java.util, kotlin.coroutines, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/IsraeliArtistRegistry.kt` | 51 | `com.jtech.zemer.utils` | no | 5 | 7 | com.google, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt` | 669 | `com.jtech.zemer.utils` | no | 16 | 82 | android.content, android.net, android.os, android.provider, androidx.documentfile, java.io, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt` | 688 | `com.jtech.zemer.utils` | no | 17 | 83 | android.content, android.net, android.os, android.provider, androidx.documentfile, java.io, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NetworkConnectivityObserver.kt` | 74 | `com.jtech.zemer.utils` | no | 7 | 15 | android.content, android.net, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NetworkUtils.kt` | 20 | `com.jtech.zemer.utils` | no | 4 | 4 | android.content, android.net, androidx.core |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NotificationUtils.kt` | 35 | `com.jtech.zemer.utils` | no | 6 | 2 | android.Manifest, android.content, android.os, androidx.core |
@@ -342,14 +349,19 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/YouTubeBrowseViewModel.kt` | 52 | `com.jtech.zemer.viewmodels` | no | 17 | 7 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
+| `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt` | 46 | `com.jtech.zemer.latestreleases` | no | 2 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlaybackTest.kt` | 120 | `com.jtech.zemer.latestreleases` | no | 6 | 9 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 | `com.jtech.zemer.latestreleases` | no | 8 | 8 | java.io, java.nio, kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadCancellationContractTest.kt` | 75 | `com.jtech.zemer.playback` | no | 10 | 10 | java.util, kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt` | 140 | `com.jtech.zemer.playback` | no | 3 | 21 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt` | 186 | `com.jtech.zemer.playback` | no | 6 | 38 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/AudioResamplerTest.kt` | 59 | `com.jtech.zemer.recognition` | no | 6 | 15 | java.nio, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionHistoryFilterTest.kt` | 47 | `com.jtech.zemer.recognition` | no | 4 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 | `com.jtech.zemer.ui.utils` | no | 3 | 2 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 45 | `com.jtech.zemer.ui.utils` | no | 2 | 6 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -1,6 +1,6 @@
 # Non-Kotlin file reference
 
-Every tracked non-Kotlin path outside `docs/` is listed. Text files report line counts; binary files report byte counts; gitlinks are recorded as non-file tracked paths. Total paths: `358`.
+Every tracked non-Kotlin path outside `docs/` is listed. Text files report line counts; binary files report byte counts; gitlinks are recorded as non-file tracked paths. Total paths: `359`.
 
 | Path | Size/status | Type metadata |
 | --- | ---: | --- |
@@ -8,10 +8,10 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/docs-regenerate.yml` | 74 lines | text `.yml` |
 | `.github/workflows/player-monitor.yml` | 140 lines | text `.yml` |
 | `.github/workflows/release-build.yml` | 155 lines | text `.yml` |
-| `.github/workflows/ui-audit.yml` | 28 lines | text `.yml` |
+| `.github/workflows/ui-audit.yml` | 38 lines | text `.yml` |
 | `.gitignore` | 115 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 137 lines | text `.md` |
+| `AGENTS.md` | 214 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 11 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |
@@ -276,9 +276,10 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `lrclib/.gitignore` | 1 lines | text `[none]` |
 | `lrclib/build.gradle.kts` | 16 lines | text `.kts`; plugins `kotlin.serialization, jvm` |
 | `scripts/check-16kb-alignment.sh` | 67 lines | text `.sh` |
+| `scripts/check-download-unification.sh` | 58 lines | text `.sh` |
 | `scripts/telegram-chats.sh` | 38 lines | text `.sh` |
 | `scripts/ui-audit-baseline.tsv` | 13 lines | text `.tsv` |
-| `scripts/ui-audit.sh` | 119 lines | text `.sh` |
+| `scripts/ui-audit.sh` | 125 lines | text `.sh` |
 | `scripts/ui-strings-scan.py` | 96 lines | text `.py` |
 | `settings.gradle.kts` | 56 lines | text `.kts`; plugins `org.gradle.toolchains.foojay-resolver-convention` |
 | `simpmusic/build.gradle.kts` | 15 lines | text `.kts`; plugins `kotlin.serialization, jvm` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `851`
+- Files counted: `864`
 - By extension:
-  - `.kt`: `450`
+  - `.kt`: `462`
   - `.xml`: `184`
   - `.mjs`: `72`
   - `.md`: `51`
@@ -88,10 +88,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
   - `[none]`: `7`
   - `.kts`: `6`
   - `.yml`: `5`
+  - `.sh`: `4`
   - `.js`: `3`
   - `.lottie`: `3`
   - `.properties`: `3`
-  - `.sh`: `3`
   - `.dm`: `2`
   - `.png`: `2`
   - `.py`: `2`
@@ -111,10 +111,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/docs-regenerate.yml` | 74 lines | `.yml` |
 | `.github/workflows/player-monitor.yml` | 140 lines | `.yml` |
 | `.github/workflows/release-build.yml` | 155 lines | `.yml` |
-| `.github/workflows/ui-audit.yml` | 28 lines | `.yml` |
+| `.github/workflows/ui-audit.yml` | 38 lines | `.yml` |
 | `.gitignore` | 115 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 137 lines | `.md` |
+| `AGENTS.md` | 214 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 11 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -226,8 +226,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/extensions/QueueExt.kt` | 112 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/extensions/StringExt.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/extensions/UtilExt.kt` | 8 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt` | 83 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt` | 133 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseDate.kt` | 16 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilter.kt` | 15 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseMapping.kt` | 19 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlayback.kt` | 80 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt` | 256 lines | `.kt` |
@@ -246,12 +247,14 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistPlayerState.kt` | 14 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistQueue.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/AudioOnlyRenderersFactory.kt` | 25 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt` | 361 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadMenuLogic.kt` | 68 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadStateResolver.kt` | 106 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/DownloadUtil.kt` | 319 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/ExoDownloadService.kt` | 111 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 832 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 728 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 808 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 806 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadService.kt` | 306 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 1694 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 1744 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt` | 207 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/SleepTimer.kt` | 68 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/queues/EmptyQueue.kt` | 14 lines | `.kt` |
@@ -284,16 +287,17 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheet.kt` | 348 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetMenu.kt` | 86 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetPage.kt` | 166 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 247 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 254 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/CreatePlaylistDialog.kt` | 131 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Dialog.kt` | 389 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/DownloadStatusUi.kt` | 170 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/DraggableScrollBarOverlay.kt` | 242 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/EmptyPlaceholder.kt` | 47 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 50 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 197 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GridMenu.kt` | 158 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1630 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1571 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 410 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 970 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
@@ -309,6 +313,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 lines | `.kt` |
@@ -320,21 +325,23 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/TextPlaceholder.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialog.kt` | 195 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/AddToPlaylistDialogOnline.kt` | 207 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt` | 451 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt` | 365 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ArtistMenu.kt` | 266 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/CustomThumbnailMenu.kt` | 63 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItems.kt` | 71 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ImportPlaylistDialog.kt` | 63 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/LibraryMenuItems.kt` | 34 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/LoadingScreen.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/LyricsMenu.kt` | 372 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt` | 508 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt` | 215 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt` | 488 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/PlaylistMenu.kt` | 234 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/ReportContentDialog.kt` | 130 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt` | 736 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt` | 628 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt` | 392 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SelectionSongsMenu.kt` | 588 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt` | 550 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt` | 348 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeArtistMenu.kt` | 204 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 502 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 554 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt` | 477 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt` | 469 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 748 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1040 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
@@ -343,14 +350,14 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 1130 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 481 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt` | 200 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 723 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt` | 635 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/BrowseScreen.kt` | 143 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ExploreScreen.kt` | 400 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 517 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 924 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 336 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 100 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 122 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt` | 253 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt` | 227 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/MoodAndGenresScreen.kt` | 171 lines | `.kt` |
@@ -372,16 +379,16 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 797 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 545 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 87 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 356 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 327 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 156 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt` | 1105 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt` | 681 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt` | 491 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt` | 1060 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt` | 607 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt` | 474 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedContentScreen.kt` | 182 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt` | 510 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt` | 1513 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt` | 489 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt` | 1428 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt` | 730 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 632 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 441 lines | `.kt` |
@@ -434,7 +441,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/FirestoreUtils.kt` | 41 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/FutureUtils.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/IsraeliArtistRegistry.kt` | 51 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt` | 669 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/MediaStoreHelper.kt` | 688 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NetworkConnectivityObserver.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NetworkUtils.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/NotificationUtils.kt` | 35 lines | `.kt` |
@@ -698,14 +705,19 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/xml/data_extraction_rules.xml` | 29 lines | `.xml` |
 | `app/src/main/res/xml/music_widget_info.xml` | 18 lines | `.xml` |
 | `app/src/main/res/xml/provider_paths.xml` | 12 lines | `.xml` |
+| `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt` | 46 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlaybackTest.kt` | 120 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadCancellationContractTest.kt` | 75 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadMenuLogicTest.kt` | 140 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/playback/DownloadStateResolverTest.kt` | 186 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/AudioResamplerTest.kt` | 59 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionHistoryFilterTest.kt` | 47 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 45 lines | `.kt` |
@@ -745,8 +757,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 473 lines | `.md` |
-| `docs/reference/non-kotlin-files.md` | 364 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 485 lines | `.md` |
+| `docs/reference/non-kotlin-files.md` | 365 lines | `.md` |
 | `docs/reference/resource-index.md` | 288 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
 | `docs/remote_cipher_config/02-file-format.md` | 116 lines | `.md` |
@@ -756,9 +768,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 960 lines | `.md` |
+| `docs/repository-map.md` | 973 lines | `.md` |
 | `docs/ui/README.md` | 329 lines | `.md` |
-| `docs/ui/standards.md` | 247 lines | `.md` |
+| `docs/ui/standards.md` | 290 lines | `.md` |
 | `docs/whitelist/README.md` | 181 lines | `.md` |
 | `gradle.properties` | 40 lines | `.properties` |
 | `gradle/libs.versions.toml` | 159 lines | `.toml` |
@@ -870,9 +882,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `lrclib/src/main/kotlin/com/metrolist/lrclib/LrcLib.kt` | 293 lines | `.kt` |
 | `lrclib/src/main/kotlin/com/metrolist/lrclib/models/Track.kt` | 137 lines | `.kt` |
 | `scripts/check-16kb-alignment.sh` | 67 lines | `.sh` |
+| `scripts/check-download-unification.sh` | 58 lines | `.sh` |
 | `scripts/telegram-chats.sh` | 38 lines | `.sh` |
 | `scripts/ui-audit-baseline.tsv` | 13 lines | `.tsv` |
-| `scripts/ui-audit.sh` | 119 lines | `.sh` |
+| `scripts/ui-audit.sh` | 125 lines | `.sh` |
 | `scripts/ui-strings-scan.py` | 96 lines | `.py` |
 | `settings.gradle.kts` | 56 lines | `.kts` |
 | `simpmusic/build.gradle.kts` | 15 lines | `.kts` |

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -245,3 +245,28 @@ Rules for these and any new row component:
   scrolling on orientation/screen (e.g. `userScrollEnabled = !isPortrait`). Tall menus fit on the
   developer's device but overflow on shorter screens, larger font/display scale, or with a gesture
   nav bar; disabling scroll there makes the bottom items unreachable.
+
+## 12. Download state (one source of truth)
+
+Download/progress state is computed in exactly one place and read everywhere — never re-derived per
+surface. This is what keeps a downloaded album/song/playlist showing "Remove download" (and a live
+progress ring) identically in the library, Home, search rows, every menu and every header.
+
+- The rule lives in `playback/DownloadStateResolver.kt` (pure, unit-tested): a song is **DOWNLOADED**
+  when the persisted `SongEntity.isDownloaded` flag is set **OR** the live MediaStore state is
+  `COMPLETED`, **DOWNLOADING** when the live state is `QUEUED`/`DOWNLOADING`, else **NOT_DOWNLOADED**;
+  `aggregateSongs` / `aggregateProgress` extend that to a collection. The persisted flag is the only
+  thing that survives a process restart — the live `MediaStoreDownloadManager.downloadStates` map is
+  in-memory — so reading the live map *alone* is the bug that makes downloads "vanish" after relaunch.
+- The UI reads it through `ui/component/DownloadStatusUi.kt`: `rememberSongDownloadStatus`,
+  `rememberAggregateDownloadStatus`/`…Progress`, the `DownloadStatusIcon` badge, `SongDownloadBadge`
+  (the default song-row badge) and `AggregateDownloadButton` (the album/playlist header control, with
+  the D-pad focus border + determinate progress).
+- Menu rows are built by one decision (`playback/DownloadMenuLogic.kt`, unit-tested) + one builder
+  (`ui/menu/DownloadMenuItems.kt` `downloadMenuItem(...)`). Tapping a download row **never dismisses
+  the menu** — it animates Download → progress ring + "%" → Remove in place. Videos are handled by the
+  same path (`DownloadRowKind.DOWNLOAD_VIDEO`, hidden when videos are blocked).
+- The legacy ExoPlayer `DownloadUtil.downloads` / `getDownload()` map is dead (nothing writes it for
+  MediaStore downloads). **Do not read it, and do not hand-roll an `Icon.Download(`.** Enforcement:
+  `scripts/ui-audit.sh` rule `R13-download` (baselined at zero) fails CI on any new
+  `downloadUtil.downloads`, `.getDownload(` or `Icon.Download(` under `ui/`.

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -266,6 +266,24 @@ progress ring) identically in the library, Home, search rows, every menu and eve
   (`ui/menu/DownloadMenuItems.kt` `downloadMenuItem(...)`). Tapping a download row **never dismisses
   the menu** — it animates Download → progress ring + "%" → Remove in place. Videos are handled by the
   same path (`DownloadRowKind.DOWNLOAD_VIDEO`, hidden when videos are blocked).
+- **A collection never gets a FAILED/retry row.** `collectionRow` returns only REMOVE / DOWNLOADING /
+  DOWNLOAD — a failed member leaves the aggregate NOT_DOWNLOADED, so the collection offers DOWNLOAD
+  (which re-enqueues just the missing members = retry) and is removable once complete. A collection
+  "retry" row was a dead end that hid Download *and* Remove and re-failed the dead track forever. Only
+  single songs get a FAILED row (`songRow`).
+- **Async/online collection menus (album / playlist / multi-select) read ONE resolved list for every
+  action.** Resolve/fetch the tracks at click time (fetch-if-empty), then Download, Remove **and** the
+  aggregate status all iterate that *same* resolved list — never the original (possibly-empty) `songs`
+  prop. A Remove that loops the empty prop while Download loops the fetched list removes nothing (real
+  bug on the Home long-press playlist menu). For online items: aggregate via `aggregateByIds` (+ a
+  persisted-downloaded id set) so progress shows without Room entities, and on Download **persist each
+  item then download** (`database.insert`/`transaction { insert }` then `database.song(id).first()`) —
+  a bare lookup of a not-yet-persisted id no-ops, so the first tap appears to do nothing.
+- **Manager invariants** (`MediaStoreDownloadManager`, no Robolectric so verified by code + on-device):
+  `markSongAsDownloaded` bases the row on the **existing** DB row and overwrites only download columns
+  (never clobber `liked`/`inLibrary` with a caller's stale `Song`); `performDownload` backfills
+  `duration` **and** `thumbnailUrl` from the playback response; the per-download video bitrate is
+  cleared only on success/cancel/delete (never on a failed attempt, so retry keeps the chosen quality).
 - The legacy ExoPlayer `DownloadUtil.downloads` / `getDownload()` map is dead (nothing writes it for
   MediaStore downloads). **Do not read it, and do not hand-roll an `Icon.Download(`.** Enforcement:
   `scripts/ui-audit.sh` rule `R13-download` (baselined at zero) fails CI on any new

--- a/scripts/check-download-unification.sh
+++ b/scripts/check-download-unification.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Whole-app guard that the download/progress UI stays unified on ONE path.
+#
+# Background: the app downloads exclusively through MediaStore (MediaStoreDownloadManager) and the
+# durable truth is SongEntity.isDownloaded. The legacy ExoPlayer download map
+# (DownloadUtil.downloads / DownloadUtil.getDownload) is never written for those downloads, so any UI
+# that reads it silently reports "not downloaded". Likewise, download/progress state must be rendered
+# through the shared helpers, never a per-surface re-implementation. This script fails CI the moment a
+# banned pattern reappears ANYWHERE under app/src/main (ui-audit's R13 only covers ui/).
+#
+# Allowed homes for the legacy infrastructure (these legitimately reference the ExoPlayer download
+# manager + Download.STATE_* for the still-present download cache): DownloadUtil.kt, ExoDownloadService.kt.
+#
+# The ONE path:
+#   - state:    com.jtech.zemer.playback.DownloadStateResolver (pure) + ui/component/DownloadStatusUi.kt
+#   - menu row: ui/menu/DownloadMenuItems.kt (downloadMenuItem) decided by DownloadMenuLogic
+#   - header:   ui/component/DownloadStatusUi.kt (AggregateDownloadButton)
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+SRC="app/src/main/kotlin/com/jtech/zemer"
+
+# Files allowed to touch the legacy ExoPlayer download manager / Download.STATE_* (the infra itself).
+INFRA='playback/DownloadUtil.kt|playback/ExoDownloadService.kt'
+
+fail=0
+
+report() { # <pattern-description> <grep-output>
+  if [ -n "$2" ]; then
+    echo "FAIL: $1"
+    echo "$2" | sed 's/^/  /'
+    echo
+    fail=1
+  fi
+}
+
+# 1. The dead legacy download map / flow must not be read anywhere.
+hits="$(grep -rnE "downloadUtil\.downloads|\.getDownload\(" "$SRC" --include=*.kt 2>/dev/null \
+  | grep -vE "$INFRA")"
+report "legacy download map read (use DownloadStateResolver / getMediaStoreDownload / getAllMediaStoreDownloads)" "$hits"
+
+# 2. Download.STATE_* (the ExoPlayer enum) only belongs in the legacy infra, not in UI/playback logic.
+hits="$(grep -rnE "Download\.STATE_" "$SRC" --include=*.kt 2>/dev/null \
+  | grep -vE "$INFRA")"
+report "Download.STATE_* outside the legacy download infra (compute status via DownloadStateResolver)" "$hits"
+
+# 3. The download badge has exactly one renderer; no per-surface Icon.Download.
+hits="$(grep -rnE "Icon\.Download\(" "$SRC" --include=*.kt 2>/dev/null)"
+report "per-surface Icon.Download( (use DownloadStatusIcon / SongDownloadBadge in DownloadStatusUi.kt)" "$hits"
+
+if [ "$fail" -eq 0 ]; then
+  echo "download-unification check passed — one path, no legacy reads, one badge."
+  exit 0
+fi
+
+echo "Download/progress UI must go through the unified path (see docs/ui/standards.md §12)."
+exit 1

--- a/scripts/ui-audit.sh
+++ b/scripts/ui-audit.sh
@@ -62,6 +62,12 @@ violations() {
   # (the RenderEffect blur is a no-op below API 31). Ratcheted: existing blurs are baselined.
   grep -rnE "\.blur\(" "$UI" --include=*.kt 2>/dev/null \
     | grep -v "/theme/" | sed -E 's/:.*//' | sed 's/$/\tR12-blur/'
+  # R13: dead/legacy download-state reads in UI. Download/progress state is ONE path —
+  # DownloadStateResolver + the DownloadStatusUi helpers (persisted isDownloaded + live MediaStore).
+  # The legacy ExoPlayer `downloadUtil.downloads` / `getDownload()` map is never written, and a
+  # per-surface `Icon.Download(` re-implements the unified badge. Baselined at zero.
+  grep -rnE "downloadUtil\.downloads|\.getDownload\(|Icon\.Download\(" "$UI" --include=*.kt 2>/dev/null \
+    | grep -v "/theme/" | sed -E 's/:.*//' | sed 's/$/\tR13-download/'
 }
 
 # Aggregate to "<path>\t<rule>\t<count>", sorted.
@@ -96,7 +102,7 @@ improved="$(awk -F'\t' '
 ' <(printf "%s\n" "$cur") "$BASELINE")"
 
 if [ -n "$new" ]; then
-  echo "UI audit FAILED — new Rule 5/7/8/11/12 violations (docs/ui/standards.md sections 5, 7-8, 11):"
+  echo "UI audit FAILED — new Rule 5/7/8/11/12/13 violations (docs/ui/standards.md sections 5, 7-8, 11, 13):"
   echo "$new"
   echo
   echo "Route font sizes through MaterialTheme.typography (Type.kt), colors through"
@@ -111,7 +117,7 @@ if [ -n "$new" ]; then
 fi
 
 total="$(violations | grep -c .)"
-echo "UI audit passed — no new Rule 5/7/8/11/12 violations (baseline: $total known, only allowed to shrink)."
+echo "UI audit passed — no new Rule 5/7/8/11/12/13 violations (baseline: $total known, only allowed to shrink)."
 if [ -n "$improved" ]; then
   echo "Burned down since the baseline — tighten it with \`bash scripts/ui-audit.sh --update\`:"
   echo "$improved"


### PR DESCRIPTION
## What & why

The app had **forked download logic** across every menu, screen, badge, and header — some surfaces read a dead legacy ExoPlayer map, marking-as-downloaded raced itself, custom-path removes didn't delete files, and progress bounced. This PR routes **all** of it through one shared, tested path, and applies the same unification to **Add/Remove-from-library** and **multi-select mode**.

## Highlights

**Downloads — one path everywhere**
- `DownloadStateResolver` (pure) + `DownloadStatusUi` (badge/progress) + `DownloadMenuItems`/`DownloadMenuLogic` (menu rows) — every surface (menus, home, playlists, albums, latest releases, fullscreen player, video player) reads the *same* resolver: `downloaded = persisted isDownloaded OR live MediaStore state`.
- **Fixed the marking race**: `markSongAsDownloaded` now does the whole mutation in one `database.transaction {}` (was two racing fire-and-forget `query {}` writes that intermittently persisted `isDownloaded=0`).
- **Custom SAF-path remove now deletes the file** via `DocumentsContract.deleteDocument` (`ContentResolver.delete` silently no-ops on document URIs).
- Self-repair on missing file (stream + re-enqueue, never ENOENT), monotonic progress (no ring bounce), duration backfill, first-tap full-playlist/album download (fetch-if-empty), `VideoPlayerScreen` routed through the unified manager.
- Dead legacy reads removed; **CI guard** (`scripts/check-download-unification.sh` + ui-audit R13) fails on any `downloadUtil.downloads` / `getDownload(` / per-surface `Icon.Download(`.

**Library & selection**
- Shared `libraryMenuItem` (Add/Remove-from-library) across SongMenu/YouTubeSongMenu/Selection.
- Shared `SelectionTopActions` (inline) + `SelectionActions` (TopAppBar) — the select-mode close/count/select-all/overflow cluster is identical across all multi-select screens.
- `ChipsRow` routes D-pad up/down for every chip.

**Latest Releases**: working actions + All/Albums/Songs filter.

## Tests & verification
- 53+ new JVM regression tests (resolver, menu logic, cancellation contract, filter); `AGENTS.md` + `docs/ui/standards.md §12` document the pitfalls.
- Verified live: audio download all routes (27/27 atomic), custom SAF download+delete, cancel-mid-download, restart persistence + badges, library toggle, selection (4/6 screens + both idioms), remove (public + custom), in-menu progress, debug **and** release (R8) builds + unit tests, zero crashes.
- **Video download verified on a physical device** (the emulator lacks a hardware video codec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)