### PR TITLE
feat(search): Zemer search engine with YouTube/Zemer toggle

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -202,7 +202,10 @@ import com.jtech.zemer.ui.component.LocalBottomSheetPageState
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.RecognizeMusicFab
 import com.jtech.zemer.ui.screens.recognition.RecognizeMusicDialogActivity
+import com.jtech.zemer.ui.component.SearchProviderToggle
 import com.jtech.zemer.ui.component.TopSearch
+import com.jtech.zemer.constants.SearchProviderKey
+import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.ui.component.rememberBottomSheetState
 import com.jtech.zemer.ui.component.shimmer.ShimmerTheme
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
@@ -1569,8 +1572,17 @@ class MainActivity : ComponentActivity() {
                                             }
                                         },
                                         trailingIcon = {
-                                            Row {
+                                            Row(verticalAlignment = Alignment.CenterVertically) {
                                                 if (active) {
+                                                    val (searchProvider, onSearchProviderChange) =
+                                                        rememberEnumPreference(
+                                                            SearchProviderKey,
+                                                            SearchProvider.ZEMER,
+                                                        )
+                                                    SearchProviderToggle(
+                                                        provider = searchProvider,
+                                                        onProviderChange = onSearchProviderChange,
+                                                    )
                                                     if (query.text.isNotEmpty()) {
                                                         IconButton(
                                                             onClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -162,6 +162,9 @@ val AllowChasidishKey = booleanPreferencesKey("allowChasidish")
 val BlockVideosKey = booleanPreferencesKey("blockVideos")
 val EnableContentFiltersKey = booleanPreferencesKey("enableContentFilters")
 
+// Online search engine: SearchProvider.name (ZEMER default, or YOUTUBE)
+val SearchProviderKey = stringPreferencesKey("searchProvider")
+
 // Sync-related preference keys
 val LastContentFilterSyncTimeKey = longPreferencesKey("last_content_filter_sync_time")
 val IsContentFilterSyncEnabledKey = booleanPreferencesKey("content_filter_sync_enabled")

--- a/app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt
@@ -1,0 +1,15 @@
+package com.jtech.zemer.search
+
+/**
+ * Which engine backs the online search screen.
+ *
+ * - [ZEMER] — the whitelist-scoped, Hebrew-aware engine at search.zemer.io (the default). Results are
+ *   already content-filtered server-side, so the app does not re-run the local whitelist filter on them.
+ * - [YOUTUBE] — the upstream YouTube Music search path, with the local whitelist filter applied on top.
+ *
+ * Persisted as its [name] under `searchProvider` (see `SearchProviderKey`).
+ */
+enum class SearchProvider {
+    ZEMER,
+    YOUTUBE,
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -87,14 +87,33 @@ object ZemerResultMapper {
             radioEndpoint = null,
         )
 
+    // Each helper drops rows missing their id (the server should never send those, but one sparse row
+    // must not crash navigation) and de-dupes by id, since the id-keyed LazyColumns reject duplicates.
     private fun songItems(tracks: List<ZemerTrack>, hideExplicit: Boolean): List<SongItem> =
-        tracks.map { it.toSongItem() }.filterExplicit(hideExplicit)
+        tracks.filter { it.videoId.isNotBlank() }
+            .map { it.toSongItem() }
+            .filterExplicit(hideExplicit)
+            .distinctBy { it.id }
+
+    private fun artistItems(resp: ZemerSearchResponse): List<ArtistItem> =
+        resp.categories.artists.filter { it.id.isNotBlank() }.map { it.toArtistItem() }.distinctBy { it.id }
 
     /** Albums + singles together, in that order — both navigate via the FILTER_ALBUM chip. */
     private fun albumItems(resp: ZemerSearchResponse): List<AlbumItem> =
-        (resp.categories.albums + resp.categories.singles).map { it.toAlbumItem() }
+        (resp.categories.albums + resp.categories.singles)
+            .filter { it.id.isNotBlank() }
+            .map { it.toAlbumItem() }
+            .distinctBy { it.id }
 
-    /** The grouped summary view (the `filter == null` screen). Empty sections are omitted. */
+    private fun playlistItems(resp: ZemerSearchResponse): List<PlaylistItem> =
+        resp.categories.playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem() }.distinctBy { it.id }
+
+    /**
+     * The grouped summary view (the `filter == null` screen). Empty sections are omitted. There is
+     * deliberately no separate "Videos" section: videos map to [SongItem], and `OnlineSearchResult`
+     * resolves a section's "see more" filter by item type first (SongItem → Songs), so a Videos section
+     * would mis-navigate to Songs. Videos stay reachable via the Videos chip and the as-you-type list.
+     */
     fun summaryPage(
         resp: ZemerSearchResponse,
         titles: SectionTitles,
@@ -103,13 +122,11 @@ object ZemerResultMapper {
         val summaries = buildList {
             songItems(resp.categories.songs, hideExplicit)
                 .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.songs, it)) }
-            resp.categories.artists.map { it.toArtistItem() }
+            artistItems(resp)
                 .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.artists, it)) }
             albumItems(resp)
                 .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.albums, it)) }
-            songItems(resp.categories.videos, hideExplicit)
-                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.videos, it)) }
-            resp.categories.playlists.map { it.toPlaylistItem() }
+            playlistItems(resp)
                 .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.playlists, it)) }
         }
         return SearchSummaryPage(summaries = summaries)
@@ -124,11 +141,11 @@ object ZemerResultMapper {
         val items: List<YTItem> = when (filter.value) {
             SearchFilter.FILTER_SONG.value -> songItems(resp.categories.songs, hideExplicit)
             SearchFilter.FILTER_VIDEO.value -> songItems(resp.categories.videos, hideExplicit)
-            SearchFilter.FILTER_ARTIST.value -> resp.categories.artists.map { it.toArtistItem() }
+            SearchFilter.FILTER_ARTIST.value -> artistItems(resp)
             SearchFilter.FILTER_ALBUM.value -> albumItems(resp)
             SearchFilter.FILTER_COMMUNITY_PLAYLIST.value,
             SearchFilter.FILTER_FEATURED_PLAYLIST.value,
-            -> resp.categories.playlists.map { it.toPlaylistItem() }
+            -> playlistItems(resp)
             else -> emptyList()
         }
         return SearchResult(items = items, continuation = null)
@@ -139,15 +156,17 @@ object ZemerResultMapper {
      * (`queries`) on top, then full live result rows (`recommendedItems`) across ALL categories in the
      * same order as the summary screen. Completions are Zemer-native: artist names first (the most
      * useful "search everything by…" completion and the one that absorbs Hebrew/romanization fuzz),
-     * then a few song titles to fill — deduped case-insensitively and capped.
+     * then a few song titles to fill — deduped case-insensitively and capped. The combined rows are
+     * de-duped by id (a videoId can appear in both songs and videos) so the id-keyed list can't crash.
      */
     fun suggestions(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSuggestions {
         val items: List<YTItem> =
-            songItems(resp.categories.songs, hideExplicit) +
-                resp.categories.artists.map { it.toArtistItem() } +
+            (songItems(resp.categories.songs, hideExplicit) +
+                artistItems(resp) +
                 albumItems(resp) +
                 songItems(resp.categories.videos, hideExplicit) +
-                resp.categories.playlists.map { it.toPlaylistItem() }
+                playlistItems(resp))
+                .distinctBy { it.id }
 
         val completions: List<String> =
             (resp.categories.artists.map { it.name } + resp.categories.songs.map { it.title })

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -126,11 +126,15 @@ object ZemerResultMapper {
     ): SearchSummaryPage {
         val songsAndVideos = songAndVideoItems(resp, hideExplicit)
         val playlists = playlistItems(resp.categories.community, formatSongCount)
+        // Each section is a compact preview; the merged sections (songs+videos, albums+singles) would
+        // otherwise run up to ~16 rows. The full per-category list is one tap away on the chip.
+        fun MutableList<SearchSummary>.section(title: String, items: List<YTItem>) =
+            items.take(SUMMARY_SECTION_LIMIT).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(title, it)) }
         val summaries = buildList {
-            albumItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ALBUMS, it)) }
-            songsAndVideos.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_SONGS, it)) }
-            artistItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ARTISTS, it)) }
-            playlists.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_PLAYLISTS, it)) }
+            section(TITLE_ALBUMS, albumItems(resp))
+            section(TITLE_SONGS, songsAndVideos)
+            section(TITLE_ARTISTS, artistItems(resp))
+            section(TITLE_PLAYLISTS, playlists)
         }
         return SearchSummaryPage(summaries = summaries)
     }
@@ -191,6 +195,9 @@ object ZemerResultMapper {
     }
 
     private const val MAX_QUERY_SUGGESTIONS = 5
+
+    /** Per-section preview cap on the grouped summary, so a merged section isn't a long scroll. */
+    private const val SUMMARY_SECTION_LIMIT = 8
 
     // Verbatim match of the YouTube summary section titles/order (YouTube.searchSummary hardcodes
     // these English literals too), so the summary looks identical whichever engine is selected.

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -19,7 +19,8 @@ import com.metrolist.innertube.models.SearchSuggestions
  *
  * - songs & videos → [SongItem] (thumbnail derived from the videoId; `endpoint` left null, which the
  *   results screen already handles by playing `WatchEndpoint(videoId = id)`).
- * - artists → [ArtistItem], albums + singles → [AlbumItem], playlists → [PlaylistItem].
+ * - artists → [ArtistItem], albums + singles → [AlbumItem], playlists & community → [PlaylistItem]
+ *   (the artist-owned `playlists` back the Featured chip, the `community` list backs the Community chip).
  *
  * Zemer results are already whitelist-scoped server-side, so the local whitelist filter is NOT applied
  * here; only `hideExplicit` is honored (on the song/video lists — the other types are never explicit).
@@ -91,26 +92,32 @@ object ZemerResultMapper {
             .map { it.toAlbumItem() }
             .distinctBy { it.id }
 
-    private fun playlistItems(resp: ZemerSearchResponse): List<PlaylistItem> =
-        resp.categories.playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem() }.distinctBy { it.id }
+    /** Shared playlist adaptation — used for both the artist-owned `playlists` and the `community` lists. */
+    private fun playlistItems(playlists: List<ZemerPlaylist>): List<PlaylistItem> =
+        playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem() }.distinctBy { it.id }
 
     /**
      * The grouped summary view (`filter == null`), matching the YouTube summary's shape exactly
      * (`YouTube.searchSummary`): items grouped by type into the same sections, in the same order, with
      * the same hardcoded English titles, so toggling engines never changes the summary's headers or
      * layout. Videos are folded into the Songs section (they are [SongItem]s — exactly how YouTube
-     * groups them); there is no separate Videos section. Empty sections are omitted. (No "Top result"
-     * card — the Zemer server does not return one.)
+     * groups them); there is no separate Videos section. Featured and community playlists are likewise
+     * folded into one "Playlists" section (exactly like YouTube's single combined Playlists section);
+     * the two are split apart only behind their dedicated chips. Empty sections are omitted. (No "Top
+     * result" card — the Zemer server does not return one.)
      */
     fun summaryPage(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSummaryPage {
         val songsAndVideos =
             (songItems(resp.categories.songs, hideExplicit) + songItems(resp.categories.videos, hideExplicit))
                 .distinctBy { it.id }
+        val playlists =
+            (playlistItems(resp.categories.playlists) + playlistItems(resp.categories.community))
+                .distinctBy { it.id }
         val summaries = buildList {
             albumItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ALBUMS, it)) }
             songsAndVideos.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_SONGS, it)) }
             artistItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ARTISTS, it)) }
-            playlistItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_PLAYLISTS, it)) }
+            playlists.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_PLAYLISTS, it)) }
         }
         return SearchSummaryPage(summaries = summaries)
     }
@@ -126,9 +133,8 @@ object ZemerResultMapper {
             SearchFilter.FILTER_VIDEO.value -> songItems(resp.categories.videos, hideExplicit)
             SearchFilter.FILTER_ARTIST.value -> artistItems(resp)
             SearchFilter.FILTER_ALBUM.value -> albumItems(resp)
-            SearchFilter.FILTER_COMMUNITY_PLAYLIST.value,
-            SearchFilter.FILTER_FEATURED_PLAYLIST.value,
-            -> playlistItems(resp)
+            SearchFilter.FILTER_COMMUNITY_PLAYLIST.value -> playlistItems(resp.categories.community)
+            SearchFilter.FILTER_FEATURED_PLAYLIST.value -> playlistItems(resp.categories.playlists)
             else -> emptyList()
         }
         return SearchResult(items = items, continuation = null)
@@ -148,7 +154,8 @@ object ZemerResultMapper {
                 artistItems(resp) +
                 albumItems(resp) +
                 songItems(resp.categories.videos, hideExplicit) +
-                playlistItems(resp))
+                playlistItems(resp.categories.playlists) +
+                playlistItems(resp.categories.community))
                 .distinctBy { it.id }
 
         val completions: List<String> =

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -1,0 +1,162 @@
+package com.jtech.zemer.search
+
+import com.metrolist.innertube.YouTube.SearchFilter
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.Artist
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.YTItem
+import com.metrolist.innertube.models.filterExplicit
+import com.metrolist.innertube.pages.SearchResult
+import com.metrolist.innertube.pages.SearchSummary
+import com.metrolist.innertube.pages.SearchSummaryPage
+import com.metrolist.innertube.models.SearchSuggestions
+
+/**
+ * Localized section headings for the Zemer summary view. Supplied by the caller (the repository pulls
+ * them from `context.getString(...)`) so this mapper stays pure and unit-testable without an Android
+ * runtime. Albums and singles are shown under one "Albums" heading; community/featured playlists both
+ * map to the one Zemer playlist category.
+ */
+data class SectionTitles(
+    val songs: String,
+    val videos: String,
+    val albums: String,
+    val artists: String,
+    val playlists: String,
+)
+
+/**
+ * Adapts a [ZemerSearchResponse] into the exact `YTItem`/page types the existing search UI already
+ * renders, so the screens, rows, playback and navigation are all reused unchanged:
+ *
+ * - songs & videos → [SongItem] (thumbnail derived from the videoId; `endpoint` left null, which the
+ *   results screen already handles by playing `WatchEndpoint(videoId = id)`).
+ * - artists → [ArtistItem], albums + singles → [AlbumItem], playlists → [PlaylistItem].
+ *
+ * Zemer results are already whitelist-scoped server-side, so the local whitelist filter is NOT applied
+ * here; only `hideExplicit` is honored (on the song/video lists — the other types are never explicit).
+ */
+object ZemerResultMapper {
+
+    /** YouTube serves the video thumbnail for any videoId; `String.resize` no-ops on this host. */
+    fun thumbnailFor(videoId: String): String = "https://i.ytimg.com/vi/$videoId/hqdefault.jpg"
+
+    fun ZemerTrack.toSongItem(): SongItem =
+        SongItem(
+            id = videoId,
+            title = title,
+            artists = listOf(Artist(name = artist, id = null)),
+            album = null,
+            duration = null,
+            thumbnail = thumbnailFor(videoId),
+            explicit = explicit,
+        )
+
+    fun ZemerArtist.toArtistItem(): ArtistItem =
+        ArtistItem(
+            id = id,
+            title = name,
+            thumbnail = thumbnail,
+            channelId = null,
+            playEndpoint = null,
+            shuffleEndpoint = null,
+            radioEndpoint = null,
+        )
+
+    fun ZemerAlbum.toAlbumItem(): AlbumItem =
+        AlbumItem(
+            browseId = id,
+            playlistId = playlistId ?: id,
+            title = title,
+            artists = if (artist.isBlank()) null else listOf(Artist(name = artist, id = null)),
+            year = year,
+            thumbnail = thumbnail.orEmpty(),
+        )
+
+    fun ZemerPlaylist.toPlaylistItem(): PlaylistItem =
+        PlaylistItem(
+            id = id,
+            title = title,
+            author = if (artist.isBlank()) null else Artist(name = artist, id = null),
+            songCountText = null,
+            thumbnail = thumbnail,
+            playEndpoint = null,
+            shuffleEndpoint = null,
+            radioEndpoint = null,
+        )
+
+    private fun songItems(tracks: List<ZemerTrack>, hideExplicit: Boolean): List<SongItem> =
+        tracks.map { it.toSongItem() }.filterExplicit(hideExplicit)
+
+    /** Albums + singles together, in that order — both navigate via the FILTER_ALBUM chip. */
+    private fun albumItems(resp: ZemerSearchResponse): List<AlbumItem> =
+        (resp.categories.albums + resp.categories.singles).map { it.toAlbumItem() }
+
+    /** The grouped summary view (the `filter == null` screen). Empty sections are omitted. */
+    fun summaryPage(
+        resp: ZemerSearchResponse,
+        titles: SectionTitles,
+        hideExplicit: Boolean,
+    ): SearchSummaryPage {
+        val summaries = buildList {
+            songItems(resp.categories.songs, hideExplicit)
+                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.songs, it)) }
+            resp.categories.artists.map { it.toArtistItem() }
+                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.artists, it)) }
+            albumItems(resp)
+                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.albums, it)) }
+            songItems(resp.categories.videos, hideExplicit)
+                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.videos, it)) }
+            resp.categories.playlists.map { it.toPlaylistItem() }
+                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.playlists, it)) }
+        }
+        return SearchSummaryPage(summaries = summaries)
+    }
+
+    /** A single chip's results. Zemer has no pagination, so `continuation` is always null. */
+    fun filtered(
+        resp: ZemerSearchResponse,
+        filter: SearchFilter,
+        hideExplicit: Boolean,
+    ): SearchResult {
+        val items: List<YTItem> = when (filter.value) {
+            SearchFilter.FILTER_SONG.value -> songItems(resp.categories.songs, hideExplicit)
+            SearchFilter.FILTER_VIDEO.value -> songItems(resp.categories.videos, hideExplicit)
+            SearchFilter.FILTER_ARTIST.value -> resp.categories.artists.map { it.toArtistItem() }
+            SearchFilter.FILTER_ALBUM.value -> albumItems(resp)
+            SearchFilter.FILTER_COMMUNITY_PLAYLIST.value,
+            SearchFilter.FILTER_FEATURED_PLAYLIST.value,
+            -> resp.categories.playlists.map { it.toPlaylistItem() }
+            else -> emptyList()
+        }
+        return SearchResult(items = items, continuation = null)
+    }
+
+    /**
+     * As-you-type dropdown — the two-part layout Metrolist uses: tappable text **completions**
+     * (`queries`) on top, then full live result rows (`recommendedItems`) across ALL categories in the
+     * same order as the summary screen. Completions are Zemer-native: artist names first (the most
+     * useful "search everything by…" completion and the one that absorbs Hebrew/romanization fuzz),
+     * then a few song titles to fill — deduped case-insensitively and capped.
+     */
+    fun suggestions(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSuggestions {
+        val items: List<YTItem> =
+            songItems(resp.categories.songs, hideExplicit) +
+                resp.categories.artists.map { it.toArtistItem() } +
+                albumItems(resp) +
+                songItems(resp.categories.videos, hideExplicit) +
+                resp.categories.playlists.map { it.toPlaylistItem() }
+
+        val completions: List<String> =
+            (resp.categories.artists.map { it.name } + resp.categories.songs.map { it.title })
+                .filter { it.isNotBlank() }
+                .distinctBy { it.lowercase() }
+                .take(MAX_QUERY_SUGGESTIONS)
+
+        return SearchSuggestions(queries = completions, recommendedItems = items)
+    }
+
+    private const val MAX_QUERY_SUGGESTIONS = 5
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -62,12 +62,15 @@ object ZemerResultMapper {
             thumbnail = thumbnail.orEmpty(),
         )
 
-    fun ZemerPlaylist.toPlaylistItem(): PlaylistItem =
+    fun ZemerPlaylist.toPlaylistItem(formatSongCount: (Int) -> String?): PlaylistItem =
         PlaylistItem(
             id = id,
             title = title,
             author = if (artist.isBlank()) null else Artist(name = artist, id = null),
-            songCountText = null,
+            // e.g. "12 songs"; omitted when the server sends no/zero count. The row renders this after a
+            // bullet next to the curator (Items.kt), and the count is regex-read elsewhere, so the
+            // localized "N songs" string keeps both working.
+            songCountText = songCount?.takeIf { it > 0 }?.let(formatSongCount),
             thumbnail = thumbnail,
             playEndpoint = null,
             shuffleEndpoint = null,
@@ -93,8 +96,8 @@ object ZemerResultMapper {
             .distinctBy { it.id }
 
     /** Shared playlist adaptation — used for both the artist-owned `playlists` and the `community` lists. */
-    private fun playlistItems(playlists: List<ZemerPlaylist>): List<PlaylistItem> =
-        playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem() }.distinctBy { it.id }
+    private fun playlistItems(playlists: List<ZemerPlaylist>, formatSongCount: (Int) -> String?): List<PlaylistItem> =
+        playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem(formatSongCount) }.distinctBy { it.id }
 
     /**
      * The grouped summary view (`filter == null`), matching the YouTube summary's shape exactly
@@ -106,12 +109,16 @@ object ZemerResultMapper {
      * the two are split apart only behind their dedicated chips. Empty sections are omitted. (No "Top
      * result" card — the Zemer server does not return one.)
      */
-    fun summaryPage(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSummaryPage {
+    fun summaryPage(
+        resp: ZemerSearchResponse,
+        hideExplicit: Boolean,
+        formatSongCount: (Int) -> String? = { null },
+    ): SearchSummaryPage {
         val songsAndVideos =
             (songItems(resp.categories.songs, hideExplicit) + songItems(resp.categories.videos, hideExplicit))
                 .distinctBy { it.id }
         val playlists =
-            (playlistItems(resp.categories.playlists) + playlistItems(resp.categories.community))
+            (playlistItems(resp.categories.playlists, formatSongCount) + playlistItems(resp.categories.community, formatSongCount))
                 .distinctBy { it.id }
         val summaries = buildList {
             albumItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ALBUMS, it)) }
@@ -127,14 +134,15 @@ object ZemerResultMapper {
         resp: ZemerSearchResponse,
         filter: SearchFilter,
         hideExplicit: Boolean,
+        formatSongCount: (Int) -> String? = { null },
     ): SearchResult {
         val items: List<YTItem> = when (filter.value) {
             SearchFilter.FILTER_SONG.value -> songItems(resp.categories.songs, hideExplicit)
             SearchFilter.FILTER_VIDEO.value -> songItems(resp.categories.videos, hideExplicit)
             SearchFilter.FILTER_ARTIST.value -> artistItems(resp)
             SearchFilter.FILTER_ALBUM.value -> albumItems(resp)
-            SearchFilter.FILTER_COMMUNITY_PLAYLIST.value -> playlistItems(resp.categories.community)
-            SearchFilter.FILTER_FEATURED_PLAYLIST.value -> playlistItems(resp.categories.playlists)
+            SearchFilter.FILTER_COMMUNITY_PLAYLIST.value -> playlistItems(resp.categories.community, formatSongCount)
+            SearchFilter.FILTER_FEATURED_PLAYLIST.value -> playlistItems(resp.categories.playlists, formatSongCount)
             else -> emptyList()
         }
         return SearchResult(items = items, continuation = null)
@@ -148,14 +156,18 @@ object ZemerResultMapper {
      * then a few song titles to fill — deduped case-insensitively and capped. The combined rows are
      * de-duped by id (a videoId can appear in both songs and videos) so the id-keyed list can't crash.
      */
-    fun suggestions(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSuggestions {
+    fun suggestions(
+        resp: ZemerSearchResponse,
+        hideExplicit: Boolean,
+        formatSongCount: (Int) -> String? = { null },
+    ): SearchSuggestions {
         val items: List<YTItem> =
             (songItems(resp.categories.songs, hideExplicit) +
                 artistItems(resp) +
                 albumItems(resp) +
                 songItems(resp.categories.videos, hideExplicit) +
-                playlistItems(resp.categories.playlists) +
-                playlistItems(resp.categories.community))
+                playlistItems(resp.categories.playlists, formatSongCount) +
+                playlistItems(resp.categories.community, formatSongCount))
                 .distinctBy { it.id }
 
         val completions: List<String> =

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -14,20 +14,6 @@ import com.metrolist.innertube.pages.SearchSummaryPage
 import com.metrolist.innertube.models.SearchSuggestions
 
 /**
- * Localized section headings for the Zemer summary view. Supplied by the caller (the repository pulls
- * them from `context.getString(...)`) so this mapper stays pure and unit-testable without an Android
- * runtime. Albums and singles are shown under one "Albums" heading; community/featured playlists both
- * map to the one Zemer playlist category.
- */
-data class SectionTitles(
-    val songs: String,
-    val videos: String,
-    val albums: String,
-    val artists: String,
-    val playlists: String,
-)
-
-/**
  * Adapts a [ZemerSearchResponse] into the exact `YTItem`/page types the existing search UI already
  * renders, so the screens, rows, playback and navigation are all reused unchanged:
  *
@@ -109,25 +95,22 @@ object ZemerResultMapper {
         resp.categories.playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem() }.distinctBy { it.id }
 
     /**
-     * The grouped summary view (the `filter == null` screen). Empty sections are omitted. There is
-     * deliberately no separate "Videos" section: videos map to [SongItem], and `OnlineSearchResult`
-     * resolves a section's "see more" filter by item type first (SongItem → Songs), so a Videos section
-     * would mis-navigate to Songs. Videos stay reachable via the Videos chip and the as-you-type list.
+     * The grouped summary view (`filter == null`), matching the YouTube summary's shape exactly
+     * (`YouTube.searchSummary`): items grouped by type into the same sections, in the same order, with
+     * the same hardcoded English titles, so toggling engines never changes the summary's headers or
+     * layout. Videos are folded into the Songs section (they are [SongItem]s — exactly how YouTube
+     * groups them); there is no separate Videos section. Empty sections are omitted. (No "Top result"
+     * card — the Zemer server does not return one.)
      */
-    fun summaryPage(
-        resp: ZemerSearchResponse,
-        titles: SectionTitles,
-        hideExplicit: Boolean,
-    ): SearchSummaryPage {
+    fun summaryPage(resp: ZemerSearchResponse, hideExplicit: Boolean): SearchSummaryPage {
+        val songsAndVideos =
+            (songItems(resp.categories.songs, hideExplicit) + songItems(resp.categories.videos, hideExplicit))
+                .distinctBy { it.id }
         val summaries = buildList {
-            songItems(resp.categories.songs, hideExplicit)
-                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.songs, it)) }
-            artistItems(resp)
-                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.artists, it)) }
-            albumItems(resp)
-                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.albums, it)) }
-            playlistItems(resp)
-                .takeIf { it.isNotEmpty() }?.let { add(SearchSummary(titles.playlists, it)) }
+            albumItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ALBUMS, it)) }
+            songsAndVideos.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_SONGS, it)) }
+            artistItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ARTISTS, it)) }
+            playlistItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_PLAYLISTS, it)) }
         }
         return SearchSummaryPage(summaries = summaries)
     }
@@ -178,4 +161,11 @@ object ZemerResultMapper {
     }
 
     private const val MAX_QUERY_SUGGESTIONS = 5
+
+    // Verbatim match of the YouTube summary section titles/order (YouTube.searchSummary hardcodes
+    // these English literals too), so the summary looks identical whichever engine is selected.
+    private const val TITLE_ALBUMS = "Albums"
+    private const val TITLE_SONGS = "Songs"
+    private const val TITLE_ARTISTS = "Artists"
+    private const val TITLE_PLAYLISTS = "Playlists"
 }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -85,6 +85,16 @@ object ZemerResultMapper {
             .filterExplicit(hideExplicit)
             .distinctBy { it.id }
 
+    /**
+     * Songs + videos as one list (videos are [SongItem]s). The summary "Songs" section and the
+     * `FILTER_SONG` chip BOTH use this, so drilling into "Songs" from the summary returns exactly what
+     * the section showed — videos folded into the preview never disappear (or yield "No results" on a
+     * video-only query) on tap. The dedicated Videos chip still narrows to videos only.
+     */
+    private fun songAndVideoItems(resp: ZemerSearchResponse, hideExplicit: Boolean): List<SongItem> =
+        (songItems(resp.categories.songs, hideExplicit) + songItems(resp.categories.videos, hideExplicit))
+            .distinctBy { it.id }
+
     private fun artistItems(resp: ZemerSearchResponse): List<ArtistItem> =
         resp.categories.artists.filter { it.id.isNotBlank() }.map { it.toArtistItem() }.distinctBy { it.id }
 
@@ -104,22 +114,18 @@ object ZemerResultMapper {
      * (`YouTube.searchSummary`): items grouped by type into the same sections, in the same order, with
      * the same hardcoded English titles, so toggling engines never changes the summary's headers or
      * layout. Videos are folded into the Songs section (they are [SongItem]s — exactly how YouTube
-     * groups them); there is no separate Videos section. Featured and community playlists are likewise
-     * folded into one "Playlists" section (exactly like YouTube's single combined Playlists section);
-     * the two are split apart only behind their dedicated chips. Empty sections are omitted. (No "Top
-     * result" card — the Zemer server does not return one.)
+     * groups them); there is no separate Videos section. The "Playlists" section shows the community
+     * playlists only — its header drills into the Community chip, so previewing community here keeps
+     * tap-through consistent (artist-owned/featured playlists are reached via the Featured chip).
+     * Empty sections are omitted. (No "Top result" card — the Zemer server does not return one.)
      */
     fun summaryPage(
         resp: ZemerSearchResponse,
         hideExplicit: Boolean,
         formatSongCount: (Int) -> String? = { null },
     ): SearchSummaryPage {
-        val songsAndVideos =
-            (songItems(resp.categories.songs, hideExplicit) + songItems(resp.categories.videos, hideExplicit))
-                .distinctBy { it.id }
-        val playlists =
-            (playlistItems(resp.categories.playlists, formatSongCount) + playlistItems(resp.categories.community, formatSongCount))
-                .distinctBy { it.id }
+        val songsAndVideos = songAndVideoItems(resp, hideExplicit)
+        val playlists = playlistItems(resp.categories.community, formatSongCount)
         val summaries = buildList {
             albumItems(resp).takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_ALBUMS, it)) }
             songsAndVideos.takeIf { it.isNotEmpty() }?.let { add(SearchSummary(TITLE_SONGS, it)) }
@@ -137,7 +143,9 @@ object ZemerResultMapper {
         formatSongCount: (Int) -> String? = { null },
     ): SearchResult {
         val items: List<YTItem> = when (filter.value) {
-            SearchFilter.FILTER_SONG.value -> songItems(resp.categories.songs, hideExplicit)
+            // Songs chip returns songs + videos (the summary "Songs" section folds them together, so the
+            // drill-in must too); the Videos chip narrows to videos only.
+            SearchFilter.FILTER_SONG.value -> songAndVideoItems(resp, hideExplicit)
             SearchFilter.FILTER_VIDEO.value -> songItems(resp.categories.videos, hideExplicit)
             SearchFilter.FILTER_ARTIST.value -> artistItems(resp)
             SearchFilter.FILTER_ALBUM.value -> albumItems(resp)
@@ -170,8 +178,11 @@ object ZemerResultMapper {
                 playlistItems(resp.categories.community, formatSongCount))
                 .distinctBy { it.id }
 
+        // Drop explicit-flagged songs from the completion strings too (not just the result rows) so an
+        // explicit title can't be offered as a tappable suggestion when Hide explicit is on.
         val completions: List<String> =
-            (resp.categories.artists.map { it.name } + resp.categories.songs.map { it.title })
+            (resp.categories.artists.map { it.name } +
+                resp.categories.songs.filter { !hideExplicit || !it.explicit }.map { it.title })
                 .filter { it.isNotBlank() }
                 .distinctBy { it.lowercase() }
                 .take(MAX_QUERY_SUGGESTIONS)

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -5,8 +5,11 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,13 +42,18 @@ class ZemerSearchClient @Inject constructor() {
         blockVideos: Boolean,
         k: Int,
     ): ZemerSearchResponse {
-        val text = client.get("$BASE_URL/search") {
+        val response: HttpResponse = client.get("$BASE_URL/search") {
             parameter("q", query)
             parameter("allowFemale", if (allowFemale) "1" else "0")
             if (blockVideos) parameter("blockVideos", "1")
             parameter("k", k)
-        }.bodyAsText()
-        return json.decodeFromString(ZemerSearchResponse.serializer(), text)
+        }
+        // CIO does not throw on non-2xx; guard so an error page (HTML/5xx) is a clean failure rather
+        // than a confusing JSON parse error fed from the error body.
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer search returned HTTP ${response.status.value}")
+        }
+        return json.decodeFromString(ZemerSearchResponse.serializer(), response.bodyAsText())
     }
 
     companion object {

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -3,6 +3,7 @@ package com.jtech.zemer.search
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
@@ -56,6 +57,10 @@ class ZemerSearchClient @Inject constructor() {
             parameter("allowFemale", if (allowFemale) "1" else "0")
             if (blockVideos) parameter("blockVideos", "1")
             parameter("k", k)
+            // The Community chip asks for a large k (a few hundred rows); give that heavier response more
+            // headroom than the default ceiling, while the as-you-type / filter calls keep the tighter
+            // default so a genuinely hung request still fails fast.
+            if (k > LARGE_REQUEST_K) timeout { requestTimeoutMillis = LARGE_REQUEST_TIMEOUT_MS }
         }
         // CIO does not throw on non-2xx; guard so an error page (HTML/5xx) is a clean failure rather
         // than a confusing JSON parse error fed from the error body.
@@ -69,5 +74,8 @@ class ZemerSearchClient @Inject constructor() {
         const val BASE_URL = "https://search.zemer.io"
         private const val REQUEST_TIMEOUT_MS = 8_000L
         private const val CONNECT_TIMEOUT_MS = 5_000L
+        // Requests above this k (the Community chip's K_COMMUNITY) get the larger ceiling below.
+        private const val LARGE_REQUEST_K = 100
+        private const val LARGE_REQUEST_TIMEOUT_MS = 20_000L
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -21,13 +21,22 @@ import javax.inject.Singleton
  * Content-type is not assumed: the body is read as text and decoded with a lenient,
  * unknown-key-tolerant [Json], so a missing/odd `Content-Type` or a new server field never breaks it.
  */
+/**
+ * The lenient reader for every Zemer response. Pulled out of the client so its exact config is
+ * unit-testable. `ignoreUnknownKeys` forward-compats new server fields; `isLenient` tolerates an
+ * odd/missing content-type; `coerceInputValues` falls an explicit JSON `null` on a non-null defaulted
+ * field back to its default — kotlinx applies defaults only for ABSENT keys, so without this a
+ * `"categories": null` / `"videos": null` would throw and fail the WHOLE response (the strict-
+ * deserialization "No results" trap), instead of degrading gracefully.
+ */
+internal val zemerResponseJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    coerceInputValues = true
+}
+
 @Singleton
 class ZemerSearchClient @Inject constructor() {
-
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-    }
 
     private val client = HttpClient(CIO) {
         install(HttpTimeout) {
@@ -53,7 +62,7 @@ class ZemerSearchClient @Inject constructor() {
         if (!response.status.isSuccess()) {
             throw IOException("Zemer search returned HTTP ${response.status.value}")
         }
-        return json.decodeFromString(ZemerSearchResponse.serializer(), response.bodyAsText())
+        return zemerResponseJson.decodeFromString(ZemerSearchResponse.serializer(), response.bodyAsText())
     }
 
     companion object {

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -1,0 +1,56 @@
+package com.jtech.zemer.search
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Thin HTTP client for the deployed Zemer search service (search.zemer.io). One request shape —
+ * `GET /search` — feeds every screen; the caller picks `k` (per-category result cap) to suit the
+ * summary, a single filter, or the as-you-type dropdown.
+ *
+ * Content-type is not assumed: the body is read as text and decoded with a lenient,
+ * unknown-key-tolerant [Json], so a missing/odd `Content-Type` or a new server field never breaks it.
+ */
+@Singleton
+class ZemerSearchClient @Inject constructor() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    private val client = HttpClient(CIO) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = CONNECT_TIMEOUT_MS
+        }
+    }
+
+    suspend fun search(
+        query: String,
+        allowFemale: Boolean,
+        blockVideos: Boolean,
+        k: Int,
+    ): ZemerSearchResponse {
+        val text = client.get("$BASE_URL/search") {
+            parameter("q", query)
+            parameter("allowFemale", if (allowFemale) "1" else "0")
+            if (blockVideos) parameter("blockVideos", "1")
+            parameter("k", k)
+        }.bodyAsText()
+        return json.decodeFromString(ZemerSearchResponse.serializer(), text)
+    }
+
+    companion object {
+        const val BASE_URL = "https://search.zemer.io"
+        private const val REQUEST_TIMEOUT_MS = 8_000L
+        private const val CONNECT_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -25,9 +25,12 @@ data class ZemerCategories(
     val playlists: List<ZemerPlaylist> = emptyList(),
 )
 
+// id/videoId default to "" rather than being required: kotlinx throws MissingFieldException for the
+// WHOLE response if one element omits a required field, so a single sparse row would blank the entire
+// result. The mapper drops rows whose id is blank instead.
 @Serializable
 data class ZemerArtist(
-    val id: String,
+    val id: String = "",
     val name: String = "",
     val thumbnail: String? = null,
 )
@@ -35,7 +38,7 @@ data class ZemerArtist(
 /** Both songs and videos share this shape (videos differ only by which category they arrive in). */
 @Serializable
 data class ZemerTrack(
-    val videoId: String,
+    val videoId: String = "",
     val title: String = "",
     val artist: String = "",
     val explicit: Boolean = false,
@@ -43,7 +46,7 @@ data class ZemerTrack(
 
 @Serializable
 data class ZemerAlbum(
-    val id: String,
+    val id: String = "",
     val playlistId: String? = null,
     val title: String = "",
     val artist: String = "",
@@ -53,7 +56,7 @@ data class ZemerAlbum(
 
 @Serializable
 data class ZemerPlaylist(
-    val id: String,
+    val id: String = "",
     val title: String = "",
     val artist: String = "",
     val thumbnail: String? = null,

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -22,7 +22,11 @@ data class ZemerCategories(
     val albums: List<ZemerAlbum> = emptyList(),
     val singles: List<ZemerAlbum> = emptyList(),
     val videos: List<ZemerTrack> = emptyList(),
+    // Artist-owned playlists (the "Featured playlists" chip) and the community-discovered playlists
+    // (the "Community playlists" chip) are two separate server categories; either may be absent
+    // (older server build) and then defaults to empty.
     val playlists: List<ZemerPlaylist> = emptyList(),
+    val community: List<ZemerPlaylist> = emptyList(),
 )
 
 // id/videoId default to "" rather than being required: kotlinx throws MissingFieldException for the

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -1,5 +1,6 @@
 package com.jtech.zemer.search
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -64,4 +65,8 @@ data class ZemerPlaylist(
     val title: String = "",
     val artist: String = "",
     val thumbnail: String? = null,
+    // Number of whitelisted songs the playlist actually serves. The server filters community playlists
+    // to the whitelist at open time, so this — not the raw `total` — is the count to surface (showing
+    // `total` would over-count vs. what the user gets when they open it). Absent on older server builds.
+    @SerialName("whitelisted") val songCount: Int? = null,
 )

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -1,0 +1,60 @@
+package com.jtech.zemer.search
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire models for the `GET /search` response served by search.zemer.io. Field names match the JSON
+ * exactly; everything that the server may omit is nullable/defaulted so a sparse row never fails
+ * deserialization. The `Json` reader is configured with `ignoreUnknownKeys = true`, so new server
+ * fields are forward-compatible.
+ */
+@Serializable
+data class ZemerSearchResponse(
+    val q: String = "",
+    val count: Int = 0,
+    val categories: ZemerCategories = ZemerCategories(),
+)
+
+@Serializable
+data class ZemerCategories(
+    val artists: List<ZemerArtist> = emptyList(),
+    val songs: List<ZemerTrack> = emptyList(),
+    val albums: List<ZemerAlbum> = emptyList(),
+    val singles: List<ZemerAlbum> = emptyList(),
+    val videos: List<ZemerTrack> = emptyList(),
+    val playlists: List<ZemerPlaylist> = emptyList(),
+)
+
+@Serializable
+data class ZemerArtist(
+    val id: String,
+    val name: String = "",
+    val thumbnail: String? = null,
+)
+
+/** Both songs and videos share this shape (videos differ only by which category they arrive in). */
+@Serializable
+data class ZemerTrack(
+    val videoId: String,
+    val title: String = "",
+    val artist: String = "",
+    val explicit: Boolean = false,
+)
+
+@Serializable
+data class ZemerAlbum(
+    val id: String,
+    val playlistId: String? = null,
+    val title: String = "",
+    val artist: String = "",
+    val year: Int? = null,
+    val thumbnail: String? = null,
+)
+
+@Serializable
+data class ZemerPlaylist(
+    val id: String,
+    val title: String = "",
+    val artist: String = "",
+    val thumbnail: String? = null,
+)

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt
@@ -1,0 +1,28 @@
+package com.jtech.zemer.search
+
+import android.content.Context
+import com.jtech.zemer.constants.HideExplicitKey
+import com.jtech.zemer.utils.ContentFilterState
+import com.jtech.zemer.utils.dataStore
+import com.jtech.zemer.utils.getSuspend
+
+/**
+ * The content-filter inputs a Zemer query needs, mapped from the app's existing filter state. The
+ * server applies [allowFemale]/[blockVideos] (it has no chasid param — that flag isn't part of the
+ * runtime [ContentFilterState]); [hideExplicit] is applied client-side to the mapped song/video lists.
+ */
+data class ZemerSearchOptions(
+    val allowFemale: Boolean,
+    val blockVideos: Boolean,
+    val hideExplicit: Boolean,
+)
+
+/** Builds the options from the live content-filter state + the Hide-Explicit preference. */
+suspend fun zemerSearchOptions(context: Context): ZemerSearchOptions {
+    val filters = ContentFilterState.current
+    return ZemerSearchOptions(
+        allowFemale = filters.allowFemaleSingers,
+        blockVideos = filters.blockVideos,
+        hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false),
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -1,9 +1,12 @@
 package com.jtech.zemer.search
 
+import android.content.Context
+import com.jtech.zemer.R
 import com.metrolist.innertube.YouTube.SearchFilter
 import com.metrolist.innertube.models.SearchSuggestions
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -26,19 +29,24 @@ import javax.inject.Singleton
 @Singleton
 class ZemerSearchRepository @Inject constructor(
     private val client: ZemerSearchClient,
+    @ApplicationContext private val context: Context,
 ) {
+    // Localized "N songs" for a playlist's whitelisted track count (reuses the shared n_song plural).
+    private val formatSongCount: (Int) -> String =
+        { n -> context.resources.getQuantityString(R.plurals.n_song, n, n) }
+
     suspend fun summary(query: String, options: ZemerSearchOptions): SearchSummaryPage =
-        ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), options.hideExplicit)
+        ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), options.hideExplicit, formatSongCount)
 
     suspend fun filtered(query: String, filter: SearchFilter, options: ZemerSearchOptions): SearchResult {
         // The Community chip browses a whole curated set, so it must not be clipped by the default
         // per-chip cap; every other chip uses K_FILTER.
         val k = if (filter.value == SearchFilter.FILTER_COMMUNITY_PLAYLIST.value) K_COMMUNITY else K_FILTER
-        return ZemerResultMapper.filtered(fetch(query, options, k), filter, options.hideExplicit)
+        return ZemerResultMapper.filtered(fetch(query, options, k), filter, options.hideExplicit, formatSongCount)
     }
 
     suspend fun suggestions(query: String, options: ZemerSearchOptions): SearchSuggestions =
-        ZemerResultMapper.suggestions(fetch(query, options, K_SUGGEST), options.hideExplicit)
+        ZemerResultMapper.suggestions(fetch(query, options, K_SUGGEST), options.hideExplicit, formatSongCount)
 
     private val cacheMutex = Mutex()
     private val cache = object : LinkedHashMap<String, ZemerSearchResponse>(16, 0.75f, true) {

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -1,0 +1,51 @@
+package com.jtech.zemer.search
+
+import android.content.Context
+import com.jtech.zemer.R
+import com.metrolist.innertube.YouTube.SearchFilter
+import com.metrolist.innertube.models.SearchSuggestions
+import com.metrolist.innertube.pages.SearchResult
+import com.metrolist.innertube.pages.SearchSummaryPage
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Entry point for Zemer-engine search. It returns the same `YTItem`/page types the YouTube path does,
+ * so the ViewModels can swap providers with a one-line branch and the UI is reused verbatim.
+ *
+ * Today every query goes to [ZemerSearchClient] (search.zemer.io). [fetch] is the single seam where
+ * Phase 2 will add the on-device subset fallback (download + cache + pure-Kotlin matcher) without
+ * touching callers — keeping the APK size unchanged.
+ */
+@Singleton
+class ZemerSearchRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val client: ZemerSearchClient,
+) {
+    suspend fun summary(query: String, options: ZemerSearchOptions): SearchSummaryPage =
+        ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), sectionTitles(), options.hideExplicit)
+
+    suspend fun filtered(query: String, filter: SearchFilter, options: ZemerSearchOptions): SearchResult =
+        ZemerResultMapper.filtered(fetch(query, options, K_FILTER), filter, options.hideExplicit)
+
+    suspend fun suggestions(query: String, options: ZemerSearchOptions): SearchSuggestions =
+        ZemerResultMapper.suggestions(fetch(query, options, K_SUGGEST), options.hideExplicit)
+
+    private suspend fun fetch(query: String, options: ZemerSearchOptions, k: Int): ZemerSearchResponse =
+        client.search(query.trim(), options.allowFemale, options.blockVideos, k)
+
+    private fun sectionTitles() = SectionTitles(
+        songs = context.getString(R.string.filter_songs),
+        videos = context.getString(R.string.filter_videos),
+        albums = context.getString(R.string.filter_albums),
+        artists = context.getString(R.string.filter_artists),
+        playlists = context.getString(R.string.filter_community_playlists),
+    )
+
+    companion object {
+        private const val K_SUMMARY = 8
+        private const val K_FILTER = 100
+        private const val K_SUGGEST = 8
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -1,12 +1,9 @@
 package com.jtech.zemer.search
 
-import android.content.Context
-import com.jtech.zemer.R
 import com.metrolist.innertube.YouTube.SearchFilter
 import com.metrolist.innertube.models.SearchSuggestions
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -26,11 +23,10 @@ import javax.inject.Singleton
  */
 @Singleton
 class ZemerSearchRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val client: ZemerSearchClient,
 ) {
     suspend fun summary(query: String, options: ZemerSearchOptions): SearchSummaryPage =
-        ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), sectionTitles(), options.hideExplicit)
+        ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), options.hideExplicit)
 
     suspend fun filtered(query: String, filter: SearchFilter, options: ZemerSearchOptions): SearchResult =
         ZemerResultMapper.filtered(fetch(query, options, K_FILTER), filter, options.hideExplicit)
@@ -51,14 +47,6 @@ class ZemerSearchRepository @Inject constructor(
         cacheMutex.withLock { cache[key] = response }
         return response
     }
-
-    private fun sectionTitles() = SectionTitles(
-        songs = context.getString(R.string.filter_songs),
-        videos = context.getString(R.string.filter_videos),
-        albums = context.getString(R.string.filter_albums),
-        artists = context.getString(R.string.filter_artists),
-        playlists = context.getString(R.string.filter_community_playlists),
-    )
 
     companion object {
         private const val K_SUMMARY = 8

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -17,9 +17,11 @@ import javax.inject.Singleton
  * If the service is unreachable the call throws, the ViewModel shows the search-error state, and the
  * user can flip the toggle to YouTube Music search.
  *
- * Responses are memoized in a small LRU keyed by (k, filters, query): the five filter chips all request
- * the same k, so after the first they hit the cache instead of re-fetching the full payload five times;
- * the summary and as-you-type share the k=8 entry too.
+ * Responses are memoized in a small LRU keyed by (k, filters, query): the song/video/album/artist/
+ * featured-playlist chips all request the same k, so after the first they hit the cache instead of
+ * re-fetching the full payload; the summary and as-you-type share the k=8 entry too. The Community
+ * chip is the exception — it requests a much larger k so its whole curated set comes back uncapped (see
+ * [K_COMMUNITY]) — so it owns its own cache entry.
  */
 @Singleton
 class ZemerSearchRepository @Inject constructor(
@@ -28,8 +30,12 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun summary(query: String, options: ZemerSearchOptions): SearchSummaryPage =
         ZemerResultMapper.summaryPage(fetch(query, options, K_SUMMARY), options.hideExplicit)
 
-    suspend fun filtered(query: String, filter: SearchFilter, options: ZemerSearchOptions): SearchResult =
-        ZemerResultMapper.filtered(fetch(query, options, K_FILTER), filter, options.hideExplicit)
+    suspend fun filtered(query: String, filter: SearchFilter, options: ZemerSearchOptions): SearchResult {
+        // The Community chip browses a whole curated set, so it must not be clipped by the default
+        // per-chip cap; every other chip uses K_FILTER.
+        val k = if (filter.value == SearchFilter.FILTER_COMMUNITY_PLAYLIST.value) K_COMMUNITY else K_FILTER
+        return ZemerResultMapper.filtered(fetch(query, options, k), filter, options.hideExplicit)
+    }
 
     suspend fun suggestions(query: String, options: ZemerSearchOptions): SearchSuggestions =
         ZemerResultMapper.suggestions(fetch(query, options, K_SUGGEST), options.hideExplicit)
@@ -52,6 +58,10 @@ class ZemerSearchRepository @Inject constructor(
         private const val K_SUMMARY = 8
         private const val K_FILTER = 100
         private const val K_SUGGEST = 8
+        // Community playlists are a browsable curated set (a few hundred and growing); request well
+        // above the corpus size so the Community chip returns all query-relevant results uncapped (the
+        // server now honors k for that category). Bump if the community catalog ever approaches this.
+        private const val K_COMMUNITY = 500
         private const val CACHE_SIZE = 12
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -53,6 +53,13 @@ class ZemerSearchRepository @Inject constructor(
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ZemerSearchResponse>) = size > CACHE_SIZE
     }
 
+    /**
+     * Drop all memoized responses so the next call re-hits the server. Without this the session LRU
+     * would keep serving a stale (or empty) response — making the "Retry" action a silent no-op — for
+     * the whole process lifetime. Called from the ViewModel's pull-to-refresh / retry path.
+     */
+    suspend fun invalidate() = cacheMutex.withLock { cache.clear() }
+
     private suspend fun fetch(query: String, options: ZemerSearchOptions, k: Int): ZemerSearchResponse {
         val trimmed = query.trim()
         val key = "$k|${options.allowFemale}|${options.blockVideos}|$trimmed"

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -7,6 +7,8 @@ import com.metrolist.innertube.models.SearchSuggestions
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,9 +16,13 @@ import javax.inject.Singleton
  * Entry point for Zemer-engine search. It returns the same `YTItem`/page types the YouTube path does,
  * so the ViewModels can swap providers with a one-line branch and the UI is reused verbatim.
  *
- * Today every query goes to [ZemerSearchClient] (search.zemer.io). [fetch] is the single seam where
- * Phase 2 will add the on-device subset fallback (download + cache + pure-Kotlin matcher) without
- * touching callers — keeping the APK size unchanged.
+ * Every query goes to [ZemerSearchClient] (search.zemer.io); there is no on-device fallback by design.
+ * If the service is unreachable the call throws, the ViewModel shows the search-error state, and the
+ * user can flip the toggle to YouTube Music search.
+ *
+ * Responses are memoized in a small LRU keyed by (k, filters, query): the five filter chips all request
+ * the same k, so after the first they hit the cache instead of re-fetching the full payload five times;
+ * the summary and as-you-type share the k=8 entry too.
  */
 @Singleton
 class ZemerSearchRepository @Inject constructor(
@@ -32,8 +38,19 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun suggestions(query: String, options: ZemerSearchOptions): SearchSuggestions =
         ZemerResultMapper.suggestions(fetch(query, options, K_SUGGEST), options.hideExplicit)
 
-    private suspend fun fetch(query: String, options: ZemerSearchOptions, k: Int): ZemerSearchResponse =
-        client.search(query.trim(), options.allowFemale, options.blockVideos, k)
+    private val cacheMutex = Mutex()
+    private val cache = object : LinkedHashMap<String, ZemerSearchResponse>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ZemerSearchResponse>) = size > CACHE_SIZE
+    }
+
+    private suspend fun fetch(query: String, options: ZemerSearchOptions, k: Int): ZemerSearchResponse {
+        val trimmed = query.trim()
+        val key = "$k|${options.allowFemale}|${options.blockVideos}|$trimmed"
+        cacheMutex.withLock { cache[key] }?.let { return it }
+        val response = client.search(trimmed, options.allowFemale, options.blockVideos, k)
+        cacheMutex.withLock { cache[key] = response }
+        return response
+    }
 
     private fun sectionTitles() = SectionTitles(
         songs = context.getString(R.string.filter_songs),
@@ -47,5 +64,6 @@ class ZemerSearchRepository @Inject constructor(
         private const val K_SUMMARY = 8
         private const val K_FILTER = 100
         private const val K_SUGGEST = 8
+        private const val CACHE_SIZE = 12
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +37,8 @@ fun AppStateView(
     progress: Float? = null,
     actionLabel: String? = null,
     onAction: (() -> Unit)? = null,
+    secondaryActionLabel: String? = null,
+    onSecondaryAction: (() -> Unit)? = null,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -104,6 +107,13 @@ fun AppStateView(
                 Spacer(modifier = Modifier.height(20.dp))
                 Button(onClick = onAction) {
                     Text(actionLabel)
+                }
+            }
+
+            if (secondaryActionLabel != null && onSecondaryAction != null) {
+                Spacer(modifier = Modifier.height(4.dp))
+                TextButton(onClick = onSecondaryAction) {
+                    Text(secondaryActionLabel)
                 }
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
@@ -86,8 +86,14 @@ private fun ProviderSegment(
             .clip(shape)
             .background(background)
             .then(
-                if (focused && !selected) {
-                    Modifier.border(1.5.dp, MaterialTheme.colorScheme.outline, shape)
+                // Focus ring on BOTH states so the already-selected segment still shows D-pad focus;
+                // contrast against the primary fill when selected.
+                if (focused) {
+                    Modifier.border(
+                        1.5.dp,
+                        if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.outline,
+                        shape,
+                    )
                 } else {
                     Modifier
                 },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
@@ -1,0 +1,124 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+import com.jtech.zemer.search.SearchProvider
+
+/**
+ * The two-segment "pill" that switches the online search engine, shown on the right of the search bar.
+ * The selected side is filled with the accent color; the other is an outline. Each segment is a single
+ * focus target (the `clickable`), so it stays 100% D-pad navigable — a focused-but-unselected segment
+ * shows the standard outline highlight (docs/ui/standards.md). Material 3 *standard*.
+ *
+ * Zemer is marked with the actual app launcher icon (rendered full-color via [Image], as AboutScreen
+ * does); YouTube with a tinted play glyph.
+ */
+@Composable
+fun SearchProviderToggle(
+    provider: SearchProvider,
+    onProviderChange: (SearchProvider) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(percent = 50)
+    Row(
+        modifier = modifier
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .padding(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ProviderSegment(
+            label = stringResource(R.string.search_provider_zemer),
+            selected = provider == SearchProvider.ZEMER,
+            onClick = { onProviderChange(SearchProvider.ZEMER) },
+        ) {
+            Image(
+                painter = painterResource(R.mipmap.ic_launcher_foreground),
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+        ProviderSegment(
+            label = stringResource(R.string.search_provider_youtube_short),
+            selected = provider == SearchProvider.YOUTUBE,
+            onClick = { onProviderChange(SearchProvider.YOUTUBE) },
+        ) { contentColor ->
+            Icon(
+                painter = painterResource(R.drawable.play),
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(15.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProviderSegment(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: @Composable (contentColor: Color) -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+    val shape = RoundedCornerShape(percent = 50)
+    val background = when {
+        selected -> MaterialTheme.colorScheme.primary
+        focused -> MaterialTheme.colorScheme.surfaceVariant
+        else -> Color.Transparent
+    }
+    val content =
+        if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+
+    Row(
+        modifier = Modifier
+            .clip(shape)
+            .background(background)
+            .then(
+                if (focused && !selected) {
+                    Modifier.border(1.5.dp, MaterialTheme.colorScheme.outline, shape)
+                } else {
+                    Modifier
+                },
+            )
+            .onFocusChanged { focused = it.isFocused }
+            .clickable(role = Role.RadioButton, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon(content)
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = label,
+            color = content,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt
@@ -1,6 +1,5 @@
 package com.jtech.zemer.ui.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -35,9 +34,6 @@ import com.jtech.zemer.search.SearchProvider
  * The selected side is filled with the accent color; the other is an outline. Each segment is a single
  * focus target (the `clickable`), so it stays 100% D-pad navigable — a focused-but-unselected segment
  * shows the standard outline highlight (docs/ui/standards.md). Material 3 *standard*.
- *
- * Zemer is marked with the actual app launcher icon (rendered full-color via [Image], as AboutScreen
- * does); YouTube with a tinted play glyph.
  */
 @Composable
 fun SearchProviderToggle(
@@ -54,37 +50,26 @@ fun SearchProviderToggle(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ProviderSegment(
+            iconRes = R.drawable.ic_launcher_monochrome,
             label = stringResource(R.string.search_provider_zemer),
             selected = provider == SearchProvider.ZEMER,
             onClick = { onProviderChange(SearchProvider.ZEMER) },
-        ) {
-            Image(
-                painter = painterResource(R.mipmap.ic_launcher_foreground),
-                contentDescription = null,
-                modifier = Modifier.size(22.dp),
-            )
-        }
+        )
         ProviderSegment(
+            iconRes = R.drawable.play,
             label = stringResource(R.string.search_provider_youtube_short),
             selected = provider == SearchProvider.YOUTUBE,
             onClick = { onProviderChange(SearchProvider.YOUTUBE) },
-        ) { contentColor ->
-            Icon(
-                painter = painterResource(R.drawable.play),
-                contentDescription = null,
-                tint = contentColor,
-                modifier = Modifier.size(15.dp),
-            )
-        }
+        )
     }
 }
 
 @Composable
 private fun ProviderSegment(
+    iconRes: Int,
     label: String,
     selected: Boolean,
     onClick: () -> Unit,
-    icon: @Composable (contentColor: Color) -> Unit,
 ) {
     var focused by remember { mutableStateOf(false) }
     val shape = RoundedCornerShape(percent = 50)
@@ -109,10 +94,15 @@ private fun ProviderSegment(
             )
             .onFocusChanged { focused = it.isFocused }
             .clickable(role = Role.RadioButton, onClick = onClick)
-            .padding(horizontal = 10.dp, vertical = 4.dp),
+            .padding(horizontal = 10.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        icon(content)
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = null,
+            tint = content,
+            modifier = Modifier.size(15.dp),
+        )
         Spacer(Modifier.width(4.dp))
         Text(
             text = label,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -48,6 +48,9 @@ import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.constants.BlockVideosKey
+import com.jtech.zemer.constants.SearchProviderKey
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.ChipsRow
@@ -103,6 +106,17 @@ fun OnlineSearchResult(
 
     val searchFilter by viewModel.filter.collectAsState()
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
+    // On the default (Zemer) engine, the error / no-results states offer a one-tap switch to YouTube
+    // search — the documented recovery — since the engine toggle (only in the expanded search bar) is
+    // not reachable from this results screen. Flipping the preference reloads via the ViewModel.
+    val (searchProvider, onSearchProviderChange) = rememberEnumPreference(SearchProviderKey, SearchProvider.ZEMER)
+    val youtubeFallbackLabel = stringResource(R.string.search_try_youtube)
+    val onYoutubeFallback: (() -> Unit)? =
+        if (searchProvider == SearchProvider.ZEMER) {
+            { onSearchProviderChange(SearchProvider.YOUTUBE) }
+        } else {
+            null
+        }
     val searchSummary = viewModel.summaryPage
     val isSummaryLoading by viewModel.isSummaryLoading.collectAsState()
     val summaryError by viewModel.summaryError.collectAsState()
@@ -299,6 +313,8 @@ fun OnlineSearchResult(
                             icon = R.drawable.search,
                             actionLabel = stringResource(R.string.search_retry),
                             onAction = viewModel::refresh,
+                            secondaryActionLabel = onYoutubeFallback?.let { youtubeFallbackLabel },
+                            onSecondaryAction = onYoutubeFallback,
                             modifier = Modifier
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                                 .animateItem(),
@@ -324,6 +340,8 @@ fun OnlineSearchResult(
                             icon = R.drawable.search,
                             actionLabel = stringResource(R.string.search_retry),
                             onAction = viewModel::refresh,
+                            secondaryActionLabel = onYoutubeFallback?.let { youtubeFallbackLabel },
+                            onSecondaryAction = onYoutubeFallback,
                             modifier = Modifier
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                                 .animateItem(),
@@ -378,6 +396,8 @@ fun OnlineSearchResult(
                             icon = R.drawable.search,
                             actionLabel = stringResource(R.string.search_retry),
                             onAction = viewModel::refresh,
+                            secondaryActionLabel = onYoutubeFallback?.let { youtubeFallbackLabel },
+                            onSecondaryAction = onYoutubeFallback,
                             modifier = Modifier
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                                 .animateItem(),
@@ -403,6 +423,8 @@ fun OnlineSearchResult(
                             icon = R.drawable.search,
                             actionLabel = stringResource(R.string.search_retry),
                             onAction = viewModel::refresh,
+                            secondaryActionLabel = onYoutubeFallback?.let { youtubeFallbackLabel },
+                            onSecondaryAction = onYoutubeFallback,
                             modifier = Modifier
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                                 .animateItem(),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -82,7 +82,7 @@ import com.metrolist.innertube.models.SongItem
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
@@ -121,9 +121,12 @@ fun OnlineSearchScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        snapshotFlow { lazyListState.firstVisibleItemScrollOffset }
-            .drop(1)
+    // Hide the keyboard only when the USER scrolls the list — gating on a raw scroll-offset change
+    // instead fires on programmatic content updates too (the as-you-type list re-lays-out as results
+    // stream in), which yanked the keyboard down mid-typing.
+    LaunchedEffect(lazyListState) {
+        snapshotFlow { lazyListState.isScrollInProgress }
+            .filter { it }
             .collect {
                 keyboardController?.hide()
             }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -7,11 +7,16 @@ import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.filterExplicit
 import com.jtech.zemer.constants.HideExplicitKey
+import com.jtech.zemer.constants.SearchProviderKey
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.SearchHistory
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.WhitelistCache
 import com.jtech.zemer.utils.dataStore
+import com.jtech.zemer.utils.enumPreferenceFlow
 import com.jtech.zemer.utils.getSuspend
 import com.jtech.zemer.utils.filterWhitelisted
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,6 +24,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -31,6 +37,7 @@ class OnlineSearchSuggestionViewModel
 constructor(
     @ApplicationContext val context: Context,
     val database: MusicDatabase,
+    private val zemerRepo: ZemerSearchRepository,
 ) : ViewModel() {
     val query = MutableStateFlow("")
     private val _viewState = MutableStateFlow(SearchSuggestionViewState())
@@ -38,14 +45,40 @@ constructor(
 
     init {
         viewModelScope.launch {
-            query
-                .flatMapLatest { query ->
+            combine(
+                query,
+                enumPreferenceFlow(context, SearchProviderKey, SearchProvider.ZEMER),
+            ) { typed, provider -> typed to provider }
+                .flatMapLatest { (query, provider) ->
                     if (query.isEmpty()) {
                         database.searchHistory().map { history ->
                             SearchSuggestionViewState(
                                 history = history,
                             )
                         }
+                    } else if (provider == SearchProvider.ZEMER) {
+                        // Whitelist-scoped, Hebrew-aware as-you-type results across ALL categories,
+                        // rendered through the existing (Metrolist-derived) OnlineSearchScreen list.
+                        // Below the 3-char floor show only matching history: short queries are noisy
+                        // (the engine's cross-script skeleton matching is itself off under 3 chars).
+                        database
+                            .searchHistory(query)
+                            .map { it.take(3) }
+                            .map { history ->
+                                val zemer = if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
+                                    runCatching {
+                                        zemerRepo.suggestions(query, zemerSearchOptions(context))
+                                    }.getOrNull()
+                                } else {
+                                    null
+                                }
+                                SearchSuggestionViewState(
+                                    history = history,
+                                    suggestions = zemer?.queries.orEmpty()
+                                        .filter { suggestion -> history.none { it.query == suggestion } },
+                                    items = zemer?.recommendedItems.orEmpty(),
+                                )
+                            }
                     } else {
                         val filters = ContentFilterState.state.value
                         val whitelist = WhitelistCache.allowedEntries(database, filters)
@@ -121,6 +154,9 @@ constructor(
         }
     }
 }
+
+/** Minimum query length before the Zemer engine returns as-you-type results. */
+private const val ZEMER_MIN_QUERY_LENGTH = 3
 
 data class SearchSuggestionViewState(
     val history: List<SearchHistory> = emptyList(),

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -19,15 +19,21 @@ import com.jtech.zemer.utils.dataStore
 import com.jtech.zemer.utils.enumPreferenceFlow
 import com.jtech.zemer.utils.getSuspend
 import com.jtech.zemer.utils.filterWhitelisted
+import com.jtech.zemer.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -61,24 +67,35 @@ constructor(
                         // rendered through the existing (Metrolist-derived) OnlineSearchScreen list.
                         // Below the 3-char floor show only matching history: short queries are noisy
                         // (the engine's cross-script skeleton matching is itself off under 3 chars).
-                        database
-                            .searchHistory(query)
-                            .map { it.take(3) }
-                            .map { history ->
-                                val zemer = if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
+                        // The engine call is hoisted out of the history flow (one request per query,
+                        // not one per history emission) and run off the main thread.
+                        flow {
+                            val zemer = if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
+                                withContext(Dispatchers.IO) {
                                     runCatching {
                                         zemerRepo.suggestions(query, zemerSearchOptions(context))
+                                    }.onFailure {
+                                        if (it is CancellationException) throw it
+                                        reportException(it)
                                     }.getOrNull()
-                                } else {
-                                    null
                                 }
-                                SearchSuggestionViewState(
-                                    history = history,
-                                    suggestions = zemer?.queries.orEmpty()
-                                        .filter { suggestion -> history.none { it.query == suggestion } },
-                                    items = zemer?.recommendedItems.orEmpty(),
-                                )
+                            } else {
+                                null
                             }
+                            emitAll(
+                                database
+                                    .searchHistory(query)
+                                    .map { it.take(3) }
+                                    .map { history ->
+                                        SearchSuggestionViewState(
+                                            history = history,
+                                            suggestions = zemer?.queries.orEmpty()
+                                                .filter { suggestion -> history.none { it.query == suggestion } },
+                                            items = zemer?.recommendedItems.orEmpty(),
+                                        )
+                                    },
+                            )
+                        }
                     } else {
                         val filters = ContentFilterState.state.value
                         val whitelist = WhitelistCache.allowedEntries(database, filters)

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -62,41 +62,15 @@ constructor(
                             )
                         }
                     } else if (provider == SearchProvider.ZEMER) {
-                        // Whitelist-scoped, Hebrew-aware as-you-type results across ALL categories,
-                        // rendered through the existing (Metrolist-derived) OnlineSearchScreen list.
-                        //
-                        // Two layers, so the dropdown is never blank, stale, or blocked on the network:
-                        //  • instant / offline — history plus matching whitelisted artists from the
-                        //    local DB, shown immediately and for ANY query length; this is the only
-                        //    suggestion source when the service is unreachable or below the net floor.
-                        //  • network — the engine's cross-script results for queries >= the floor,
-                        //    merged in WHEN they arrive. The flow emits null first so history/local
-                        //    never wait on the (up to 8s) request, and flatMapLatest cancels an
-                        //    in-flight request on the next keystroke.
-                        val filters = ContentFilterState.state.value
-                        val localArtists: List<YTItem> =
-                            if (filters.filtersEnabled) {
-                                WhitelistCache.allowedEntries(database, filters)
-                                    .asSequence()
-                                    .filter { it.artistName.contains(query, ignoreCase = true) }
-                                    .take(MAX_LOCAL_ARTIST_SUGGESTIONS)
-                                    .map { entry ->
-                                        com.metrolist.innertube.models.ArtistItem(
-                                            id = entry.artistId,
-                                            title = entry.artistName,
-                                            thumbnail = null,
-                                            channelId = null,
-                                            playEndpoint = null,
-                                            shuffleEndpoint = null,
-                                            radioEndpoint = null,
-                                        )
-                                    }
-                                    .toList()
-                            } else {
-                                emptyList()
-                            }
+                        // Zemer is its OWN engine (search.zemer.io), independent of the YouTube path.
+                        // History shows immediately (never blocked on the request). The engine's
+                        // whitelist-scoped, cross-script results appear ONLY once the query reaches the
+                        // floor (cross-script skeleton matching is itself off below 3 chars) — below it,
+                        // or while a request is in flight, only history shows. There is NO on-device /
+                        // local fallback by design: if the service is unreachable the user switches
+                        // engines. flatMapLatest cancels an in-flight request on the next keystroke.
                         val zemerSuggestions = flow {
-                            emit(null) // render history + local artists straight away, before any request
+                            emit(null) // history renders at once, never waiting on the request
                             if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
                                 emit(
                                     withContext(Dispatchers.IO) {
@@ -118,9 +92,7 @@ constructor(
                                     history = history,
                                     suggestions = zemer?.queries.orEmpty()
                                         .filter { suggestion -> history.none { it.query == suggestion } },
-                                    // network rows first (richer, thumbnailed); local whitelist artists
-                                    // appended as the offline/instant fallback, de-duped by id.
-                                    items = (zemer?.recommendedItems.orEmpty() + localArtists).distinctBy { it.id },
+                                    items = zemer?.recommendedItems.orEmpty(),
                                 )
                             }
                     } else {
@@ -201,9 +173,6 @@ constructor(
 
 /** Minimum query length before the Zemer engine returns as-you-type results. */
 private const val ZEMER_MIN_QUERY_LENGTH = 3
-
-/** Cap on the instant, local whitelist-artist suggestions shown on the Zemer engine. */
-private const val MAX_LOCAL_ARTIST_SUGGESTIONS = 10
 
 data class SearchSuggestionViewState(
     val history: List<SearchHistory> = emptyList(),

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -65,37 +64,65 @@ constructor(
                     } else if (provider == SearchProvider.ZEMER) {
                         // Whitelist-scoped, Hebrew-aware as-you-type results across ALL categories,
                         // rendered through the existing (Metrolist-derived) OnlineSearchScreen list.
-                        // Below the 3-char floor show only matching history: short queries are noisy
-                        // (the engine's cross-script skeleton matching is itself off under 3 chars).
-                        // The engine call is hoisted out of the history flow (one request per query,
-                        // not one per history emission) and run off the main thread.
-                        flow {
-                            val zemer = if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
-                                withContext(Dispatchers.IO) {
-                                    runCatching {
-                                        zemerRepo.suggestions(query, zemerSearchOptions(context))
-                                    }.onFailure {
-                                        if (it is CancellationException) throw it
-                                        reportException(it)
-                                    }.getOrNull()
-                                }
-                            } else {
-                                null
-                            }
-                            emitAll(
-                                database
-                                    .searchHistory(query)
-                                    .map { it.take(3) }
-                                    .map { history ->
-                                        SearchSuggestionViewState(
-                                            history = history,
-                                            suggestions = zemer?.queries.orEmpty()
-                                                .filter { suggestion -> history.none { it.query == suggestion } },
-                                            items = zemer?.recommendedItems.orEmpty(),
+                        //
+                        // Two layers, so the dropdown is never blank, stale, or blocked on the network:
+                        //  • instant / offline — history plus matching whitelisted artists from the
+                        //    local DB, shown immediately and for ANY query length; this is the only
+                        //    suggestion source when the service is unreachable or below the net floor.
+                        //  • network — the engine's cross-script results for queries >= the floor,
+                        //    merged in WHEN they arrive. The flow emits null first so history/local
+                        //    never wait on the (up to 8s) request, and flatMapLatest cancels an
+                        //    in-flight request on the next keystroke.
+                        val filters = ContentFilterState.state.value
+                        val localArtists: List<YTItem> =
+                            if (filters.filtersEnabled) {
+                                WhitelistCache.allowedEntries(database, filters)
+                                    .asSequence()
+                                    .filter { it.artistName.contains(query, ignoreCase = true) }
+                                    .take(MAX_LOCAL_ARTIST_SUGGESTIONS)
+                                    .map { entry ->
+                                        com.metrolist.innertube.models.ArtistItem(
+                                            id = entry.artistId,
+                                            title = entry.artistName,
+                                            thumbnail = null,
+                                            channelId = null,
+                                            playEndpoint = null,
+                                            shuffleEndpoint = null,
+                                            radioEndpoint = null,
                                         )
+                                    }
+                                    .toList()
+                            } else {
+                                emptyList()
+                            }
+                        val zemerSuggestions = flow {
+                            emit(null) // render history + local artists straight away, before any request
+                            if (query.trim().length >= ZEMER_MIN_QUERY_LENGTH) {
+                                emit(
+                                    withContext(Dispatchers.IO) {
+                                        runCatching {
+                                            zemerRepo.suggestions(query, zemerSearchOptions(context))
+                                        }.onFailure {
+                                            if (it is CancellationException) throw it
+                                            reportException(it)
+                                        }.getOrNull()
                                     },
-                            )
+                                )
+                            }
                         }
+                        database
+                            .searchHistory(query)
+                            .map { it.take(3) }
+                            .combine(zemerSuggestions) { history, zemer ->
+                                SearchSuggestionViewState(
+                                    history = history,
+                                    suggestions = zemer?.queries.orEmpty()
+                                        .filter { suggestion -> history.none { it.query == suggestion } },
+                                    // network rows first (richer, thumbnailed); local whitelist artists
+                                    // appended as the offline/instant fallback, de-duped by id.
+                                    items = (zemer?.recommendedItems.orEmpty() + localArtists).distinctBy { it.id },
+                                )
+                            }
                     } else {
                         val filters = ContentFilterState.state.value
                         val whitelist = WhitelistCache.allowedEntries(database, filters)
@@ -174,6 +201,9 @@ constructor(
 
 /** Minimum query length before the Zemer engine returns as-you-type results. */
 private const val ZEMER_MIN_QUERY_LENGTH = 3
+
+/** Cap on the instant, local whitelist-artist suggestions shown on the Zemer engine. */
+private const val MAX_LOCAL_ARTIST_SUGGESTIONS = 10
 
 data class SearchSuggestionViewState(
     val history: List<SearchHistory> = emptyList(),

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
@@ -15,13 +15,18 @@ import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.pages.SearchSummaryPage
 import com.metrolist.innertube.pages.SearchSummary
 import com.jtech.zemer.constants.HideExplicitKey
+import com.jtech.zemer.constants.SearchProviderKey
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.models.ItemsPage
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.WhitelistCache
 import com.jtech.zemer.utils.dataStore
+import com.jtech.zemer.utils.enumPreferenceFlow
 import com.jtech.zemer.utils.getSuspend
 import com.jtech.zemer.utils.filterWhitelisted
 import com.jtech.zemer.utils.reportException
@@ -29,6 +34,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -40,6 +46,7 @@ class OnlineSearchViewModel
 constructor(
     @ApplicationContext val context: Context,
     val database: MusicDatabase,
+    private val zemerRepo: ZemerSearchRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     val query =
@@ -66,15 +73,33 @@ constructor(
     val filterLoading = mutableStateMapOf<String, Boolean>()
     val filterError = mutableStateMapOf<String, String?>()
 
+    /** The engine in effect for the current load; updated reactively from the preference. */
+    private var provider: SearchProvider = SearchProvider.ZEMER
+    private var lastProvider: SearchProvider? = null
+
     init {
         viewModelScope.launch {
-            filter.collect { filter ->
-                if (filter == null) {
-                    loadSummary(force = summaryPage == null)
-                } else {
-                    loadFiltered(filter, force = viewStateMap[filter.value] == null)
+            combine(
+                filter,
+                enumPreferenceFlow(context, SearchProviderKey, SearchProvider.ZEMER),
+            ) { selectedFilter, selectedProvider -> selectedFilter to selectedProvider }
+                .collect { (selectedFilter, selectedProvider) ->
+                    provider = selectedProvider
+                    // Toggling the engine invalidates cached results so the new one reloads in place.
+                    if (lastProvider != null && lastProvider != selectedProvider) {
+                        summaryPage = null
+                        viewStateMap.clear()
+                        filterLoading.clear()
+                        filterError.clear()
+                        summaryError.value = null
+                    }
+                    lastProvider = selectedProvider
+                    if (selectedFilter == null) {
+                        loadSummary(force = summaryPage == null)
+                    } else {
+                        loadFiltered(selectedFilter, force = viewStateMap[selectedFilter.value] == null)
+                    }
                 }
-            }
         }
     }
 
@@ -94,20 +119,25 @@ constructor(
         val result =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
-                    val ytResults = YouTube.searchSummary(query).getOrNull()
-                    val ytFilteredPage = ytResults?.filterExplicit(hideExplicit)
+                    if (provider == SearchProvider.ZEMER) {
+                        // Zemer results are already whitelist-scoped server-side; do not re-filter.
+                        zemerRepo.summary(query, zemerSearchOptions(context)).summaries
+                    } else {
+                        val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
+                        val ytResults = YouTube.searchSummary(query).getOrNull()
+                        val ytFilteredPage = ytResults?.filterExplicit(hideExplicit)
 
-                    ytFilteredPage?.summaries
-                        ?.mapNotNull { summary ->
-                            val filteredItems = summary.items.filterWhitelisted(database)
-                            if (filteredItems.isEmpty()) {
-                                null
-                            } else {
-                                summary.copy(items = filteredItems)
+                        ytFilteredPage?.summaries
+                            ?.mapNotNull { summary ->
+                                val filteredItems = summary.items.filterWhitelisted(database)
+                                if (filteredItems.isEmpty()) {
+                                    null
+                                } else {
+                                    summary.copy(items = filteredItems)
+                                }
                             }
-                        }
-                        .orEmpty()
+                            .orEmpty()
+                    }
                 }
             }
 
@@ -143,6 +173,14 @@ constructor(
         val result =
             withContext(Dispatchers.IO) {
                 runCatching {
+                    if (provider == SearchProvider.ZEMER) {
+                        // Already whitelist-scoped; Zemer has no pagination (continuation == null).
+                        val zemerResult = zemerRepo.filtered(query, filter, zemerSearchOptions(context))
+                        return@runCatching ItemsPage(
+                            zemerResult.items.distinctBy { it.id },
+                            zemerResult.continuation,
+                        )
+                    }
                     val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
                     val items = mutableListOf<com.metrolist.innertube.models.YTItem>()
 

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
@@ -32,8 +32,10 @@ import com.jtech.zemer.utils.filterWhitelisted
 import com.jtech.zemer.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -83,7 +85,9 @@ constructor(
                 filter,
                 enumPreferenceFlow(context, SearchProviderKey, SearchProvider.ZEMER),
             ) { selectedFilter, selectedProvider -> selectedFilter to selectedProvider }
-                .collect { (selectedFilter, selectedProvider) ->
+                // collectLatest so a provider/filter change cancels an in-flight (up to 8s) request
+                // instead of queueing behind it — otherwise the toggle appears frozen.
+                .collectLatest { (selectedFilter, selectedProvider) ->
                     provider = selectedProvider
                     // Toggling the engine invalidates cached results so the new one reloads in place.
                     if (lastProvider != null && lastProvider != selectedProvider) {
@@ -150,6 +154,7 @@ constructor(
                 summaryError.value = "No results found for \"$query\""
             }
         }.onFailure { error ->
+            if (error is CancellationException) throw error // a superseded load, not a search failure
             summaryError.value = "Search error: ${error.message ?: "Unknown error"}"
             reportException(error)
         }
@@ -173,24 +178,13 @@ constructor(
         val result =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    if (provider == SearchProvider.ZEMER) {
-                        // Already whitelist-scoped; Zemer has no pagination (continuation == null).
-                        val zemerResult = zemerRepo.filtered(query, filter, zemerSearchOptions(context))
-                        return@runCatching ItemsPage(
-                            zemerResult.items.distinctBy { it.id },
-                            zemerResult.continuation,
-                        )
-                    }
                     val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
                     val items = mutableListOf<com.metrolist.innertube.models.YTItem>()
 
-                    // Search both local database and online
+                    // Local DB results first — for both engines, so locally-saved artists/albums are
+                    // surfaced regardless of which online engine is active.
                     when (filter) {
-                        SearchFilter.FILTER_SONG -> {
-                            // For songs, only search online as local songs are covered by local search
-                        }
                         SearchFilter.FILTER_ARTIST -> {
-                            // Search local artists first
                             val localArtists = database.searchArtists(query).first()
                                 .filter { if (hideExplicit) !it.artist.isLocal else true }
                             items.addAll(
@@ -206,7 +200,6 @@ constructor(
                             )
                         }
                         SearchFilter.FILTER_ALBUM -> {
-                            // Search local albums first
                             val localAlbums = database.searchAlbums(query).first()
                                 .filter { if (hideExplicit) !it.album.explicit else true }
                             items.addAll(
@@ -227,23 +220,24 @@ constructor(
                                 }
                             )
                         }
-                        else -> {} // Other filter types only search online
+                        else -> {} // Songs/videos/playlists: online only (local songs are local search)
                     }
 
-                    // Also search online
-                    val ytResult = YouTube.search(query, filter).getOrNull()
-                    if (ytResult != null) {
-                        items.addAll(
-                            ytResult.items
-                                .filterExplicit(hideExplicit)
-                                .filterWhitelisted(database)
-                        )
+                    if (provider == SearchProvider.ZEMER) {
+                        // Already whitelist-scoped; Zemer has no pagination (continuation == null).
+                        items.addAll(zemerRepo.filtered(query, filter, zemerSearchOptions(context)).items)
+                        ItemsPage(items.distinctBy { it.id }, null)
+                    } else {
+                        val ytResult = YouTube.search(query, filter).getOrNull()
+                        if (ytResult != null) {
+                            items.addAll(
+                                ytResult.items
+                                    .filterExplicit(hideExplicit)
+                                    .filterWhitelisted(database)
+                            )
+                        }
+                        ItemsPage(items.distinctBy { it.id }, ytResult?.continuation)
                     }
-
-                    ItemsPage(
-                        items.distinctBy { it.id },
-                        ytResult?.continuation
-                    )
                 }
             }
 
@@ -253,6 +247,7 @@ constructor(
                 filterError[key] = "No results found for \"$query\""
             }
         }.onFailure { error ->
+            if (error is CancellationException) throw error // a superseded load, not a search failure
             filterError[key] = "Search error: ${error.message ?: "Unknown error"}"
             reportException(error)
         }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
@@ -283,6 +283,10 @@ constructor(
 
     fun refresh() {
         viewModelScope.launch {
+            // Read the engine preference fresh: a refresh fired right after toggling engines must use
+            // the new one, not the snapshot the reactive collector may not have written to `provider`
+            // yet (otherwise the retry briefly reloads the old engine's results under the new toggle).
+            provider = enumPreferenceFlow(context, SearchProviderKey, SearchProvider.ZEMER).first()
             val currentFilter = filter.value
             // Drop the Zemer response cache so retry actually re-queries the server instead of
             // re-serving the cached (possibly empty) result; clearing VM state alone is not enough.

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
@@ -284,6 +284,9 @@ constructor(
     fun refresh() {
         viewModelScope.launch {
             val currentFilter = filter.value
+            // Drop the Zemer response cache so retry actually re-queries the server instead of
+            // re-serving the cached (possibly empty) result; clearing VM state alone is not enough.
+            zemerRepo.invalidate()
             summaryPage = null
             viewStateMap.clear()
             filterLoading.clear()

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -557,4 +557,6 @@
     <string name="search_provider_youtube_short">YT</string>
     <string name="search_provider_youtube">YouTube Music</string>
     <string name="cd_search_provider">Search engine</string>
+    <!-- Offered on the Zemer search error / no-results state to switch engines -->
+    <string name="search_try_youtube">Search with YouTube</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -551,4 +551,10 @@
     <string name="recognize_music_play">Play</string>
     <string name="recognize_music_try_again">Try again</string>
     <string name="recognize_music_close">Close</string>
+
+    <!-- Search engine toggle (search bar) -->
+    <string name="search_provider_zemer">Zemer</string>
+    <string name="search_provider_youtube_short">YT</string>
+    <string name="search_provider_youtube">YouTube Music</string>
+    <string name="cd_search_provider">Search engine</string>
 </resources>

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -155,17 +155,36 @@ class ZemerResultMapperTest {
     }
 
     @Test
-    fun `both playlist chips return the single Zemer playlist category`() {
+    fun `community chip returns community playlists, featured chip returns artist-owned playlists`() {
         val resp = ZemerSearchResponse(
-            categories = ZemerCategories(playlists = listOf(ZemerPlaylist("pl1", "PL", "A", "t"))),
+            categories = ZemerCategories(
+                playlists = listOf(ZemerPlaylist("featured1", "Featured", "A", "t")),
+                community = listOf(ZemerPlaylist("community1", "Community", "B", "t")),
+            ),
         )
 
         val community = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_COMMUNITY_PLAYLIST, false).items
         val featured = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_FEATURED_PLAYLIST, false).items
-        assertEquals(1, community.size)
-        assertEquals(1, featured.size)
+        // The two chips map to two distinct server categories — never the same list.
+        assertEquals(listOf("community1"), community.map { it.id })
+        assertEquals(listOf("featured1"), featured.map { it.id })
         assertTrue(community.single() is PlaylistItem)
-        assertEquals((community.single() as PlaylistItem).id, (featured.single() as PlaylistItem).id)
+        assertTrue(featured.single() is PlaylistItem)
+    }
+
+    @Test
+    fun `summary Playlists section merges artist-owned and community playlists`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                playlists = listOf(ZemerPlaylist("featured1", "Featured", "A", "t")),
+                community = listOf(ZemerPlaylist("community1", "Community", "B", "t")),
+            ),
+        )
+
+        // One combined "Playlists" section (matching YouTube's summary), artist-owned then community.
+        val section = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
+            .summaries.first { it.title == "Playlists" }
+        assertEquals(listOf("featured1", "community1"), section.items.map { it.id })
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -234,6 +234,22 @@ class ZemerResultMapperTest {
     }
 
     @Test
+    fun `summary caps each section to a compact preview`() {
+        // The merged Songs section (songs + videos) would otherwise be a long scroll; the chip still
+        // returns everything.
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(songs = (1..20).map { ZemerTrack("s$it", "Song $it", "A") }),
+        )
+
+        val songsSection = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
+            .summaries.first { it.title == "Songs" }
+        assertEquals(8, songsSection.items.size) // capped
+
+        val songsChip = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_SONG, hideExplicit = false).items
+        assertEquals(20, songsChip.size) // chip is uncapped
+    }
+
+    @Test
     fun `Songs chip returns songs and videos so the summary Songs drill-in keeps the videos`() {
         // The summary folds videos into "Songs"; tapping that header (FILTER_SONG) must return both,
         // and a video-only query must NOT come back empty.

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -87,7 +87,8 @@ class ZemerResultMapperTest {
                 songs = listOf(ZemerTrack("s1", "Song", "A")),
                 albums = listOf(ZemerAlbum(id = "al1", title = "Album", artist = "A")),
                 videos = listOf(ZemerTrack("v1", "Video", "A")),
-                playlists = listOf(ZemerPlaylist("pl1", "Playlist", "A", "t")),
+                playlists = listOf(ZemerPlaylist("featured1", "Featured", "A", "t")),
+                community = listOf(ZemerPlaylist("community1", "Community", "B", "t")),
             ),
         )
 
@@ -97,6 +98,10 @@ class ZemerResultMapperTest {
         // Videos fold into the Songs section (videos are SongItems), exactly like YouTube.
         val songsSection = page.summaries.first { it.title == "Songs" }
         assertEquals(listOf("s1", "v1"), songsSection.items.map { it.id })
+        // The "Playlists" section previews COMMUNITY playlists (its header drills into the Community
+        // chip), so featured/artist-owned playlists are not shown here.
+        val playlistsSection = page.summaries.first { it.title == "Playlists" }
+        assertEquals(listOf("community1"), playlistsSection.items.map { it.id })
     }
 
     @Test
@@ -205,18 +210,65 @@ class ZemerResultMapperTest {
     }
 
     @Test
-    fun `summary Playlists section merges artist-owned and community playlists`() {
-        val resp = ZemerSearchResponse(
+    fun `summary Playlists section previews community only so its header drill-in is consistent`() {
+        // Featured-only response: the "Playlists" section must NOT show featured playlists, because its
+        // header routes to the Community chip — showing them would vanish on tap / yield "No results".
+        val featuredOnly = ZemerSearchResponse(
+            categories = ZemerCategories(playlists = listOf(ZemerPlaylist("featured1", "Featured", "A", "t"))),
+        )
+        assertTrue(
+            ZemerResultMapper.summaryPage(featuredOnly, hideExplicit = false)
+                .summaries.none { it.title == "Playlists" },
+        )
+
+        // With community present, the section shows exactly the community playlists (= the chip's rows).
+        val withCommunity = ZemerSearchResponse(
             categories = ZemerCategories(
                 playlists = listOf(ZemerPlaylist("featured1", "Featured", "A", "t")),
                 community = listOf(ZemerPlaylist("community1", "Community", "B", "t")),
             ),
         )
-
-        // One combined "Playlists" section (matching YouTube's summary), artist-owned then community.
-        val section = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
+        val section = ZemerResultMapper.summaryPage(withCommunity, hideExplicit = false)
             .summaries.first { it.title == "Playlists" }
-        assertEquals(listOf("featured1", "community1"), section.items.map { it.id })
+        assertEquals(listOf("community1"), section.items.map { it.id })
+    }
+
+    @Test
+    fun `Songs chip returns songs and videos so the summary Songs drill-in keeps the videos`() {
+        // The summary folds videos into "Songs"; tapping that header (FILTER_SONG) must return both,
+        // and a video-only query must NOT come back empty.
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                songs = listOf(ZemerTrack("s1", "Song", "A")),
+                videos = listOf(ZemerTrack("v1", "Video", "A")),
+            ),
+        )
+        val songsChip = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_SONG, hideExplicit = false).items
+        assertEquals(listOf("s1", "v1"), songsChip.map { it.id })
+
+        val videoOnly = ZemerSearchResponse(
+            categories = ZemerCategories(videos = listOf(ZemerTrack("v1", "Video", "A"))),
+        )
+        val videoOnlySongsChip = ZemerResultMapper.filtered(videoOnly, SearchFilter.FILTER_SONG, hideExplicit = false).items
+        assertEquals(listOf("v1"), videoOnlySongsChip.map { it.id }) // not empty
+    }
+
+    @Test
+    fun `hideExplicit drops an explicit title from the as-you-type completions, not just the rows`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                songs = listOf(
+                    ZemerTrack("a", "Clean Song", "X", explicit = false),
+                    ZemerTrack("b", "Dirty Song", "Y", explicit = true),
+                ),
+            ),
+        )
+
+        val hidden = ZemerResultMapper.suggestions(resp, hideExplicit = true).queries
+        assertEquals(listOf("Clean Song"), hidden) // explicit title not offered as a completion
+
+        val shown = ZemerResultMapper.suggestions(resp, hideExplicit = false).queries
+        assertEquals(listOf("Clean Song", "Dirty Song"), shown)
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -18,21 +18,13 @@ import org.junit.Test
  */
 class ZemerResultMapperTest {
 
-    private val titles = SectionTitles(
-        songs = "Songs",
-        videos = "Videos",
-        albums = "Albums",
-        artists = "Artists",
-        playlists = "Playlists",
-    )
-
     @Test
     fun `song maps to playable SongItem with derived thumbnail and null endpoint`() {
         val resp = ZemerSearchResponse(
             categories = ZemerCategories(songs = listOf(ZemerTrack("vid123", "Title", "Artist"))),
         )
 
-        val song = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
+        val song = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
             .summaries.single().items.single() as SongItem
 
         assertEquals("vid123", song.id)
@@ -54,12 +46,12 @@ class ZemerResultMapperTest {
             ),
         )
 
-        val kept = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = true)
+        val kept = ZemerResultMapper.summaryPage(resp, hideExplicit = true)
             .summaries.single().items
         assertEquals(1, kept.size)
         assertEquals("a", kept.single().id)
 
-        val all = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
+        val all = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
             .summaries.single().items
         assertEquals(2, all.size)
     }
@@ -73,7 +65,7 @@ class ZemerResultMapperTest {
             ),
         )
 
-        val section = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false).summaries.single()
+        val section = ZemerResultMapper.summaryPage(resp, hideExplicit = false).summaries.single()
         assertEquals("Albums", section.title)
         assertEquals(2, section.items.size)
 
@@ -88,7 +80,7 @@ class ZemerResultMapperTest {
     }
 
     @Test
-    fun `summary omits empty sections and keeps a stable order`() {
+    fun `summary matches YouTube section order and folds videos into Songs`() {
         val resp = ZemerSearchResponse(
             categories = ZemerCategories(
                 artists = listOf(ZemerArtist("UC1", "An Artist", "thumb")),
@@ -99,10 +91,12 @@ class ZemerResultMapperTest {
             ),
         )
 
-        val page = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
-        // No "Videos" section: videos render as SongItem and the shared OnlineSearchResult resolves a
-        // section's filter by item type (SongItem -> Songs), so a Videos section would mis-navigate.
-        assertEquals(listOf("Songs", "Artists", "Albums", "Playlists"), page.summaries.map { it.title })
+        val page = ZemerResultMapper.summaryPage(resp, hideExplicit = false)
+        // Same titles/order as YouTube.searchSummary; no separate Videos section.
+        assertEquals(listOf("Albums", "Songs", "Artists", "Playlists"), page.summaries.map { it.title })
+        // Videos fold into the Songs section (videos are SongItems), exactly like YouTube.
+        val songsSection = page.summaries.first { it.title == "Songs" }
+        assertEquals(listOf("s1", "v1"), songsSection.items.map { it.id })
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -100,7 +100,39 @@ class ZemerResultMapperTest {
         )
 
         val page = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
-        assertEquals(listOf("Songs", "Artists", "Albums", "Videos", "Playlists"), page.summaries.map { it.title })
+        // No "Videos" section: videos render as SongItem and the shared OnlineSearchResult resolves a
+        // section's filter by item type (SongItem -> Songs), so a Videos section would mis-navigate.
+        assertEquals(listOf("Songs", "Artists", "Albums", "Playlists"), page.summaries.map { it.title })
+    }
+
+    @Test
+    fun `suggestions de-dupe ids shared across categories`() {
+        // The same videoId appears as both a song and a video — the id-keyed dropdown must not get a dupe.
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                songs = listOf(ZemerTrack("dup", "Track", "A")),
+                videos = listOf(ZemerTrack("dup", "Track", "A")),
+            ),
+        )
+
+        val items = ZemerResultMapper.suggestions(resp, hideExplicit = false).recommendedItems
+        assertEquals(1, items.size)
+        assertEquals(items.size, items.distinctBy { it.id }.size)
+    }
+
+    @Test
+    fun `rows missing an id are dropped, not crashing the whole response`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                songs = listOf(ZemerTrack("", "No id", "A"), ZemerTrack("ok", "Good", "A")),
+                artists = listOf(ZemerArtist("", "No id"), ZemerArtist("UC1", "Good")),
+            ),
+        )
+
+        val songs = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_SONG, false).items
+        assertEquals(listOf("ok"), songs.map { it.id })
+        val artists = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_ARTIST, false).items
+        assertEquals(listOf("UC1"), artists.map { it.id })
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -173,6 +173,38 @@ class ZemerResultMapperTest {
     }
 
     @Test
+    fun `community playlist surfaces its whitelisted song count`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                community = listOf(ZemerPlaylist("c1", "Mix", "Curator", "t", songCount = 12)),
+            ),
+        )
+
+        val item = ZemerResultMapper
+            .filtered(resp, SearchFilter.FILTER_COMMUNITY_PLAYLIST, hideExplicit = false) { "$it songs" }
+            .items.single() as PlaylistItem
+        assertEquals("12 songs", item.songCountText)
+    }
+
+    @Test
+    fun `playlist with absent or zero count shows no count text`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                community = listOf(
+                    ZemerPlaylist("c1", "No count", "Curator", "t"),               // count absent
+                    ZemerPlaylist("c2", "Zero count", "Curator", "t", songCount = 0),
+                ),
+            ),
+        )
+
+        val items = ZemerResultMapper
+            .filtered(resp, SearchFilter.FILTER_COMMUNITY_PLAYLIST, hideExplicit = false) { "$it songs" }
+            .items.map { it as PlaylistItem }
+        assertNull(items[0].songCountText) // absent → no count
+        assertNull(items[1].songCountText) // zero → no count
+    }
+
+    @Test
     fun `summary Playlists section merges artist-owned and community playlists`() {
         val resp = ZemerSearchResponse(
             categories = ZemerCategories(

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -1,0 +1,201 @@
+package com.jtech.zemer.search
+
+import com.metrolist.innertube.YouTube.SearchFilter
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.innertube.models.SongItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of the Zemer → YTItem adaptation that lets the existing search UI render Zemer
+ * results unchanged. Guards the contracts the screens depend on: derived thumbnails, null endpoints
+ * (playback falls back to the videoId), albums+singles merging, videos-as-SongItem, both playlist
+ * chips, hide-explicit, and the summary section order.
+ */
+class ZemerResultMapperTest {
+
+    private val titles = SectionTitles(
+        songs = "Songs",
+        videos = "Videos",
+        albums = "Albums",
+        artists = "Artists",
+        playlists = "Playlists",
+    )
+
+    @Test
+    fun `song maps to playable SongItem with derived thumbnail and null endpoint`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(songs = listOf(ZemerTrack("vid123", "Title", "Artist"))),
+        )
+
+        val song = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
+            .summaries.single().items.single() as SongItem
+
+        assertEquals("vid123", song.id)
+        assertEquals("Title", song.title)
+        assertEquals("Artist", song.artists.single().name)
+        assertNull(song.artists.single().id)
+        assertNull(song.endpoint)
+        assertEquals("https://i.ytimg.com/vi/vid123/hqdefault.jpg", song.thumbnail)
+    }
+
+    @Test
+    fun `hideExplicit drops only explicit songs`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                songs = listOf(
+                    ZemerTrack("a", "Clean", "X", explicit = false),
+                    ZemerTrack("b", "Dirty", "Y", explicit = true),
+                ),
+            ),
+        )
+
+        val kept = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = true)
+            .summaries.single().items
+        assertEquals(1, kept.size)
+        assertEquals("a", kept.single().id)
+
+        val all = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
+            .summaries.single().items
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `albums and singles merge under one Albums section with playlistId fallback`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                albums = listOf(ZemerAlbum(id = "al1", title = "Album", artist = "A", year = 2020)),
+                singles = listOf(ZemerAlbum(id = "si1", playlistId = "PLsi1", title = "Single", artist = "")),
+            ),
+        )
+
+        val section = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false).summaries.single()
+        assertEquals("Albums", section.title)
+        assertEquals(2, section.items.size)
+
+        val album = section.items[0] as AlbumItem
+        assertEquals("al1", album.browseId)
+        assertEquals("al1", album.playlistId) // null playlistId falls back to the browseId
+        assertEquals(2020, album.year)
+
+        val single = section.items[1] as AlbumItem
+        assertEquals("PLsi1", single.playlistId)
+        assertNull(single.artists) // blank artist => no artist list
+    }
+
+    @Test
+    fun `summary omits empty sections and keeps a stable order`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                artists = listOf(ZemerArtist("UC1", "An Artist", "thumb")),
+                songs = listOf(ZemerTrack("s1", "Song", "A")),
+                albums = listOf(ZemerAlbum(id = "al1", title = "Album", artist = "A")),
+                videos = listOf(ZemerTrack("v1", "Video", "A")),
+                playlists = listOf(ZemerPlaylist("pl1", "Playlist", "A", "t")),
+            ),
+        )
+
+        val page = ZemerResultMapper.summaryPage(resp, titles, hideExplicit = false)
+        assertEquals(listOf("Songs", "Artists", "Albums", "Videos", "Playlists"), page.summaries.map { it.title })
+    }
+
+    @Test
+    fun `filtered FILTER_ALBUM includes singles and has no continuation`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                albums = listOf(ZemerAlbum(id = "al1", title = "Album", artist = "A")),
+                singles = listOf(ZemerAlbum(id = "si1", title = "Single", artist = "A")),
+            ),
+        )
+
+        val result = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_ALBUM, hideExplicit = false)
+        assertEquals(2, result.items.size)
+        assertNull(result.continuation)
+    }
+
+    @Test
+    fun `filtered FILTER_VIDEO maps videos to SongItem`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(videos = listOf(ZemerTrack("v1", "Live", "A"))),
+        )
+
+        val item = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_VIDEO, hideExplicit = false).items.single()
+        assertTrue(item is SongItem)
+        assertEquals("v1", item.id)
+    }
+
+    @Test
+    fun `both playlist chips return the single Zemer playlist category`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(playlists = listOf(ZemerPlaylist("pl1", "PL", "A", "t"))),
+        )
+
+        val community = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_COMMUNITY_PLAYLIST, false).items
+        val featured = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_FEATURED_PLAYLIST, false).items
+        assertEquals(1, community.size)
+        assertEquals(1, featured.size)
+        assertTrue(community.single() is PlaylistItem)
+        assertEquals((community.single() as PlaylistItem).id, (featured.single() as PlaylistItem).id)
+    }
+
+    @Test
+    fun `artist maps to ArtistItem preserving id and thumbnail`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(artists = listOf(ZemerArtist("UC1", "Name", "th"))),
+        )
+
+        val artist = ZemerResultMapper.filtered(resp, SearchFilter.FILTER_ARTIST, false).items.single() as ArtistItem
+        assertEquals("UC1", artist.id)
+        assertEquals("Name", artist.title)
+        assertEquals("th", artist.thumbnail)
+    }
+
+    @Test
+    fun `suggestions give text completions then all-category result rows`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                artists = listOf(ZemerArtist("UC1", "Name")),
+                songs = listOf(ZemerTrack("s1", "Song", "A")),
+                albums = listOf(ZemerAlbum(id = "al1", title = "Album", artist = "A")),
+                videos = listOf(ZemerTrack("v1", "Video", "A")),
+                playlists = listOf(ZemerPlaylist("pl1", "PL", "A", "t")),
+            ),
+        )
+
+        val suggestions = ZemerResultMapper.suggestions(resp, hideExplicit = false)
+
+        // Part 1: text completions — artist names first, then song titles.
+        assertEquals(listOf("Name", "Song"), suggestions.queries)
+
+        // Part 2: result rows in the summary order: songs, artists, albums, videos, playlists.
+        val types = suggestions.recommendedItems.map { it::class }
+        assertEquals(
+            listOf(
+                SongItem::class,   // song
+                ArtistItem::class, // artist
+                AlbumItem::class,  // album
+                SongItem::class,   // video maps to SongItem
+                PlaylistItem::class, // playlist
+            ),
+            types,
+        )
+    }
+
+    @Test
+    fun `suggestion completions are deduped case-insensitively and capped`() {
+        val resp = ZemerSearchResponse(
+            categories = ZemerCategories(
+                artists = (1..6).map { ZemerArtist("UC$it", "Artist $it") },
+                songs = listOf(ZemerTrack("s1", "ARTIST 1", "x")), // dupe of "Artist 1" by case
+            ),
+        )
+
+        val queries = ZemerResultMapper.suggestions(resp, hideExplicit = false).queries
+        assertEquals(5, queries.size) // capped at MAX_QUERY_SUGGESTIONS
+        assertEquals(queries.size, queries.distinctBy { it.lowercase() }.size) // no case-dupes
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt
@@ -1,0 +1,40 @@
+package com.jtech.zemer.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the shared [zemerResponseJson] config the client decodes every response with — specifically
+ * `coerceInputValues`. kotlinx applies a field's default only for an ABSENT key, so without coercion an
+ * explicit JSON `null` on a non-null defaulted field throws and fails the WHOLE response (the strict-
+ * deserialization "No results" trap). These prove a sparse/odd payload degrades to defaults instead.
+ */
+class ZemerSearchJsonTest {
+
+    @Test
+    fun `explicit null on a non-null defaulted field decodes to the default, not an exception`() {
+        val payload =
+            """{"q":"x","count":0,"categories":{"songs":null,"community":null,""" +
+                """"playlists":[{"id":"p1","title":"PL","artist":"A","thumbnail":null,"whitelisted":null}]}}"""
+
+        val resp = zemerResponseJson.decodeFromString(ZemerSearchResponse.serializer(), payload)
+
+        assertTrue(resp.categories.songs.isEmpty())       // null list → default empty, no throw
+        assertTrue(resp.categories.community.isEmpty())
+        assertEquals(listOf("p1"), resp.categories.playlists.map { it.id })
+        assertEquals(null, resp.categories.playlists.single().songCount) // nullable stays null
+    }
+
+    @Test
+    fun `explicit null categories object decodes to the default empty categories`() {
+        val resp = zemerResponseJson.decodeFromString(
+            ZemerSearchResponse.serializer(),
+            """{"q":"x","categories":null}""",
+        )
+
+        assertTrue(resp.categories.songs.isEmpty())
+        assertTrue(resp.categories.playlists.isEmpty())
+        assertTrue(resp.categories.community.isEmpty())
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -119,8 +119,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 201 | `com.jtech.zemer.search` | no | 12 | 25 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 73 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 208 | `com.jtech.zemer.search` | no | 12 | 27 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 81 | `com.jtech.zemer.search` | no | 13 | 10 | io.ktor, java.io, javax.inject, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 | `com.jtech.zemer.search` | no | 2 | 34 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 82 | `com.jtech.zemer.search` | no | 11 | 21 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -131,7 +131,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/sync/models/UserPreferencesEntity.kt` | 92 | `com.jtech.zemer.sync.models` | no | 3 | 22 | com.google, java.util |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AccountSettingsDialog.kt` | 66 | `com.jtech.zemer.ui.component` | yes | 20 | 1 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AnonymousAuthEmailDialog.kt` | 123 | `com.jtech.zemer.ui.component` | yes | 25 | 3 | androidx.compose, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt` | 111 | `com.jtech.zemer.ui.component` | yes | 26 | 1 | androidx.annotation, androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt` | 121 | `com.jtech.zemer.ui.component` | yes | 27 | 1 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AutoResizeText.kt` | 97 | `com.jtech.zemer.ui.component` | yes | 20 | 9 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BigSeekBar.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 17 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheet.kt` | 348 | `com.jtech.zemer.ui.component` | yes | 47 | 45 | androidx.activity, androidx.compose, kotlin.math, kotlinx.coroutines |
@@ -242,8 +242,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 | `com.jtech.zemer.ui.screens.playlist` | yes | 96 | 27 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 | `com.jtech.zemer.ui.screens.recognition` | yes | 51 | 6 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 | `com.jtech.zemer.ui.screens.recognition` | yes | 65 | 19 | android.content, android.os, androidx.activity, androidx.compose, androidx.core, androidx.hilt, coil3.compose, dagger.hilt |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 441 | `com.jtech.zemer.ui.screens.search` | yes | 76 | 28 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt` | 458 | `com.jtech.zemer.ui.screens.search` | yes | 83 | 19 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 463 | `com.jtech.zemer.ui.screens.search` | yes | 79 | 32 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt` | 461 | `com.jtech.zemer.ui.screens.search` | yes | 83 | 19 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt` | 191 | `com.jtech.zemer.ui.screens.settings` | yes | 47 | 4 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt` | 523 | `com.jtech.zemer.ui.screens.settings` | yes | 76 | 46 | android.widget, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, io.ktor, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt` | 269 | `com.jtech.zemer.ui.screens.settings` | yes | 50 | 29 | androidx.compose, androidx.lifecycle, androidx.navigation, kotlinx.coroutines, sh.calvin |
@@ -345,8 +345,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/NewReleaseViewModel.kt` | 110 | `com.jtech.zemer.viewmodels` | no | 20 | 19 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 | `com.jtech.zemer.viewmodels` | no | 19 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 | `com.jtech.zemer.viewmodels` | no | 25 | 29 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 212 | `com.jtech.zemer.viewmodels` | no | 34 | 24 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 322 | `com.jtech.zemer.viewmodels` | no | 41 | 39 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 181 | `com.jtech.zemer.viewmodels` | no | 34 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 326 | `com.jtech.zemer.viewmodels` | no | 41 | 39 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 12 | 6 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 | `com.jtech.zemer.viewmodels` | no | 18 | 23 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 330 | `com.jtech.zemer.search` | no | 9 | 47 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 346 | `com.jtech.zemer.search` | no | 9 | 50 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 40 | `com.jtech.zemer.search` | no | 3 | 5 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (371)
+## `app` Kotlin files (372)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -119,11 +119,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 190 | `com.jtech.zemer.search` | no | 12 | 24 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 201 | `com.jtech.zemer.search` | no | 12 | 25 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 73 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 | `com.jtech.zemer.search` | no | 2 | 34 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 75 | `com.jtech.zemer.search` | no | 11 | 20 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 82 | `com.jtech.zemer.search` | no | 11 | 21 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -345,8 +345,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/NewReleaseViewModel.kt` | 110 | `com.jtech.zemer.viewmodels` | no | 20 | 19 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 | `com.jtech.zemer.viewmodels` | no | 19 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 | `com.jtech.zemer.viewmodels` | no | 25 | 29 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 182 | `com.jtech.zemer.viewmodels` | no | 35 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 319 | `com.jtech.zemer.viewmodels` | no | 41 | 39 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 212 | `com.jtech.zemer.viewmodels` | no | 34 | 24 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 322 | `com.jtech.zemer.viewmodels` | no | 41 | 39 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 12 | 6 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 | `com.jtech.zemer.viewmodels` | no | 18 | 23 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 278 | `com.jtech.zemer.search` | no | 9 | 38 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 330 | `com.jtech.zemer.search` | no | 9 | 47 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 40 | `com.jtech.zemer.search` | no | 3 | 5 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -163,7 +163,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 | `com.jtech.zemer.ui.component` | yes | 47 | 12 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 | `com.jtech.zemer.ui.component` | yes | 79 | 32 | androidx.activity, androidx.compose, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 124 | `com.jtech.zemer.ui.component` | yes | 29 | 7 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 114 | `com.jtech.zemer.ui.component` | yes | 28 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (363)
+## `app` Kotlin files (371)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -11,7 +11,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 441 | `com.jtech.zemer` | no | 63 | 44 | android.app, android.content, android.os, android.util, android.webkit, android.widget, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2146 | `com.jtech.zemer` | no | 262 | 217 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 | `com.jtech.zemer` | no | 265 | 219 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 | `com.jtech.zemer.auth` | no | 0 | 16 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 145 | `com.jtech.zemer.auth` | no | 13 | 26 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -20,7 +20,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 | `com.jtech.zemer.constants` | no | 2 | 14 | android.os, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 572 | `com.jtech.zemer.constants` | no | 9 | 178 | androidx.annotation, androidx.datastore, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 575 | `com.jtech.zemer.constants` | no | 9 | 179 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 | `com.jtech.zemer.constants` | no | 3 | 4 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1705 | `com.jtech.zemer.db` | no | 59 | 230 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
@@ -118,6 +118,12 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/Shazam.kt` | 234 | `com.jtech.zemer.recognition.shazam` | no | 22 | 47 | io.ktor, java.util, kotlin.random, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 162 | `com.jtech.zemer.search` | no | 12 | 22 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 56 | `com.jtech.zemer.search` | no | 9 | 8 | io.ktor, javax.inject, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 60 | `com.jtech.zemer.search` | no | 1 | 32 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 51 | `com.jtech.zemer.search` | no | 9 | 11 | android.content, dagger.hilt, javax.inject |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -157,6 +163,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 | `com.jtech.zemer.ui.component` | yes | 47 | 12 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 | `com.jtech.zemer.ui.component` | yes | 79 | 32 | androidx.activity, androidx.compose, kotlin.math |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 124 | `com.jtech.zemer.ui.component` | yes | 29 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
@@ -338,8 +345,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/NewReleaseViewModel.kt` | 110 | `com.jtech.zemer.viewmodels` | no | 20 | 19 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 | `com.jtech.zemer.viewmodels` | no | 19 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 | `com.jtech.zemer.viewmodels` | no | 25 | 29 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 129 | `com.jtech.zemer.viewmodels` | no | 23 | 18 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 286 | `com.jtech.zemer.viewmodels` | no | 33 | 36 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 165 | `com.jtech.zemer.viewmodels` | no | 29 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 324 | `com.jtech.zemer.viewmodels` | no | 39 | 40 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 12 | 6 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 | `com.jtech.zemer.viewmodels` | no | 18 | 23 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -360,6 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 201 | `com.jtech.zemer.search` | no | 9 | 27 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -119,11 +119,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 178 | `com.jtech.zemer.search` | no | 12 | 24 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 190 | `com.jtech.zemer.search` | no | 12 | 24 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 67 | `com.jtech.zemer.search` | no | 1 | 33 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 | `com.jtech.zemer.search` | no | 2 | 34 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 67 | `com.jtech.zemer.search` | no | 8 | 18 | javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 75 | `com.jtech.zemer.search` | no | 11 | 20 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 246 | `com.jtech.zemer.search` | no | 9 | 34 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 278 | `com.jtech.zemer.search` | no | 9 | 38 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -119,11 +119,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 162 | `com.jtech.zemer.search` | no | 12 | 22 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 56 | `com.jtech.zemer.search` | no | 9 | 8 | io.ktor, javax.inject, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 60 | `com.jtech.zemer.search` | no | 1 | 32 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 181 | `com.jtech.zemer.search` | no | 12 | 24 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 | `com.jtech.zemer.search` | no | 1 | 32 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 51 | `com.jtech.zemer.search` | no | 9 | 11 | android.content, dagger.hilt, javax.inject |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 69 | `com.jtech.zemer.search` | no | 11 | 18 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -163,7 +163,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 | `com.jtech.zemer.ui.component` | yes | 47 | 12 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 | `com.jtech.zemer.ui.component` | yes | 79 | 32 | androidx.activity, androidx.compose, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 114 | `com.jtech.zemer.ui.component` | yes | 28 | 7 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 120 | `com.jtech.zemer.ui.component` | yes | 28 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
@@ -345,8 +345,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/NewReleaseViewModel.kt` | 110 | `com.jtech.zemer.viewmodels` | no | 20 | 19 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 | `com.jtech.zemer.viewmodels` | no | 19 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 | `com.jtech.zemer.viewmodels` | no | 25 | 29 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 165 | `com.jtech.zemer.viewmodels` | no | 29 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 324 | `com.jtech.zemer.viewmodels` | no | 39 | 40 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 182 | `com.jtech.zemer.viewmodels` | no | 35 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 319 | `com.jtech.zemer.viewmodels` | no | 41 | 39 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 12 | 6 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 | `com.jtech.zemer.viewmodels` | no | 18 | 23 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 201 | `com.jtech.zemer.search` | no | 9 | 27 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 233 | `com.jtech.zemer.search` | no | 9 | 32 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -119,11 +119,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 181 | `com.jtech.zemer.search` | no | 12 | 24 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 171 | `com.jtech.zemer.search` | no | 12 | 23 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 | `com.jtech.zemer.search` | no | 1 | 32 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 69 | `com.jtech.zemer.search` | no | 11 | 18 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 57 | `com.jtech.zemer.search` | no | 8 | 16 | javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 233 | `com.jtech.zemer.search` | no | 9 | 32 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 227 | `com.jtech.zemer.search` | no | 9 | 32 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -119,11 +119,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 | `com.jtech.zemer.search` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 171 | `com.jtech.zemer.search` | no | 12 | 23 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 178 | `com.jtech.zemer.search` | no | 12 | 24 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 | `com.jtech.zemer.search` | no | 12 | 8 | io.ktor, java.io, javax.inject, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 | `com.jtech.zemer.search` | no | 1 | 32 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 67 | `com.jtech.zemer.search` | no | 1 | 33 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 57 | `com.jtech.zemer.search` | no | 8 | 16 | javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 67 | `com.jtech.zemer.search` | no | 8 | 18 | javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 | `com.jtech.zemer.sync` | no | 18 | 61 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 | `com.jtech.zemer.sync` | no | 38 | 109 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 227 | `com.jtech.zemer.search` | no | 9 | 32 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 246 | `com.jtech.zemer.search` | no | 9 | 34 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -249,7 +249,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 560 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 562 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -249,7 +249,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 554 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,11 +275,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 171 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 178 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 67 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 57 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 67 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -723,7 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 227 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 246 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -319,7 +319,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 124 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 114 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `865`
+- Files counted: `873`
 - By extension:
-  - `.kt`: `463`
+  - `.kt`: `471`
   - `.xml`: `184`
   - `.mjs`: `72`
   - `.md`: `51`
@@ -167,7 +167,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 441 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2146 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 145 lines | `.kt` |
@@ -176,7 +176,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 572 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 575 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1705 lines | `.kt` |
@@ -274,6 +274,12 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/Shazam.kt` | 234 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 162 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 56 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 60 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 51 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -313,6 +319,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 124 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
@@ -495,8 +502,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt.backup` | 215 lines | `.backup` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 129 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 286 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 165 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 324 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
@@ -694,7 +701,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 554 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
@@ -716,6 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 201 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |
@@ -758,7 +766,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 486 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 494 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 365 lines | `.md` |
 | `docs/reference/resource-index.md` | 288 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -769,7 +777,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 974 lines | `.md` |
+| `docs/repository-map.md` | 982 lines | `.md` |
 | `docs/ui/README.md` | 329 lines | `.md` |
 | `docs/ui/standards.md` | 290 lines | `.md` |
 | `docs/whitelist/README.md` | 181 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `873`
+- Files counted: `874`
 - By extension:
-  - `.kt`: `471`
+  - `.kt`: `472`
   - `.xml`: `184`
   - `.mjs`: `72`
   - `.md`: `51`
@@ -275,11 +275,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 190 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 201 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 73 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 75 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -502,8 +502,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt.backup` | 215 lines | `.backup` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 182 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 319 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 212 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 322 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
@@ -723,7 +723,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 278 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 330 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 40 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |
@@ -766,7 +767,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 494 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 495 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 365 lines | `.md` |
 | `docs/reference/resource-index.md` | 288 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -777,7 +778,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 982 lines | `.md` |
+| `docs/repository-map.md` | 983 lines | `.md` |
 | `docs/ui/README.md` | 329 lines | `.md` |
 | `docs/ui/standards.md` | 290 lines | `.md` |
 | `docs/whitelist/README.md` | 181 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,11 +275,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 56 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 60 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 181 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 51 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 69 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -319,7 +319,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Preference.kt` | 368 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/RecognizeMusicFab.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 114 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchProviderToggle.kt` | 120 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
@@ -502,8 +502,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt.backup` | 215 lines | `.backup` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 165 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 324 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 182 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 319 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
@@ -723,7 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 201 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 233 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,11 +275,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 181 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 171 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 63 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 69 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 57 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -723,7 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 233 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 227 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,8 +275,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 201 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 73 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 208 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 81 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 82 lines | `.kt` |
@@ -287,7 +287,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/sync/models/UserPreferencesEntity.kt` | 92 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AccountSettingsDialog.kt` | 66 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AnonymousAuthEmailDialog.kt` | 123 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt` | 111 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/AppStateViews.kt` | 121 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/AutoResizeText.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BigSeekBar.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheet.kt` | 348 lines | `.kt` |
@@ -398,8 +398,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 441 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt` | 458 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 463 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt` | 461 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt` | 191 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt` | 523 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt` | 269 lines | `.kt` |
@@ -502,8 +502,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt.backup` | 215 lines | `.backup` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 167 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 212 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 322 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 181 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 326 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
@@ -701,7 +701,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 560 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 562 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
@@ -723,7 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 330 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 346 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 40 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,11 +275,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 15 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 178 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 190 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 64 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 67 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 67 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 75 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 446 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 760 lines | `.kt` |
@@ -723,7 +723,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 246 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 278 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |


### PR DESCRIPTION
Adds a Zemer search engine alongside YouTube search, selectable via a toggle (Zemer is the default).

- **Zemer mode** queries the Zemer search server and renders results matching the existing YouTube summary layout.
- Surfaces community playlists in a **"Zemer Community"** chip, with a song count on each playlist result.
- As-you-type suggestions in Zemer mode are server-only.

Rebased on the latest `main`.
