### PR TITLE
feat(updater): opt-in nightly build channel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,14 @@ android {
         versionCode = 34
         versionName = "34"
         buildConfigField("String", "ARCHITECTURE", "\"universal\"")
+        // Git commit of this build — the nightly-updater's identity (every main build shares the
+        // same versionName, so "is a newer nightly available" is a SHA comparison, not a version
+        // one). Empty when git is unavailable, which makes any nightly count as an update.
+        val commitHash = runCatching {
+            providers.exec { commandLine("git", "rev-parse", "HEAD") }
+                .standardOutput.asText.get().trim()
+        }.getOrDefault("")
+        buildConfigField("String", "COMMIT_HASH", "\"$commitHash\"")
         val googleTokenExchangeUrl = (project.findProperty("googleTokenExchangeUrl") as String?) ?: ""
         buildConfigField("String", "GOOGLE_TOKEN_EXCHANGE_URL", "\"$googleTokenExchangeUrl\"")
         // Read-only content mirror (content.zemer.io) used mirror-first with the Firebase SDK as

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -45,6 +45,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -143,10 +144,10 @@ class App : Application(), SingletonImageLoader.Factory {
         val settings = dataStore.data.first()
         if (settings[CheckForUpdatesKey] != true) return
 
-        when (val result = UpdateChecker.checkForUpdates()) {
+        when (val result = UpdateChecker.checkForUpdates(settings[NightlyUpdatesKey] == true)) {
             is UpdateChecker.UpdateResult.UpdateAvailable -> {
-                pendingUpdateVersion = result.latestVersion
-                pendingUpdateNotes = result.notes
+                pendingUpdate.value =
+                    PendingUpdate(result.latestVersion, result.notes, result.isNightly)
             }
             else -> { /* No action needed */ }
         }
@@ -417,13 +418,15 @@ class App : Application(), SingletonImageLoader.Factory {
     }
 
     companion object {
-        // Holds pending update version and notes detected on startup
-        var pendingUpdateVersion: String? = null
-        var pendingUpdateNotes: String? = null
+        data class PendingUpdate(val version: String, val notes: String?, val isNightly: Boolean)
+
+        // An update found by the startup check. A StateFlow, not a plain var: the check finishes
+        // after MainActivity's first composition on virtually every launch, so a one-shot read
+        // there would miss it — the UI must observe the result whenever it lands.
+        val pendingUpdate = MutableStateFlow<PendingUpdate?>(null)
 
         fun clearPendingUpdate() {
-            pendingUpdateVersion = null
-            pendingUpdateNotes = null
+            pendingUpdate.value = null
         }
 
         suspend fun forgetAccount(context: Context) {

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -69,8 +69,11 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -160,6 +163,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.jtech.zemer.constants.AppBarHeight
 import com.jtech.zemer.constants.AppLanguageKey
 import com.jtech.zemer.constants.CheckForUpdatesKey
+import com.jtech.zemer.constants.LastNightlyAnnouncedKey
 import com.jtech.zemer.constants.DarkModeKey
 import com.jtech.zemer.constants.DefaultOpenTabKey
 import com.jtech.zemer.constants.DisableScreenshotKey
@@ -255,6 +259,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -263,6 +268,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.util.Locale
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
 
@@ -750,16 +756,41 @@ class MainActivity : ComponentActivity() {
                         var showUpdateDialog by rememberSaveable { mutableStateOf(false) }
                         var pendingUpdateVersion by rememberSaveable { mutableStateOf<String?>(null) }
                         var pendingUpdateNotes by rememberSaveable { mutableStateOf<String?>(null) }
+                        var pendingUpdateIsNightly by rememberSaveable { mutableStateOf(false) }
                         var downloadState by remember { mutableStateOf<com.jtech.zemer.utils.UpdateChecker.DownloadState>(com.jtech.zemer.utils.UpdateChecker.DownloadState.Idle) }
                         var installError by remember { mutableStateOf<String?>(null) }
                         val updateScope = rememberCoroutineScope()
+                        val snackbarHostState = remember { SnackbarHostState() }
 
+                        // Collected, not read once: the startup check finishes after the first
+                        // composition on most launches, so a one-shot peek would miss the result.
                         LaunchedEffect(Unit) {
-                            App.pendingUpdateVersion?.let { version ->
-                                pendingUpdateVersion = version
-                                pendingUpdateNotes = App.pendingUpdateNotes
-                                showUpdateDialog = true
+                            App.pendingUpdate.filterNotNull().collect { update ->
                                 App.clearPendingUpdate()
+                                pendingUpdateVersion = update.version
+                                pendingUpdateNotes = update.notes
+                                pendingUpdateIsNightly = update.isNightly
+                                if (update.isNightly) {
+                                    // Nightlies land with every push to main — a modal dialog per
+                                    // launch would be relentless. Announce each build once, as a
+                                    // quiet snackbar whose action opens the full update dialog.
+                                    if (dataStore.get(LastNightlyAnnouncedKey, "") == update.version) return@collect
+                                    Timber.d("Nightly update snackbar: ${update.version}")
+                                    val action = snackbarHostState.showSnackbar(
+                                        message = getString(R.string.nightly_update_available, update.version),
+                                        actionLabel = getString(R.string.update_action),
+                                        withDismissAction = true,
+                                        duration = SnackbarDuration.Long,
+                                    )
+                                    // Marked announced only after the snackbar was actually shown,
+                                    // so a launch that never displayed it doesn't swallow the build.
+                                    dataStore.edit { it[LastNightlyAnnouncedKey] = update.version }
+                                    if (action == SnackbarResult.ActionPerformed) {
+                                        showUpdateDialog = true
+                                    }
+                                } else {
+                                    showUpdateDialog = true
+                                }
                             }
                         }
 
@@ -796,7 +827,7 @@ class MainActivity : ComponentActivity() {
                                     downloadState = com.jtech.zemer.utils.UpdateChecker.DownloadState.Downloading(0f)
                                     installError = null
                                     updateScope.launch {
-                                        com.jtech.zemer.utils.UpdateChecker.downloadUpdate(this@MainActivity).collect { state ->
+                                        com.jtech.zemer.utils.UpdateChecker.downloadUpdate(this@MainActivity, pendingUpdateIsNightly).collect { state ->
                                             downloadState = state
                                         }
                                     }
@@ -1107,7 +1138,6 @@ class MainActivity : ComponentActivity() {
                     val burgerFocusRequester = remember { FocusRequester() }
                     val contentFocusRequester = remember { FocusRequester() }
                     val drawerScrollState = rememberScrollState()
-                    val snackbarHostState = remember { SnackbarHostState() }
 
                     // Observe playback errors and show snackbar
                     LaunchedEffect(playerConnection) {
@@ -1352,9 +1382,11 @@ class MainActivity : ComponentActivity() {
                             }
 
                             Scaffold(
-                            snackbarHost = {
-                                SnackbarHost(hostState = snackbarHostState)
-                            },
+                            // NOTE: no snackbarHost here on purpose. This Scaffold's bottomBar hosts
+                            // the full-height BottomSheetPlayer, and Material3 stacks the snackbar
+                            // ABOVE the bottomBar — i.e. off the top of the screen. The SnackbarHost
+                            // is instead rendered as a top-level overlay below (aligned to the bottom,
+                            // padded above the mini player) so snackbars are actually visible.
                             topBar = {
                                 AnimatedVisibility(
                                     visible = shouldShowTopBar,
@@ -1862,6 +1894,32 @@ class MainActivity : ComponentActivity() {
                                         bottom = playerAwareWindowInsets.asPaddingValues()
                                             .calculateBottomPadding() + 16.dp,
                                     ),
+                            )
+                        }
+
+                        // Top-level snackbar overlay (see the NOTE on the Scaffold above). Aligned to
+                        // the bottom and padded above the mini player / nav bar via the same
+                        // player-aware insets the FAB uses, so it floats clear of the transport.
+                        SnackbarHost(
+                            hostState = snackbarHostState,
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(
+                                    bottom = playerAwareWindowInsets.asPaddingValues()
+                                        .calculateBottomPadding(),
+                                ),
+                        ) { data ->
+                            // Themed to match the app's dialog surfaces instead of Material's default
+                            // dark inverse-surface bar: app surface color (pure black in AMOLED like
+                            // the nav bar), onSurface text, primary action, rounded like the app cards.
+                            Snackbar(
+                                snackbarData = data,
+                                shape = RoundedCornerShape(12.dp),
+                                containerColor = if (pureBlack) Color(0xFF0A0A0A)
+                                    else MaterialTheme.colorScheme.surfaceContainerHigh,
+                                contentColor = MaterialTheme.colorScheme.onSurface,
+                                actionColor = MaterialTheme.colorScheme.primary,
+                                dismissActionContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
 

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -73,6 +73,9 @@ val LastWhitelistSyncTimeKey = longPreferencesKey("lastWhitelistSyncTime")  // T
 // blocklist is active before the first sync of the session and survives offline launches.
 val BlockedContentIdsKey = stringPreferencesKey("blockedContentIds")
 val CheckForUpdatesKey = booleanPreferencesKey("checkForUpdates")
+val NightlyUpdatesKey = booleanPreferencesKey("nightlyUpdates") // opt-in nightly update channel
+// Last nightly build announced via the startup snackbar, so each nightly is announced only once.
+val LastNightlyAnnouncedKey = stringPreferencesKey("lastNightlyAnnounced")
 val UpdateNotificationsEnabledKey = booleanPreferencesKey("updateNotifications")
 val InstallerTypeKey = intPreferencesKey("installerType") // InstallerType ordinal
 val LastWhitelistVersionKey = longPreferencesKey("lastWhitelistVersion")

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -43,9 +43,6 @@ fun UpdateDownloadDialog(
     onDownload: () -> Unit,
     onInstall: (File) -> Unit,
     onDismiss: () -> Unit,
-    // Optional caller-supplied guidance shown under the version line (e.g. the downgrade hint
-    // when a nightly user force-downloads the current stable release).
-    infoNote: String? = null,
 ) {
     val isDownloading = downloadState is UpdateChecker.DownloadState.Downloading
     val downloadProgress = (downloadState as? UpdateChecker.DownloadState.Downloading)?.progress ?: 0f
@@ -59,15 +56,6 @@ fun UpdateDownloadDialog(
         title = { Text(stringResource(R.string.update_available)) },
         content = {
             Text(stringResource(R.string.update_available_message, currentVersion, latestVersion))
-
-            if (!infoNote.isNullOrBlank()) {
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = infoNote,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
 
             if (!notes.isNullOrBlank()) {
                 Spacer(Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -43,6 +43,9 @@ fun UpdateDownloadDialog(
     onDownload: () -> Unit,
     onInstall: (File) -> Unit,
     onDismiss: () -> Unit,
+    // Optional caller-supplied guidance shown under the version line (e.g. the downgrade hint
+    // when a nightly user force-downloads the current stable release).
+    infoNote: String? = null,
 ) {
     val isDownloading = downloadState is UpdateChecker.DownloadState.Downloading
     val downloadProgress = (downloadState as? UpdateChecker.DownloadState.Downloading)?.progress ?: 0f
@@ -56,6 +59,15 @@ fun UpdateDownloadDialog(
         title = { Text(stringResource(R.string.update_available)) },
         content = {
             Text(stringResource(R.string.update_available_message, currentVersion, latestVersion))
+
+            if (!infoNote.isNullOrBlank()) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = infoNote,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
 
             if (!notes.isNullOrBlank()) {
                 Spacer(Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -44,6 +44,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.CheckForUpdatesKey
 import com.jtech.zemer.constants.InstallerTypeKey
+import com.jtech.zemer.constants.NightlyUpdatesKey
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.UpdateDownloadDialog
 import com.jtech.zemer.ui.component.ListPreference
@@ -73,10 +74,13 @@ fun UpdaterScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val (checkForUpdates, onCheckForUpdatesChange) = rememberPreference(CheckForUpdatesKey, false)
+    val (nightlyUpdates, onNightlyUpdatesChange) = rememberPreference(NightlyUpdatesKey, false)
+    var showNightlyNotice by remember { mutableStateOf(false) }
     val (installerTypeOrdinal, onInstallerTypeChange) = rememberPreference(InstallerTypeKey, InstallerType.NATIVE.ordinal)
     val installerType = InstallerType.fromOrdinal(installerTypeOrdinal)
 
     var isChecking by remember { mutableStateOf(false) }
+    var isFetchingStable by remember { mutableStateOf(false) }
     var showResultDialog by remember { mutableStateOf(false) }
     var updateResult by remember { mutableStateOf<UpdateChecker.UpdateResult?>(null) }
     var downloadState by remember { mutableStateOf<UpdateChecker.DownloadState>(UpdateChecker.DownloadState.Idle) }
@@ -196,6 +200,19 @@ fun UpdaterScreen(
 
             Spacer(Modifier.height(4.dp))
 
+            // Opt-in only after the notice dialog is confirmed; switching back to stable is instant.
+            SwitchPreference(
+                title = { Text(stringResource(R.string.nightly_builds)) },
+                icon = { Icon(painterResource(R.drawable.dark_mode), null) },
+                checked = nightlyUpdates,
+                onCheckedChange = { checked ->
+                    if (checked) showNightlyNotice = true else onNightlyUpdatesChange(false)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(4.dp))
+
             ListPreference(
                 title = { Text(stringResource(R.string.installer_method)) },
                 icon = { Icon(painterResource(R.drawable.download), null) },
@@ -233,7 +250,7 @@ fun UpdaterScreen(
                     if (!isChecking) {
                         isChecking = true
                         scope.launch {
-                            updateResult = UpdateChecker.checkForUpdates()
+                            updateResult = UpdateChecker.checkForUpdates(nightlyUpdates)
                             isChecking = false
                             showResultDialog = true
                         }
@@ -241,9 +258,64 @@ fun UpdaterScreen(
                 },
                 modifier = Modifier.fillMaxWidth()
             )
+
+            // The way back from the nightly channel: the regular check compares versions and a
+            // stable release shares the nightly's versionName, so it is offered unconditionally.
+            if (nightlyUpdates) {
+                Spacer(Modifier.height(4.dp))
+
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.force_download_stable)) },
+                    icon = {
+                        if (isFetchingStable) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(painterResource(R.drawable.download), null)
+                        }
+                    },
+                    onClick = {
+                        if (!isFetchingStable) {
+                            isFetchingStable = true
+                            scope.launch {
+                                updateResult = UpdateChecker.forceStableUpdate()
+                                isFetchingStable = false
+                                showResultDialog = true
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
 
         Spacer(Modifier.height(32.dp))
+    }
+
+    if (showNightlyNotice) {
+        DefaultDialog(
+            onDismiss = { showNightlyNotice = false },
+            horizontalAlignment = Alignment.Start,
+            title = { Text(stringResource(R.string.nightly_builds)) },
+            content = {
+                Text(stringResource(R.string.nightly_builds_notice))
+                Spacer(Modifier.height(8.dp))
+                Text(stringResource(R.string.stable_downgrade_hint))
+            },
+            buttons = {
+                TextButton(onClick = { showNightlyNotice = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                TextButton(onClick = {
+                    showNightlyNotice = false
+                    onNightlyUpdatesChange(true)
+                }) {
+                    Text(stringResource(R.string.enable))
+                }
+            }
+        )
     }
 
     if (showResultDialog) {
@@ -261,7 +333,7 @@ fun UpdaterScreen(
                         downloadState = UpdateChecker.DownloadState.Downloading(0f)
                         installError = null
                         scope.launch {
-                            UpdateChecker.downloadUpdate(context).collectLatest { state ->
+                            UpdateChecker.downloadUpdate(context, result.isNightly).collectLatest { state ->
                                 downloadState = state
                             }
                         }
@@ -271,6 +343,13 @@ fun UpdaterScreen(
                         showResultDialog = false
                         downloadState = UpdateChecker.DownloadState.Idle
                         installError = null
+                    },
+                    // A stable offer while on the nightly channel is the forced return path —
+                    // warn how to recover if the system blocks it as a downgrade.
+                    infoNote = if (!result.isNightly && nightlyUpdates) {
+                        stringResource(R.string.stable_downgrade_hint)
+                    } else {
+                        null
                     },
                 )
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -301,8 +301,6 @@ fun UpdaterScreen(
             title = { Text(stringResource(R.string.nightly_builds)) },
             content = {
                 Text(stringResource(R.string.nightly_builds_notice))
-                Spacer(Modifier.height(8.dp))
-                Text(stringResource(R.string.stable_downgrade_hint))
             },
             buttons = {
                 TextButton(onClick = { showNightlyNotice = false }) {
@@ -343,13 +341,6 @@ fun UpdaterScreen(
                         showResultDialog = false
                         downloadState = UpdateChecker.DownloadState.Idle
                         installError = null
-                    },
-                    // A stable offer while on the nightly channel is the forced return path —
-                    // warn how to recover if the system blocks it as a downgrade.
-                    infoNote = if (!result.isNightly && nightlyUpdates) {
-                        stringResource(R.string.stable_downgrade_hint)
-                    } else {
-                        null
                     },
                 )
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -368,6 +368,21 @@ fun UpdaterScreen(
                     }
                 )
             }
+            is UpdateChecker.UpdateResult.ReleaseComingSoon -> {
+                DefaultDialog(
+                    onDismiss = { showResultDialog = false },
+                    horizontalAlignment = Alignment.Start,
+                    title = { Text(stringResource(R.string.release_coming_soon_title)) },
+                    content = {
+                        Text(stringResource(R.string.release_coming_soon_message))
+                    },
+                    buttons = {
+                        TextButton(onClick = { showResultDialog = false }) {
+                            Text(stringResource(android.R.string.ok))
+                        }
+                    }
+                )
+            }
             is UpdateChecker.UpdateResult.Error -> {
                 DefaultDialog(
                     onDismiss = { showResultDialog = false },

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -38,6 +38,9 @@ object UpdateChecker {
         ) : UpdateResult()
         data class UpToDate(val currentVersion: String) : UpdateResult()
         data class Error(val message: String) : UpdateResult()
+        // Nightly-only: the latest nightly is a higher version than this build, i.e. a release is
+        // being prepared. Nightly users are told to wait for the stable release instead.
+        data class ReleaseComingSoon(val currentVersion: String) : UpdateResult()
     }
 
     sealed class DownloadState {
@@ -74,12 +77,31 @@ object UpdateChecker {
             val currentVersion =
                 NightlyUpdates.currentVersionLabel(BuildConfig.VERSION_NAME, BuildConfig.COMMIT_HASH)
             if (NightlyUpdates.isUpdateAvailable(BuildConfig.COMMIT_HASH, run.headSha)) {
-                UpdateResult.UpdateAvailable(
-                    latestVersion = NightlyUpdates.versionLabel(run),
-                    currentVersion = currentVersion,
-                    notes = run.commitTitle,
-                    isNightly = true,
-                )
+                // A higher-versioned nightly means a release is being prepared — tell nightly users
+                // to wait for stable rather than hand them the release candidate. The version lives
+                // in build.gradle.kts at that commit; a failed fetch must not block the update, so
+                // fall through to offering the nightly.
+                val nightlyVersion = runCatching {
+                    val gradle = httpClient.get(NightlyUpdates.buildGradleUrl(run.headSha)) {
+                        header(HttpHeaders.UserAgent, "Zemer-Updater")
+                    }.bodyAsText()
+                    NightlyUpdates.parseBuildVersion(gradle)
+                }.getOrNull()
+
+                if (nightlyVersion != null &&
+                    NightlyUpdates.isReleaseComingSoon(
+                        BuildConfig.VERSION_CODE, BuildConfig.VERSION_NAME, nightlyVersion,
+                    )
+                ) {
+                    UpdateResult.ReleaseComingSoon(currentVersion)
+                } else {
+                    UpdateResult.UpdateAvailable(
+                        latestVersion = NightlyUpdates.versionLabel(run),
+                        currentVersion = currentVersion,
+                        notes = run.commitTitle,
+                        isNightly = true,
+                    )
+                }
             } else {
                 UpdateResult.UpToDate(currentVersion)
             }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import com.jtech.zemer.BuildConfig
+import com.jtech.zemer.utils.updater.NightlyUpdates
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -24,9 +25,17 @@ object UpdateChecker {
     private const val CHANGELOG_URL = "https://ghtrack.zemer.io/changelog"
     private const val DOWNLOAD_URL = "https://ghtrack.zemer.io/download"
     private const val APK_FILENAME = "zemer-update.apk"
+    private const val NIGHTLY_ZIP_FILENAME = "zemer-nightly.zip"
 
     sealed class UpdateResult {
-        data class UpdateAvailable(val latestVersion: String, val currentVersion: String, val notes: String? = null) : UpdateResult()
+        data class UpdateAvailable(
+            val latestVersion: String,
+            val currentVersion: String,
+            val notes: String? = null,
+            // Tags the result with its channel so the download uses the source this result came
+            // from, even if the nightly preference is toggled between check and download.
+            val isNightly: Boolean = false,
+        ) : UpdateResult()
         data class UpToDate(val currentVersion: String) : UpdateResult()
         data class Error(val message: String) : UpdateResult()
     }
@@ -38,8 +47,51 @@ object UpdateChecker {
         data class Error(val message: String) : DownloadState()
     }
 
-    suspend fun checkForUpdates(): UpdateResult = withContext(Dispatchers.IO) {
-        try {
+    suspend fun checkForUpdates(nightly: Boolean = false): UpdateResult = withContext(Dispatchers.IO) {
+        if (nightly) checkForNightlyUpdate() else checkForStableUpdate()
+    }
+
+    /**
+     * The nightly channel's way back to stable: always offers the current stable release, even
+     * when the version comparison says up to date — nightlies share the stable versionName, so a
+     * regular check can never offer the stable build a nightly user wants to return to.
+     */
+    suspend fun forceStableUpdate(): UpdateResult = withContext(Dispatchers.IO) {
+        checkForStableUpdate(force = true)
+    }
+
+    private suspend fun checkForNightlyUpdate(): UpdateResult {
+        val httpClient = HttpClient()
+        return try {
+            val responseText = httpClient.get(NightlyUpdates.RUNS_URL) {
+                // GitHub's API rejects requests without a User-Agent.
+                header(HttpHeaders.UserAgent, "Zemer-Updater")
+                header(HttpHeaders.Accept, "application/vnd.github+json")
+            }.bodyAsText()
+
+            val run = NightlyUpdates.parseLatestRun(responseText)
+                ?: return UpdateResult.Error("Invalid API response")
+            val currentVersion =
+                NightlyUpdates.currentVersionLabel(BuildConfig.VERSION_NAME, BuildConfig.COMMIT_HASH)
+            if (NightlyUpdates.isUpdateAvailable(BuildConfig.COMMIT_HASH, run.headSha)) {
+                UpdateResult.UpdateAvailable(
+                    latestVersion = NightlyUpdates.versionLabel(run),
+                    currentVersion = currentVersion,
+                    notes = run.commitTitle,
+                    isNightly = true,
+                )
+            } else {
+                UpdateResult.UpToDate(currentVersion)
+            }
+        } catch (e: Exception) {
+            UpdateResult.Error(e.message ?: "Failed to check for updates")
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    private suspend fun checkForStableUpdate(force: Boolean = false): UpdateResult {
+        return try {
             val httpClient = HttpClient()
             val response = httpClient.get(API_URL)
             val responseText = response.bodyAsText()
@@ -48,14 +100,14 @@ object UpdateChecker {
             val latestVersionRaw = json.jsonObject["latestVersion"]?.jsonPrimitive?.content
                 ?: run {
                     httpClient.close()
-                    return@withContext UpdateResult.Error("Invalid API response")
+                    return UpdateResult.Error("Invalid API response")
                 }
 
             // Strip "v" prefix if present (API returns "v4", app version is "4")
             val latestVersion = latestVersionRaw.removePrefix("v").removePrefix("V")
             val currentVersion = BuildConfig.VERSION_NAME
 
-            if (isNewerVersion(latestVersion, currentVersion)) {
+            if (force || isNewerVersion(latestVersion, currentVersion)) {
                 // Fetch changelog notes
                 val notes = try {
                     val changelogResponse = httpClient.get(CHANGELOG_URL)
@@ -66,7 +118,17 @@ object UpdateChecker {
                     null
                 }
                 httpClient.close()
-                UpdateResult.UpdateAvailable(latestVersion, currentVersion, notes)
+                UpdateResult.UpdateAvailable(
+                    latestVersion = latestVersion,
+                    // A forced download is the nightly user's return path — show which build
+                    // they are leaving by labelling the current version with its commit.
+                    currentVersion = if (force) {
+                        NightlyUpdates.currentVersionLabel(currentVersion, BuildConfig.COMMIT_HASH)
+                    } else {
+                        currentVersion
+                    },
+                    notes = notes,
+                )
             } else {
                 httpClient.close()
                 UpdateResult.UpToDate(currentVersion)
@@ -76,13 +138,15 @@ object UpdateChecker {
         }
     }
 
-    fun downloadUpdate(context: Context): Flow<DownloadState> = flow {
+    fun downloadUpdate(context: Context, nightly: Boolean = false): Flow<DownloadState> = flow {
         emit(DownloadState.Downloading(0f))
 
         try {
             val httpClient = HttpClient()
 
-            val response = httpClient.prepareGet(DOWNLOAD_URL).execute()
+            val response = httpClient
+                .prepareGet(if (nightly) NightlyUpdates.DOWNLOAD_URL else DOWNLOAD_URL)
+                .execute()
 
             // Size of the actual body we'll read, taken after redirects. A separate HEAD
             // is unreliable here: /download redirects through a worker + CDN, so a HEAD can
@@ -94,16 +158,21 @@ object UpdateChecker {
             val contentLength = if (isEncoded) -1L else response.contentLength() ?: -1L
 
             val apkFile = File(context.cacheDir, APK_FILENAME)
+            // A nightly arrives as the artifact zip; the APK is extracted from it afterwards.
+            val targetFile = if (nightly) File(context.cacheDir, NIGHTLY_ZIP_FILENAME) else apkFile
 
-            // Delete existing file if present
+            // Delete existing files if present
             if (apkFile.exists()) {
                 apkFile.delete()
+            }
+            if (nightly && targetFile.exists()) {
+                targetFile.delete()
             }
 
             val channel = response.bodyAsChannel()
             var downloadedBytes = 0L
 
-            apkFile.outputStream().use { output ->
+            targetFile.outputStream().use { output ->
                 val buffer = ByteArray(8192)
                 while (!channel.isClosedForRead) {
                     val bytesRead = channel.readAvailable(buffer)
@@ -122,6 +191,10 @@ object UpdateChecker {
             }
 
             httpClient.close()
+            if (nightly) {
+                NightlyUpdates.extractApk(targetFile, apkFile)
+                targetFile.delete()
+            }
             emit(DownloadState.Downloaded(apkFile))
         } catch (e: Exception) {
             emit(DownloadState.Error(e.message ?: "Download failed"))

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
@@ -54,6 +54,42 @@ object NightlyUpdates {
     fun currentVersionLabel(versionName: String, installedSha: String): String =
         if (installedSha.isBlank()) versionName else "$versionName (${installedSha.take(7)})"
 
+    /** Raw build.gradle.kts at [sha] — the authoritative version of the nightly at that commit. */
+    fun buildGradleUrl(sha: String): String =
+        "https://raw.githubusercontent.com/ZemerTeam/zemer-app/$sha/app/build.gradle.kts"
+
+    data class BuildVersion(val versionCode: Int, val versionName: String)
+
+    private val VERSION_CODE_REGEX = Regex("""versionCode\s*=\s*(\d+)""")
+    private val VERSION_NAME_REGEX = Regex("""versionName\s*=\s*"([^"]+)"""")
+
+    /** Parses versionCode/versionName out of a build.gradle.kts; null if either is absent. */
+    fun parseBuildVersion(buildGradle: String): BuildVersion? {
+        val code = VERSION_CODE_REGEX.find(buildGradle)?.groupValues?.get(1)?.toIntOrNull() ?: return null
+        val name = VERSION_NAME_REGEX.find(buildGradle)?.groupValues?.get(1) ?: return null
+        return BuildVersion(code, name)
+    }
+
+    /** True when [candidate] is a strictly higher dotted-numeric version than [base] (e.g. 35 > 34). */
+    fun isNameGreater(candidate: String, base: String): Boolean {
+        val a = candidate.split(".").map { it.toIntOrNull() ?: 0 }
+        val b = base.split(".").map { it.toIntOrNull() ?: 0 }
+        for (i in 0 until maxOf(a.size, b.size)) {
+            val x = a.getOrElse(i) { 0 }
+            val y = b.getOrElse(i) { 0 }
+            if (x != y) return x > y
+        }
+        return false
+    }
+
+    /**
+     * A new nightly whose versionCode AND versionName are both above the installed build is a
+     * release being prepared — nightly users should wait for the stable release rather than jump
+     * to what is effectively the release candidate.
+     */
+    fun isReleaseComingSoon(installedCode: Int, installedName: String, nightly: BuildVersion): Boolean =
+        nightly.versionCode > installedCode && isNameGreater(nightly.versionName, installedName)
+
     /**
      * Extracts the single APK inside a nightly.link artifact zip into [destination]. Throws when
      * the archive holds no APK so a broken artifact surfaces as a download error, not a dead file.

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
@@ -1,0 +1,71 @@
+package com.jtech.zemer.utils.updater
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * The opt-in nightly update channel: every push to `main` produces a signed release APK via the
+ * release-build workflow, and nightly.link mirrors the latest artifact. Nightlies all share the
+ * stable versionName, so "is a newer nightly available" is a commit-SHA comparison against
+ * BuildConfig.COMMIT_HASH — never a version comparison. Pure logic (parsing, comparison, labels,
+ * zip extraction) lives here so it is unit-testable; the network/UI flow stays in UpdateChecker.
+ */
+object NightlyUpdates {
+    /** Latest successful release-build run on main; its head SHA identifies the latest nightly. */
+    const val RUNS_URL =
+        "https://api.github.com/repos/ZemerTeam/zemer-app/actions/workflows/release-build.yml/runs?branch=main&status=success&per_page=1"
+
+    /** nightly.link mirror of the latest release-apk artifact — a zip wrapping the APK. */
+    const val DOWNLOAD_URL =
+        "https://nightly.link/ZemerTeam/zemer-app/workflows/release-build/main/release-apk.zip"
+
+    data class NightlyRun(
+        val headSha: String,
+        val runNumber: Int,
+        val commitTitle: String?,
+    )
+
+    /** Parses the GitHub Actions runs response; null when it holds no usable run. */
+    fun parseLatestRun(json: String): NightlyRun? = runCatching {
+        val run = Json.parseToJsonElement(json)
+            .jsonObject["workflow_runs"]?.jsonArray?.firstOrNull()?.jsonObject
+            ?: return null
+        NightlyRun(
+            headSha = run["head_sha"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+                ?: return null,
+            runNumber = run["run_number"]?.jsonPrimitive?.int ?: return null,
+            // head_commit carries the full commit message; display_title is a truncated fallback.
+            commitTitle = run["head_commit"]?.jsonObject?.get("message")?.jsonPrimitive?.content
+                ?: run["display_title"]?.jsonPrimitive?.content,
+        )
+    }.getOrNull()
+
+    /** A build with an unknown (blank) SHA — e.g. built without git — always counts as outdated. */
+    fun isUpdateAvailable(installedSha: String, latestSha: String): Boolean =
+        !latestSha.equals(installedSha, ignoreCase = true)
+
+    fun versionLabel(run: NightlyRun): String = "nightly #${run.runNumber} (${run.headSha.take(7)})"
+
+    fun currentVersionLabel(versionName: String, installedSha: String): String =
+        if (installedSha.isBlank()) versionName else "$versionName (${installedSha.take(7)})"
+
+    /**
+     * Extracts the single APK inside a nightly.link artifact zip into [destination]. Throws when
+     * the archive holds no APK so a broken artifact surfaces as a download error, not a dead file.
+     */
+    fun extractApk(zip: File, destination: File) {
+        ZipFile(zip).use { archive ->
+            val entry = archive.entries().asSequence()
+                .firstOrNull { !it.isDirectory && it.name.endsWith(".apk") }
+                ?: error("No APK found in the nightly archive")
+            archive.getInputStream(entry).use { input ->
+                destination.outputStream().use { output -> input.copyTo(output) }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -267,7 +267,6 @@
     <string name="force_download_stable">Download current stable release</string>
     <string name="release_coming_soon_title">Coming soon</string>
     <string name="release_coming_soon_message">A newer version is on the way. Please wait for the stable release.</string>
-    <string name="stable_downgrade_hint">If the stable release won\'t install on top because of a lower version, uninstall the app and download the latest release from https://zemer.io.</string>
     <string name="check_for_updates_now">Check for updates now</string>
     <string name="update_notifications">Enable update notifications</string>
     <string name="update_available_title">Update available</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -259,6 +259,13 @@
     <!-- Updater -->
     <string name="updater">Updater</string>
     <string name="check_for_updates">Automatically check for updates</string>
+    <string name="nightly_builds">Nightly builds</string>
+    <string name="nightly_builds_notice">Nightly builds have new features implemented. However, they may have bugs. Going back to stable release builds may require you to clear data of the app.</string>
+    <string name="enable">Enable</string>
+    <string name="nightly_update_available">Update available: %1$s</string>
+    <string name="update_action">Update</string>
+    <string name="force_download_stable">Download current stable release</string>
+    <string name="stable_downgrade_hint">If the stable release won\'t install on top because of a lower version, uninstall the app and download the latest release from https://zemer.io.</string>
     <string name="check_for_updates_now">Check for updates now</string>
     <string name="update_notifications">Enable update notifications</string>
     <string name="update_available_title">Update available</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -265,6 +265,8 @@
     <string name="nightly_update_available">Update available: %1$s</string>
     <string name="update_action">Update</string>
     <string name="force_download_stable">Download current stable release</string>
+    <string name="release_coming_soon_title">Coming soon</string>
+    <string name="release_coming_soon_message">A newer version is on the way. Please wait for the stable release.</string>
     <string name="stable_downgrade_hint">If the stable release won\'t install on top because of a lower version, uninstall the app and download the latest release from https://zemer.io.</string>
     <string name="check_for_updates_now">Check for updates now</string>
     <string name="update_notifications">Enable update notifications</string>

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
@@ -1,0 +1,130 @@
+package com.jtech.zemer.utils.updater
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Pure coverage of the nightly update channel: GitHub runs parsing, the SHA-based "is an update
+ * available" rule (nightlies share the stable versionName, so versions can never be compared),
+ * and APK extraction from the nightly.link artifact zip.
+ */
+class NightlyUpdatesTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    // Trimmed from a real https://api.github.com/.../release-build.yml/runs response.
+    private val runsJson = """
+        {
+          "total_count": 103,
+          "workflow_runs": [
+            {
+              "id": 28590629343,
+              "name": "Android Release Build",
+              "head_branch": "main",
+              "head_sha": "5226868eaf3e6ae9e0e022c5b80c4d1b020e28e4",
+              "display_title": "fix(search): route Zemer-search albums through the server /album endp…",
+              "run_number": 549,
+              "status": "completed",
+              "conclusion": "success",
+              "head_commit": {
+                "id": "5226868eaf3e6ae9e0e022c5b80c4d1b020e28e4",
+                "message": "fix(search): route Zemer-search albums through the server /album endpoint (#171)"
+              }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `parses the latest run from a real-shaped response`() {
+        val run = NightlyUpdates.parseLatestRun(runsJson)!!
+
+        assertEquals("5226868eaf3e6ae9e0e022c5b80c4d1b020e28e4", run.headSha)
+        assertEquals(549, run.runNumber)
+        // The full head_commit message is shown to the user, not GitHub's truncated display_title.
+        assertEquals(
+            "fix(search): route Zemer-search albums through the server /album endpoint (#171)",
+            run.commitTitle,
+        )
+    }
+
+    @Test
+    fun `falls back to display_title when head_commit is absent`() {
+        val run = NightlyUpdates.parseLatestRun(
+            """{"workflow_runs":[{"head_sha":"abc123","run_number":42,"display_title":"truncated title…"}]}"""
+        )!!
+
+        assertEquals("truncated title…", run.commitTitle)
+    }
+
+    @Test
+    fun `unusable responses parse to null instead of throwing`() {
+        assertNull(NightlyUpdates.parseLatestRun("""{"total_count":0,"workflow_runs":[]}"""))
+        assertNull(NightlyUpdates.parseLatestRun("""{"message":"API rate limit exceeded"}"""))
+        assertNull(NightlyUpdates.parseLatestRun("""{"workflow_runs":[{"run_number":549}]}""")) // no head_sha
+        assertNull(NightlyUpdates.parseLatestRun("""{"workflow_runs":[{"head_sha":"abc"}]}""")) // no run_number
+        assertNull(NightlyUpdates.parseLatestRun("not json at all"))
+    }
+
+    @Test
+    fun `update is available only when the latest SHA differs from the installed one`() {
+        val sha = "5226868eaf3e6ae9e0e022c5b80c4d1b020e28e4"
+
+        assertFalse(NightlyUpdates.isUpdateAvailable(sha, sha))
+        assertFalse(NightlyUpdates.isUpdateAvailable(sha.uppercase(), sha)) // case never matters
+        assertTrue(NightlyUpdates.isUpdateAvailable("0000000aaf3e6ae9e0e022c5b80c4d1b020e28e4", sha))
+        // A build without a baked-in SHA (built outside git) always counts as outdated.
+        assertTrue(NightlyUpdates.isUpdateAvailable("", sha))
+    }
+
+    @Test
+    fun `version labels use the run number and short SHAs`() {
+        val run = NightlyUpdates.parseLatestRun(runsJson)!!
+
+        assertEquals("nightly #549 (5226868)", NightlyUpdates.versionLabel(run))
+        assertEquals("34 (5226868)", NightlyUpdates.currentVersionLabel("34", run.headSha))
+        assertEquals("34", NightlyUpdates.currentVersionLabel("34", "")) // no SHA -> plain version
+    }
+
+    @Test
+    fun `extracts the APK entry from the artifact zip`() {
+        val apkBytes = ByteArray(4096) { (it % 251).toByte() }
+        val zip = tempFolder.newFile("release-apk.zip")
+        ZipOutputStream(zip.outputStream()).use { out ->
+            out.putNextEntry(ZipEntry("output-metadata.json"))
+            out.write("{}".toByteArray())
+            out.closeEntry()
+            out.putNextEntry(ZipEntry("app-release.apk"))
+            out.write(apkBytes)
+            out.closeEntry()
+        }
+        val destination = tempFolder.newFile("zemer-update.apk")
+
+        NightlyUpdates.extractApk(zip, destination)
+
+        assertTrue(apkBytes.contentEquals(destination.readBytes()))
+    }
+
+    @Test
+    fun `a zip without an APK fails loudly instead of producing a dead file`() {
+        val zip = tempFolder.newFile("broken.zip")
+        ZipOutputStream(zip.outputStream()).use { out ->
+            out.putNextEntry(ZipEntry("readme.txt"))
+            out.write("no apk here".toByteArray())
+            out.closeEntry()
+        }
+        val destination = tempFolder.newFile("zemer-update.apk")
+
+        val result = runCatching { NightlyUpdates.extractApk(zip, destination) }
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
@@ -127,4 +127,62 @@ class NightlyUpdatesTest {
 
         assertTrue(result.isFailure)
     }
+
+    @Test
+    fun `parses versionCode and versionName from a build gradle`() {
+        val gradle = """
+            defaultConfig {
+                applicationId = "com.jtech.zemer"
+                versionCode = 35
+                versionName = "35"
+                buildConfigField("String", "ARCHITECTURE", "\"universal\"")
+            }
+        """.trimIndent()
+
+        val version = NightlyUpdates.parseBuildVersion(gradle)!!
+        assertEquals(35, version.versionCode)
+        assertEquals("35", version.versionName)
+    }
+
+    @Test
+    fun `parseBuildVersion returns null when a field is missing`() {
+        assertNull(NightlyUpdates.parseBuildVersion("""versionName = "35""""))     // no versionCode
+        assertNull(NightlyUpdates.parseBuildVersion("versionCode = 35"))           // no versionName
+        assertNull(NightlyUpdates.parseBuildVersion("nothing here"))
+    }
+
+    @Test
+    fun `isNameGreater compares dotted-numeric versions`() {
+        assertTrue(NightlyUpdates.isNameGreater("35", "34"))
+        assertTrue(NightlyUpdates.isNameGreater("34.1", "34"))
+        assertFalse(NightlyUpdates.isNameGreater("34", "34"))
+        assertFalse(NightlyUpdates.isNameGreater("34", "35"))
+    }
+
+    @Test
+    fun `release is coming soon only when both code and name are higher`() {
+        // Installed build is code 34 / name "34".
+        assertTrue(
+            NightlyUpdates.isReleaseComingSoon(34, "34", NightlyUpdates.BuildVersion(35, "35")),
+        )
+        // Same version (a normal same-release nightly) => offer it, not "coming soon".
+        assertFalse(
+            NightlyUpdates.isReleaseComingSoon(34, "34", NightlyUpdates.BuildVersion(34, "34")),
+        )
+        // Only one of the two higher => not a release bump; still offer it.
+        assertFalse(
+            NightlyUpdates.isReleaseComingSoon(34, "34", NightlyUpdates.BuildVersion(35, "34")),
+        )
+        assertFalse(
+            NightlyUpdates.isReleaseComingSoon(34, "34", NightlyUpdates.BuildVersion(34, "35")),
+        )
+    }
+
+    @Test
+    fun `buildGradleUrl points at the raw file for the commit`() {
+        assertEquals(
+            "https://raw.githubusercontent.com/ZemerTeam/zemer-app/abc123/app/build.gradle.kts",
+            NightlyUpdates.buildGradleUrl("abc123"),
+        )
+    }
 }

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (384)
+## `app` Kotlin files (386)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -10,8 +10,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 456 | `com.jtech.zemer` | no | 65 | 45 | android.app, android.content, android.os, android.util, android.webkit, android.widget, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 | `com.jtech.zemer` | no | 265 | 219 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 459 | `com.jtech.zemer` | no | 66 | 48 | android.app, android.content, android.os, android.util, android.webkit, android.widget, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2216 | `com.jtech.zemer` | no | 271 | 221 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 | `com.jtech.zemer.auth` | no | 0 | 16 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 145 | `com.jtech.zemer.auth` | no | 13 | 26 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -20,7 +20,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 | `com.jtech.zemer.constants` | no | 2 | 14 | android.os, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 578 | `com.jtech.zemer.constants` | no | 9 | 180 | androidx.annotation, androidx.datastore, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 581 | `com.jtech.zemer.constants` | no | 9 | 182 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 | `com.jtech.zemer.constants` | no | 3 | 4 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1719 | `com.jtech.zemer.db` | no | 59 | 232 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
@@ -167,7 +167,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 141 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/WebViewAuthDialog.kt` | 130 | `com.jtech.zemer.ui.component` | yes | 36 | 4 | android.annotation, android.util, android.view, android.webkit, androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/ButtonPlaceholder.kt` | 21 | `com.jtech.zemer.ui.component.shimmer` | yes | 9 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/GridItemPlaceholder.kt` | 56 | `com.jtech.zemer.ui.component.shimmer` | yes | 17 | 1 | androidx.compose |
@@ -260,7 +260,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 | `com.jtech.zemer.ui.screens.settings` | yes | 36 | 21 | android.os, android.widget, androidx.compose, androidx.navigation, com.google |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 | `com.jtech.zemer.ui.screens.settings` | yes | 67 | 36 | android.annotation, android.content, android.net, android.provider, androidx.activity, androidx.compose, androidx.navigation, coil3.annotation, coil3.imageLoader, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 | `com.jtech.zemer.ui.screens.settings` | yes | 46 | 20 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 328 | `com.jtech.zemer.ui.screens.settings` | yes | 63 | 23 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 407 | `com.jtech.zemer.ui.screens.settings` | yes | 64 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 | `com.jtech.zemer.ui.screens.settings.integrations` | yes | 18 | 1 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 | `com.jtech.zemer.ui.theme` | no | 5 | 42 | androidx.compose, androidx.palette, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 | `com.jtech.zemer.ui.theme` | yes | 6 | 12 | androidx.compose |
@@ -303,7 +303,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 | `com.jtech.zemer.utils` | no | 10 | 19 | android.Manifest, android.app, android.content, android.os, androidx.activity, androidx.core, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 | `com.jtech.zemer.utils` | no | 2 | 8 | java.math, java.security |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 782 | `com.jtech.zemer.utils` | no | 35 | 104 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 155 | `com.jtech.zemer.utils` | no | 18 | 53 | android.content, android.net, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 228 | `com.jtech.zemer.utils` | no | 19 | 63 | android.content, android.net, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 | `com.jtech.zemer.utils` | no | 2 | 12 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
@@ -321,6 +321,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 | `com.jtech.zemer.utils.updater` | no | 1 | 4 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 70 | `com.jtech.zemer.utils.updater` | no | 10 | 7 | android.content, android.os, android.widget, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 | `com.jtech.zemer.utils.updater` | no | 2 | 4 | androidx.annotation |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 71 | `com.jtech.zemer.utils.updater` | no | 7 | 14 | java.io, java.util, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 9 | 4 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountViewModel.kt` | 81 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 76 | `com.jtech.zemer.viewmodels` | no | 17 | 10 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -389,6 +390,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 | `com.jtech.zemer.utils` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 | `com.jtech.zemer.utils` | no | 7 | 11 | kotlinx.coroutines, kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 130 | `com.jtech.zemer.utils.updater` | no | 9 | 13 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |
 
 ## `innertube` Kotlin files (96)

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -167,7 +167,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 141 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/WebViewAuthDialog.kt` | 130 | `com.jtech.zemer.ui.component` | yes | 36 | 4 | android.annotation, android.util, android.view, android.webkit, androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/ButtonPlaceholder.kt` | 21 | `com.jtech.zemer.ui.component.shimmer` | yes | 9 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/GridItemPlaceholder.kt` | 56 | `com.jtech.zemer.ui.component.shimmer` | yes | 17 | 1 | androidx.compose |
@@ -260,7 +260,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 | `com.jtech.zemer.ui.screens.settings` | yes | 36 | 21 | android.os, android.widget, androidx.compose, androidx.navigation, com.google |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 | `com.jtech.zemer.ui.screens.settings` | yes | 67 | 36 | android.annotation, android.content, android.net, android.provider, androidx.activity, androidx.compose, androidx.navigation, coil3.annotation, coil3.imageLoader, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 | `com.jtech.zemer.ui.screens.settings` | yes | 46 | 20 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 422 | `com.jtech.zemer.ui.screens.settings` | yes | 64 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 413 | `com.jtech.zemer.ui.screens.settings` | yes | 64 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 | `com.jtech.zemer.ui.screens.settings.integrations` | yes | 18 | 1 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 | `com.jtech.zemer.ui.theme` | no | 5 | 42 | androidx.compose, androidx.palette, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 | `com.jtech.zemer.ui.theme` | yes | 6 | 12 | androidx.compose |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -260,7 +260,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 | `com.jtech.zemer.ui.screens.settings` | yes | 36 | 21 | android.os, android.widget, androidx.compose, androidx.navigation, com.google |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 | `com.jtech.zemer.ui.screens.settings` | yes | 67 | 36 | android.annotation, android.content, android.net, android.provider, androidx.activity, androidx.compose, androidx.navigation, coil3.annotation, coil3.imageLoader, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 | `com.jtech.zemer.ui.screens.settings` | yes | 46 | 20 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 407 | `com.jtech.zemer.ui.screens.settings` | yes | 64 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 422 | `com.jtech.zemer.ui.screens.settings` | yes | 64 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 | `com.jtech.zemer.ui.screens.settings.integrations` | yes | 18 | 1 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 | `com.jtech.zemer.ui.theme` | no | 5 | 42 | androidx.compose, androidx.palette, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 | `com.jtech.zemer.ui.theme` | yes | 6 | 12 | androidx.compose |
@@ -303,7 +303,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 | `com.jtech.zemer.utils` | no | 10 | 19 | android.Manifest, android.app, android.content, android.os, androidx.activity, androidx.core, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 | `com.jtech.zemer.utils` | no | 2 | 8 | java.math, java.security |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 782 | `com.jtech.zemer.utils` | no | 35 | 104 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 228 | `com.jtech.zemer.utils` | no | 19 | 63 | android.content, android.net, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 250 | `com.jtech.zemer.utils` | no | 19 | 67 | android.content, android.net, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 | `com.jtech.zemer.utils` | no | 2 | 12 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
@@ -321,7 +321,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 | `com.jtech.zemer.utils.updater` | no | 1 | 4 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 70 | `com.jtech.zemer.utils.updater` | no | 10 | 7 | android.content, android.os, android.widget, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 | `com.jtech.zemer.utils.updater` | no | 2 | 4 | androidx.annotation |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 71 | `com.jtech.zemer.utils.updater` | no | 7 | 14 | java.io, java.util, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 107 | `com.jtech.zemer.utils.updater` | no | 7 | 29 | java.io, java.util, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 9 | 4 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountViewModel.kt` | 81 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 76 | `com.jtech.zemer.viewmodels` | no | 17 | 10 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -390,7 +390,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 | `com.jtech.zemer.utils` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 | `com.jtech.zemer.utils` | no | 7 | 11 | kotlinx.coroutines, kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 130 | `com.jtech.zemer.utils.updater` | no | 9 | 13 | java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |
 
 ## `innertube` Kotlin files (96)

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -249,7 +249,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 570 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 572 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -249,7 +249,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 572 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 571 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -15,7 +15,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |
-| `app/build.gradle.kts` | 290 lines | text `.kts`; plugins `com.android.application, android, kotlin.serialization, hilt, kotlin.ksp, compose.compiler, google.gms.google.services, firebase.crashlytics, rikka.tools.refine` |
+| `app/build.gradle.kts` | 298 lines | text `.kts`; plugins `com.android.application, android, kotlin.serialization, hilt, kotlin.ksp, compose.compiler, google.gms.google.services, firebase.crashlytics, rikka.tools.refine` |
 | `app/lint.xml` | 12 lines | text `.xml`; XML root `lint` |
 | `app/proguard-rules.pro` | 257 lines | text `.pro` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/1.json` | 297 lines | text `.json`; JSON keys `formatVersion, database` |
@@ -249,7 +249,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 563 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 570 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 560 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -323,7 +323,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 141 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/WebViewAuthDialog.kt` | 130 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/ButtonPlaceholder.kt` | 21 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/GridItemPlaceholder.kt` | 56 lines | `.kt` |
@@ -416,7 +416,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 422 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 413 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 lines | `.kt` |
@@ -707,7 +707,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 572 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 571 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -416,7 +416,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 407 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 422 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 lines | `.kt` |
@@ -459,7 +459,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 782 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 228 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 250 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
@@ -477,7 +477,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 70 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 71 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 107 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountViewModel.kt` | 81 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 76 lines | `.kt` |
@@ -707,7 +707,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 570 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 572 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
@@ -746,7 +746,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 130 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |
 | `app/universal/release/baselineProfiles/0/app-universal-release.dm` | 10017 bytes | `.dm` |
 | `app/universal/release/baselineProfiles/1/app-universal-release.dm` | 9981 bytes | `.dm` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `886`
+- Files counted: `888`
 - By extension:
-  - `.kt`: `484`
+  - `.kt`: `486`
   - `.xml`: `184`
   - `.mjs`: `72`
   - `.md`: `51`
@@ -118,7 +118,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
-| `app/build.gradle.kts` | 290 lines | `.kts` |
+| `app/build.gradle.kts` | 298 lines | `.kts` |
 | `app/lint.xml` | 12 lines | `.xml` |
 | `app/proguard-rules.pro` | 257 lines | `.pro` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/1.json` | 297 lines | `.json` |
@@ -166,8 +166,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 456 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2158 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 459 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2216 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 145 lines | `.kt` |
@@ -176,7 +176,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 578 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 581 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1719 lines | `.kt` |
@@ -323,7 +323,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 77 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 141 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/WebViewAuthDialog.kt` | 130 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/ButtonPlaceholder.kt` | 21 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/shimmer/GridItemPlaceholder.kt` | 56 lines | `.kt` |
@@ -416,7 +416,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt` | 263 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 451 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 218 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 328 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 407 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 50 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerColorExtractor.kt` | 159 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/PlayerSliderColors.kt` | 146 lines | `.kt` |
@@ -459,7 +459,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/PermissionHelper.kt` | 247 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 31 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 782 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 155 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 228 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 109 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
@@ -477,6 +477,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 70 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 71 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountViewModel.kt` | 81 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 76 lines | `.kt` |
@@ -706,7 +707,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 563 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 570 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 560 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
@@ -745,6 +746,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/PlaylistSongWhitelistTest.kt` | 52 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 130 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |
 | `app/universal/release/baselineProfiles/0/app-universal-release.dm` | 10017 bytes | `.dm` |
 | `app/universal/release/baselineProfiles/1/app-universal-release.dm` | 9981 bytes | `.dm` |
@@ -779,7 +781,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 507 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 509 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 365 lines | `.md` |
 | `docs/reference/resource-index.md` | 288 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -790,7 +792,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 995 lines | `.md` |
+| `docs/repository-map.md` | 997 lines | `.md` |
 | `docs/ui/README.md` | 329 lines | `.md` |
 | `docs/ui/standards.md` | 290 lines | `.md` |
 | `docs/whitelist/README.md` | 256 lines | `.md` |


### PR DESCRIPTION
## Summary

Adds an opt-in **Nightly builds** channel to Settings → Updater, tracking the latest `main` release-build artifact (via nightly.link) alongside the existing stable channel.

## What's included

- **Nightly toggle** with a confirmation notice (nightlies may have bugs; going back to stable may need a data clear / uninstall + reinstall from https://zemer.io).
- **SHA-based update detection** — every nightly shares the stable versionName, so "newer nightly" is a commit-SHA comparison (`BuildConfig.COMMIT_HASH`) against the latest successful release-build run, not a version comparison.
- **Once-per-build themed snackbar** announcement (not a modal dialog); tapping *Update* opens the shared download/install flow. This also fixes the snackbar host, which sat above the full-height player bottomBar and rendered off-screen for every snackbar in the app.
- **"Download current stable release"** button (nightly only) as the way back to stable.
- **Release-coming-soon guard** — if the latest nightly's `versionCode` AND `versionName` are both higher than the installed build (a release being prepared), the manual update check shows "Coming soon — please wait for the stable release" instead of handing over the release candidate. The nightly's version is read from `build.gradle.kts` at that commit; a failed fetch falls through to offering the nightly. Startup stays silent for this case.

## Testing

- `NightlyUpdates` holds the pure logic (runs parsing, SHA comparison, version parsing/comparison, artifact-zip extraction) with JVM unit tests — all passing.
- `:app:assembleDebug` builds; `scripts/ui-audit.sh` passes.
- Verified live on an emulator: nightly toggle + notice dialog, the once-per-build snackbar rendering on-screen, and the manual check offering the latest nightly.

`BuildConfig.COMMIT_HASH` is derived from `git rev-parse HEAD` at build time (empty when git is unavailable, which makes any nightly count as newer).