### PR TITLE
Faster whitelisted-artist thumbnails

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -54,6 +54,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Credentials
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -383,6 +384,10 @@ class App : Application(), SingletonImageLoader.Factory {
     override fun newImageLoader(context: PlatformContext): ImageLoader {
         val cacheSize = dataStore.get(MaxImageCacheSizeKey, 256).coerceIn(0, 512)
         val okHttpClient = OkHttpClient.Builder()
+            // Coil shares one host for many thumbnails (yt3.googleusercontent.com etc.). OkHttp's default
+            // is 5 concurrent per host, so a screenful of same-host avatars loads in staggered waves.
+            // Raise it so a full grid of avatars fetches in one wave.
+            .dispatcher(Dispatcher().apply { maxRequestsPerHost = 12 })
             .dns(ResilientDns())
             .proxy(YouTube.proxy)
             .proxyAuthenticator { _, response ->

--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -1439,6 +1439,10 @@ interface DatabaseDao {
     @Update
     fun update(artist: ArtistEntity)
 
+    /** Set only the artist image; used to batch-populate thumbnails from the whitelist sync in one transaction. */
+    @Query("UPDATE artist SET thumbnailUrl = :thumbnailUrl WHERE id = :artistId")
+    fun updateArtistThumbnailUrl(artistId: String, thumbnailUrl: String)
+
     @Update
     fun update(album: AlbumEntity)
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
@@ -2,6 +2,7 @@ package com.jtech.zemer.db.entities
 
 import androidx.compose.runtime.Immutable
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import java.time.LocalDateTime
 
@@ -18,4 +19,9 @@ data class ArtistWhitelistEntity(
     val isGenZ: Boolean = false,
     val isKids: Boolean = false,
     val isKidZone: Boolean = false
-)
+) {
+    // Transient (NOT a column — no migration): the artist's channel image carried in from the whitelist
+    // sync, used to populate Artist.thumbnailUrl. Room ignores it; equals/hashCode/copy don't include it.
+    @Ignore
+    var thumbnailUrl: String? = null
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
@@ -30,6 +30,8 @@ import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.PlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
+import com.jtech.zemer.ui.utils.ARTIST_AVATAR_PX
+import com.jtech.zemer.ui.utils.resize
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.WatchEndpoint
 import kotlinx.coroutines.CoroutineScope
@@ -87,9 +89,9 @@ fun WhitelistedArtistListItem(
         }
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
-                .data(artist.artist.thumbnailUrl)
+                .data(artist.artist.thumbnailUrl?.resize(ARTIST_AVATAR_PX, ARTIST_AVATAR_PX))
                 .scale(Scale.FILL) // fill the target bounds to avoid narrow slices
-                .size(ListThumbnailSize.value.toInt())
+                .size(ARTIST_AVATAR_PX)
                 .memoryCachePolicy(coil3.request.CachePolicy.ENABLED)
                 .diskCachePolicy(coil3.request.CachePolicy.ENABLED)
                 .networkCachePolicy(coil3.request.CachePolicy.ENABLED)
@@ -102,6 +104,8 @@ fun WhitelistedArtistListItem(
             alignment = Alignment.Center,
             placeholder = painterResource(R.drawable.artist),
             error = painterResource(R.drawable.artist),
+            // Fallback: a synced URL that rotated/404s re-resolves on-device (rare, bounded in the VM).
+            onError = { onRequestThumb() },
         )
     },
     trailingContent = {
@@ -179,13 +183,17 @@ fun WhitelistedArtistGridItem(
         }
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
-                .data(artist.artist.thumbnailUrl)
+                .data(artist.artist.thumbnailUrl?.resize(ARTIST_AVATAR_PX, ARTIST_AVATAR_PX))
+                .size(ARTIST_AVATAR_PX)
                 .memoryCachePolicy(coil3.request.CachePolicy.ENABLED)
                 .diskCachePolicy(coil3.request.CachePolicy.ENABLED)
                 .networkCachePolicy(coil3.request.CachePolicy.ENABLED)
                 .build(),
             contentDescription = null,
             contentScale = ContentScale.Crop,
+            error = painterResource(R.drawable.artist),
+            // Fallback: a synced URL that rotated/404s re-resolves on-device (rare, bounded in the VM).
+            onError = { onRequestThumb() },
             modifier = Modifier
                 .fillMaxSize()
                 .clip(CircleShape)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt
@@ -2,6 +2,13 @@
 
 package com.jtech.zemer.ui.utils
 
+/**
+ * Pixel size requested for whitelisted-artist avatars (list + grid + the sync prewarm all use this, so
+ * the prewarmed image is a cache hit whichever view opens). The source yt3 URLs are ~2880px / ~290 KB;
+ * a 256px crop is a few tens of KB and crisp in a small circular avatar.
+ */
+const val ARTIST_AVATAR_PX = 256
+
 fun String.resize(
     width: Int? = null,
     height: Int? = null,

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -618,9 +618,18 @@ class SyncUtils @Inject constructor(
                     val existingArtistIds = getAllArtistIdsSync().toSet()
                     val missingArtists = whitelistEntries
                         .filter { it.artistId !in existingArtistIds }
-                        .map { ArtistEntity(id = it.artistId, name = it.artistName) }
+                        .map { ArtistEntity(id = it.artistId, name = it.artistName, thumbnailUrl = it.thumbnailUrl) }
                     if (missingArtists.isNotEmpty()) {
                         insertArtists(missingArtists)
+                    }
+                    // Populate the per-artist thumbnail (carried in the synced whitelist) onto EXISTING artist
+                    // rows too. Batched inside this transaction, so it's a single flow re-emit — not the old
+                    // write-per-thumbnail recompose storm. A null/blank thumbnail never wipes an existing one.
+                    whitelistEntries.forEach { entry ->
+                        val thumb = entry.thumbnailUrl
+                        if (!thumb.isNullOrBlank() && entry.artistId in existingArtistIds) {
+                            updateArtistThumbnailUrl(entry.artistId, thumb)
+                        }
                     }
                 }
                 WhitelistCache.updateAll(whitelistEntries)

--- a/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt
@@ -58,7 +58,7 @@ object WhitelistFetcher {
                                 isGenZ = doc.isGenZ ?: false,
                                 isKids = doc.isKids ?: false,
                                 isKidZone = doc.isKidZone ?: false,
-                            )
+                            ).also { it.thumbnailUrl = doc.thumbnail?.takeIf { t -> t.isNotBlank() } }
                         )
                     }
                     lastFetchTime = System.currentTimeMillis()
@@ -84,6 +84,7 @@ object WhitelistFetcher {
                         val isGenZ = doc.getBoolean("isGenZ") ?: false
                         val isKids = doc.getBoolean("isKids") ?: false
                         val isKidZone = doc.getBoolean("isKidZone") ?: false
+                        val thumbnailUrl = doc.getString("thumbnail")?.takeIf { it.isNotBlank() }
 
                         whitelistEntities.add(
                             ArtistWhitelistEntity(
@@ -97,7 +98,7 @@ object WhitelistFetcher {
                                 isGenZ = isGenZ,
                                 isKids = isKids,
                                 isKidZone = isKidZone
-                            )
+                            ).also { it.thumbnailUrl = thumbnailUrl }
                         )
                         processed++
                         onProgress(processed, total)

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
@@ -164,6 +164,8 @@ data class ContentWhitelistDoc(
     val isFamous: Boolean? = null,
     val isDJ: Boolean? = null,
     val isGroup: Boolean? = null,
+    // Per-artist channel image (yt3/lh3 URL), resolved once server-side so devices don't each fetch it.
+    val thumbnail: String? = null,
 )
 
 /**

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -59,23 +61,31 @@ constructor(
 
     private val thumbRequests = mutableSetOf<String>()
 
+    // Fallback resolver, used ONLY when a synced thumbnail is missing (the ~3 without one) or its URL
+    // fails to load (rotated/404). Thumbnails normally arrive with the whitelist sync, so this fires
+    // rarely — bound it anyway so a bad server batch can't storm InnerTube like the old backfill did.
+    private val thumbSemaphore = Semaphore(4)
+
     fun requestThumb(artistId: String) {
         synchronized(thumbRequests) {
             if (!thumbRequests.add(artistId)) return
         }
         viewModelScope.launch(Dispatchers.IO) {
-            runCatching {
-                val pageResult = com.metrolist.innertube.YouTube.artist(artistId)
-                pageResult.onSuccess { artistPage ->
-                    val thumb = artistPage.artist.thumbnail
-                    if (!thumb.isNullOrBlank()) {
-                        database.getArtistById(artistId)?.let { existing ->
-                            database.update(existing.copy(thumbnailUrl = thumb))
+            thumbSemaphore.withPermit {
+                runCatching {
+                    val pageResult = com.metrolist.innertube.YouTube.artist(artistId)
+                    pageResult.onSuccess { artistPage ->
+                        val thumb = artistPage.artist.thumbnail
+                        if (!thumb.isNullOrBlank()) {
+                            database.getArtistById(artistId)?.let { existing ->
+                                database.update(existing.copy(thumbnailUrl = thumb))
+                            }
                         }
                     }
                 }
-            }.onFailure {
-                thumbRequests.remove(artistId)
+                // Intentionally keep artistId in thumbRequests even on failure: re-requesting on every
+                // recomposition is exactly the storm this replaces. A persistent failure just shows the
+                // default avatar for this session; the set clears on next launch.
             }
         }
     }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt
@@ -51,6 +51,21 @@ class ZemerContentClientTest {
     }
 
     @Test
+    fun `whitelist doc reads the thumbnail when present, null when absent`() {
+        val withThumb = json.decodeFromString(
+            ContentWhitelistDoc.serializer(),
+            """{"id":"UC1","name":"A","thumbnail":"https://yt3.googleusercontent.com/abc"}""",
+        )
+        assertEquals("https://yt3.googleusercontent.com/abc", withThumb.thumbnail)
+
+        val noThumb = json.decodeFromString(
+            ContentWhitelistDoc.serializer(),
+            """{"id":"UC2","name":"B"}""",
+        )
+        assertNull(noThumb.thumbnail)        // the ~3 artists without a server thumb -> null -> default avatar
+    }
+
+    @Test
     fun `whitelist doc tolerates the artistId or artistName fallback fields`() {
         val doc = json.decodeFromString(
             ContentWhitelistDoc.serializer(),

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -10,7 +10,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 451 | `com.jtech.zemer` | no | 64 | 45 | android.app, android.content, android.os, android.util, android.webkit, android.widget, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 456 | `com.jtech.zemer` | no | 65 | 45 | android.app, android.content, android.os, android.util, android.webkit, android.widget, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 | `com.jtech.zemer` | no | 265 | 219 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 | `com.jtech.zemer.auth` | no | 0 | 16 |  |
@@ -23,7 +23,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 578 | `com.jtech.zemer.constants` | no | 9 | 180 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 | `com.jtech.zemer.constants` | no | 3 | 4 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1705 | `com.jtech.zemer.db` | no | 59 | 230 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1709 | `com.jtech.zemer.db` | no | 59 | 231 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 594 | `com.jtech.zemer.db` | no | 42 | 78 | android.annotation, android.content, android.database, androidx.core, androidx.room, androidx.sqlite, java.time, java.util, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 | `com.jtech.zemer.db.entities` | no | 4 | 8 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumArtistMap.kt` | 29 | `com.jtech.zemer.db.entities` | no | 3 | 4 | androidx.room |
@@ -31,7 +31,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 | `com.jtech.zemer.db.entities` | no | 4 | 4 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 7 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 55 | `com.jtech.zemer.db.entities` | no | 11 | 13 | androidx.compose, androidx.room, java.time, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 21 | `com.jtech.zemer.db.entities` | no | 4 | 11 | androidx.compose, androidx.room, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 27 | `com.jtech.zemer.db.entities` | no | 5 | 12 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 | `com.jtech.zemer.db.entities` | no | 7 | 5 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 | `com.jtech.zemer.db.entities` | no | 3 | 3 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 11 | androidx.room |
@@ -148,7 +148,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 | `com.jtech.zemer.ui.component` | yes | 36 | 6 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1571 | `com.jtech.zemer.ui.component` | yes | 109 | 87 | android.annotation, android.widget, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 410 | `com.jtech.zemer.ui.component` | yes | 33 | 8 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 418 | `com.jtech.zemer.ui.component` | yes | 35 | 8 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 970 | `com.jtech.zemer.ui.component` | yes | 117 | 112 | android.annotation, android.content, android.os, android.widget, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 139 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
@@ -275,7 +275,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShapeUtils.kt` | 8 | `com.jtech.zemer.ui.utils` | no | 3 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt` | 194 | `com.jtech.zemer.ui.utils` | yes | 52 | 17 | android.content, android.text, android.widget, androidx.annotation, androidx.compose, com.zemer |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/StringUtils.kt` | 34 | `com.jtech.zemer.ui.utils` | no | 2 | 5 | java.text, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 27 | `com.jtech.zemer.ui.utils` | no | 0 | 5 |  |
+| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 34 | `com.jtech.zemer.ui.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/AccessibilityUtils.kt` | 91 | `com.jtech.zemer.utils` | yes | 19 | 18 | android.content, android.database, android.net, android.os, android.provider, android.text, androidx.compose, androidx.lifecycle |
 | `app/src/main/kotlin/com/jtech/zemer/utils/BlockedIdsCache.kt` | 74 | `com.jtech.zemer.utils` | no | 0 | 12 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonInputCapture.kt` | 40 | `com.jtech.zemer.utils` | no | 5 | 10 | android.view, java.util, kotlinx.coroutines |
@@ -300,17 +300,17 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/NotificationUtils.kt` | 35 | `com.jtech.zemer.utils` | no | 6 | 2 | android.Manifest, android.content, android.os, androidx.core |
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 | `com.jtech.zemer.utils` | no | 10 | 19 | android.Manifest, android.app, android.content, android.os, androidx.activity, androidx.core, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 | `com.jtech.zemer.utils` | no | 2 | 8 | java.math, java.security |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 779 | `com.jtech.zemer.utils` | no | 35 | 105 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 788 | `com.jtech.zemer.utils` | no | 35 | 106 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 155 | `com.jtech.zemer.utils` | no | 18 | 53 | android.content, android.net, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 | `com.jtech.zemer.utils` | no | 2 | 12 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoLinkBuilder.kt` | 10 | `com.jtech.zemer.utils` | no | 0 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt` | 40 | `com.jtech.zemer.utils` | no | 2 | 10 | java.util |
-| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 146 | `com.jtech.zemer.utils` | no | 6 | 31 | com.google, java.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 | `com.jtech.zemer.utils` | no | 6 | 32 | com.google, java.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 | `com.jtech.zemer.utils` | no | 10 | 42 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 629 | `com.jtech.zemer.utils` | no | 39 | 75 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 183 | `com.jtech.zemer.utils` | no | 21 | 42 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 185 | `com.jtech.zemer.utils` | no | 21 | 43 | io.ktor, java.io, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerLinkBuilder.kt` | 16 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 | `com.jtech.zemer.utils.sabr` | no | 17 | 37 | android.content, android.net, android.webkit, com.zemer, java.io, kotlin.coroutines, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 | `com.jtech.zemer.utils.sabr` | no | 0 | 1 |  |
@@ -355,7 +355,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StatsViewModel.kt` | 175 | `com.jtech.zemer.viewmodels` | no | 20 | 9 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 | `com.jtech.zemer.viewmodels` | no | 14 | 4 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 82 | `com.jtech.zemer.viewmodels` | no | 16 | 15 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 92 | `com.jtech.zemer.viewmodels` | no | 18 | 16 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/YouTubeBrowseViewModel.kt` | 52 | `com.jtech.zemer.viewmodels` | no | 17 | 7 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
@@ -383,7 +383,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 | `com.jtech.zemer.utils` | no | 5 | 7 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 | `com.jtech.zemer.utils` | no | 6 | 6 | org.junit, timber.log |
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 | `com.jtech.zemer.utils` | no | 3 | 2 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 82 | `com.jtech.zemer.utils` | no | 7 | 9 | kotlinx.coroutines, kotlinx.serialization, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 | `com.jtech.zemer.utils` | no | 7 | 11 | kotlinx.coroutines, kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |
 

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -166,7 +166,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 451 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 456 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 lines | `.kt` |
@@ -179,7 +179,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 578 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1705 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1709 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 594 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumArtistMap.kt` | 29 lines | `.kt` |
@@ -187,7 +187,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 55 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 21 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 27 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 lines | `.kt` |
@@ -304,7 +304,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 118 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1571 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 410 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 418 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 970 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 139 lines | `.kt` |
@@ -431,7 +431,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShapeUtils.kt` | 8 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt` | 194 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/utils/StringUtils.kt` | 34 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 27 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/utils/YouTubeUtils.kt` | 34 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/AccessibilityUtils.kt` | 91 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/BlockedIdsCache.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ButtonInputCapture.kt` | 40 lines | `.kt` |
@@ -456,17 +456,17 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/NotificationUtils.kt` | 35 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 779 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 788 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 155 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoLinkBuilder.kt` | 10 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt` | 40 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 146 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 629 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 183 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 185 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerLinkBuilder.kt` | 16 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 lines | `.kt` |
@@ -512,7 +512,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StatsViewModel.kt` | 175 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 82 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 92 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/YouTubeBrowseViewModel.kt` | 52 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 lines | `.kt` |
@@ -739,7 +739,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 82 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |
 | `app/universal/release/baselineProfiles/0/app-universal-release.dm` | 10017 bytes | `.dm` |


### PR DESCRIPTION
Speeds up the Whitelisted-Artists tab, which previously fetched each artist's channel image with a full `YouTube.artist()` browse per row (unbounded concurrency + a write-per-thumbnail recompose storm), then downloaded the ~2880px source (~290 KB each).

**Changes**
- **Thumbnails ride the whitelist sync.** Each artist's whitelist doc now carries a `thumbnail` (served by the content mirror and the Firebase fallback). It's threaded through as a transient on `ArtistWhitelistEntity` (`@Ignore`, no column) and written onto `Artist.thumbnailUrl` in the sync transaction as one batch = one flow re-emit. A null/blank thumbnail never overwrites an existing one.
- **Resize.** The tab requests a 256px crop via `resize()` (~25 KB instead of ~290 KB per avatar).
- **Fallback only.** The per-artist `YouTube.artist()` resolver is now a bounded (`Semaphore(4)`) `onError`-triggered fallback for a missing/rotated URL, and no longer retries on every recomposition.
- **Concurrency.** OkHttp per-host limit raised 5 → 12 so a full grid of same-host avatars loads in one wave.

**Notes**
- No schema/DB migration — `thumbnailUrl` is `@Ignore` on the entity and `Artist.thumbnailUrl` already exists. Depends on the `thumbnail` field on `content.zemer.io/whitelist` (already live, 1619/1622 covered).
- Adds a DTO thumbnail-deserialization test.

**Verified on-device (OnePlus 12 / Android 16):** avatars paint on open, no per-artist fetch storm, no recompose storm. An earlier prewarm attempt was removed after logs showed it flooded the single-host request queue and delayed painting.