### PR TITLE
Bump cipher for pipeline hardening; align sts precedence in test harness

### DIFF
--- a/tests/cipher.mjs
+++ b/tests/cipher.mjs
@@ -52,8 +52,10 @@ function extractHashesFromJs(playerJs) {
 }
 
 export function extractSignatureTimestamp(playerJs, hashes = []) {
-  for (const p of SIG_TS_PATTERNS) { const m = playerJs.match(p); if (m) return Number(m[1]); }
+  // Validated config first, regex heuristics as fallback — mirrors
+  // FunctionNameExtractor.extractSignatureTimestamp's precedence on-device.
   for (const h of hashes) if (knownPlayerConfigs()[h]) return knownPlayerConfigs()[h].sts;
+  for (const p of SIG_TS_PATTERNS) { const m = playerJs.match(p); if (m) return Number(m[1]); }
   return null;
 }
 

--- a/tests/cipher.mjs
+++ b/tests/cipher.mjs
@@ -33,7 +33,10 @@ function knownPlayerConfigs() {
   return knownPlayerConfigsCache;
 }
 
-const SIG_TS_PATTERNS = [/signatureTimestamp['":\s]+(\d+)/, /\bsts['":\s]+(\d+)/];
+// Anchored pattern = the player's own embedded field (ground truth); the loose \bsts
+// pattern can false-match and is fallback-only, tried after the config.
+const SIG_TS_ANCHORED = /signatureTimestamp['":\s]+(\d+)/;
+const SIG_TS_LOOSE = /\bsts['":\s]+(\d+)/;
 
 function md5hash4(s) {
   return crypto.createHash("md5").update(Buffer.from(s.slice(0, 10000), "utf8")).digest("hex").slice(0, 8);
@@ -52,11 +55,14 @@ function extractHashesFromJs(playerJs) {
 }
 
 export function extractSignatureTimestamp(playerJs, hashes = []) {
-  // Validated config first, regex heuristics as fallback — mirrors
-  // FunctionNameExtractor.extractSignatureTimestamp's precedence on-device.
+  // Precedence (mirrors FunctionNameExtractor.extractSignatureTimestamp on-device):
+  // 1. the anchored literal in the JS itself — the field configs are copied from, immune
+  //    to config typos/stale aliases; 2. the config; 3. the false-match-prone loose pattern.
+  const anchored = playerJs.match(SIG_TS_ANCHORED);
+  if (anchored) return Number(anchored[1]);
   for (const h of hashes) if (knownPlayerConfigs()[h]) return knownPlayerConfigs()[h].sts;
-  for (const p of SIG_TS_PATTERNS) { const m = playerJs.match(p); if (m) return Number(m[1]); }
-  return null;
+  const loose = playerJs.match(SIG_TS_LOOSE);
+  return loose ? Number(loose[1]) : null;
 }
 
 export async function fetchPlayerJs() {


### PR DESCRIPTION
## Summary

- Bumps the cipher submodule to the hardening branch (ZemerTeam/zemer-cipher#1): race/leak/clock-skew fixes and main-thread IO removal in the poToken + decipher pipeline. See that PR for the full changelog and validation.
- `tests/cipher.mjs`: `extractSignatureTimestamp` mirrors the new on-device precedence — the anchored `signatureTimestamp` literal from the player JS wins, config second, the false-match-prone loose `sts` pattern last. This also removes the harness's multi-hash config shadow (a wrong alias entry could previously return another build's sts).

## Validation

Cipher unit suite green (debug + release); app compiles and streams cleanly on-device with the bumped submodule (15/15 deciphers, zero failures — details in the cipher PR).

Merge ZemerTeam/zemer-cipher#1 first, then this (the pointer references that branch's head).