### PR TITLE
feat(24six): add trending cards with Supabase, YouTubeGridItem, and search-to-play click handler

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseModels.kt
@@ -1,0 +1,53 @@
+package com.jtech.zemer.supabase
+
+import com.metrolist.innertube.models.Artist
+import com.metrolist.innertube.models.SongItem
+import kotlinx.serialization.Serializable
+
+/**
+ * Raw Supabase response row for the 24six trending RPC.
+ */
+@Serializable
+data class TrendingWithComparisonRow(
+    val song_name: String,
+    val singer_name: String,
+    val thumbnail_url: String? = null,
+    val current_spot: Int? = null,
+    val previous_spot: Int? = null,
+    val scrape_time: String? = null,
+    val category: String,
+    val subcategory: String? = null,
+    val url: String? = null,
+)
+
+sealed interface SupabaseItem {
+    data class TrendingWithComparison(
+        val songName: String,
+        val singerName: String,
+        val thumbnailUrl: String?,
+        val currentSpot: Int?,
+        val previousSpot: Int?,
+        val category: String,
+        val subcategory: String?,
+        val url: String?,
+    ) : SupabaseItem
+}
+
+fun TrendingWithComparisonRow.toSupabaseItem() = SupabaseItem.TrendingWithComparison(
+    songName = song_name,
+    singerName = singer_name,
+    thumbnailUrl = thumbnail_url,
+    currentSpot = current_spot,
+    previousSpot = previous_spot,
+    category = category,
+    subcategory = subcategory,
+    url = url,
+)
+
+fun SupabaseItem.TrendingWithComparison.toSongItem() = SongItem(
+    id = "24six_${songName.hashCode().toLong().toString(16).replace("-", "0")}",
+    title = songName,
+    artists = listOf(Artist(name = singerName, id = null)),
+    thumbnail = thumbnailUrl ?: "",
+)
+

--- a/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseModule.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseModule.kt
@@ -1,0 +1,17 @@
+package com.jtech.zemer.supabase
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SupabaseModule {
+    @Provides
+    @Singleton
+    fun provideSupabaseRepository(): SupabaseRepository {
+        return SupabaseRepository()
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/supabase/SupabaseRepository.kt
@@ -1,0 +1,34 @@
+package com.jtech.zemer.supabase
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SupabaseRepository @Inject constructor() {
+    private val supabaseUrl = "https://aometextgaovquqcrrgv.supabase.co"
+    private val anonKey = "sb_publishable_9wr1SUVQ5sjPY9b-hZnBBQ_SXSvDw3V"
+
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                isLenient = true
+            })
+        }
+    }
+
+    suspend fun getTrendingWithComparison(): List<TrendingWithComparisonRow> {
+        return client.post("$supabaseUrl/rest/v1/rpc/get_trending_with_comparison") {
+            header("apikey", anonKey)
+            header("Authorization", "Bearer $anonKey")
+            contentType(ContentType.Application.Json)
+        }.body()
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -15,8 +18,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -95,9 +103,12 @@ import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.latestreleases.LatestReleaseCard
+import com.jtech.zemer.supabase.SupabaseItem
+import com.jtech.zemer.supabase.toSongItem
 import com.jtech.zemer.viewmodels.HomeViewModel
 import com.jtech.zemer.viewmodels.LatestReleasesViewModel
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
+import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
@@ -132,6 +143,7 @@ fun HomeScreen(
     val quickPicks = homeUiState.quickPicks
     val featuredPlaylists = homeUiState.featuredPlaylists
     val trendingSongs = homeUiState.trendingSongs
+    val trendingByCategory = homeUiState.trendingByCategory
     val forgottenFavorites = homeUiState.forgottenFavorites
     val keepListening = homeUiState.keepListening
     val featuredAlbums = homeUiState.featuredAlbums
@@ -445,6 +457,7 @@ fun HomeScreen(
                 featuredAlbums.isNotEmpty() ||
                 (!blockVideos && featuredVideos.isNotEmpty()) ||
                 trendingSongs.isNotEmpty() ||
+                trendingByCategory.isNotEmpty() ||
                 latestReleases.isNotEmpty() ||
                 zemerPlaylists.isNotEmpty()
         val shouldShowShimmer = isLoading || (!hasLocalHomeContent && !hasRemoteHomeContent)
@@ -836,6 +849,94 @@ fun HomeScreen(
                 }
             }
 
+            // 24six trending by category
+            fun play24six(item: SupabaseItem.TrendingWithComparison) {
+                scope.launch {
+                    val query = "${item.songName} ${item.singerName}"
+                    YouTube.search(query, YouTube.SearchFilter.FILTER_SONG).onSuccess { result ->
+                        val song = result.items.firstOrNull { it is SongItem } as? SongItem
+                        song?.let {
+                            playerConnection.playQueue(YouTubeQueue(
+                                it.endpoint ?: WatchEndpoint(videoId = it.id),
+                                preloadItem = null,
+                                database = database,
+                            ))
+                        }
+                    }
+                }
+            }
+
+            val supabaseCategoryFilter = mapOf(
+                "Trending" to "24six Trending",
+                "New Singles" to "24six New Music",
+            )
+            supabaseCategoryFilter.forEach { (rawCategory, displayName) ->
+                val items = trendingByCategory[rawCategory].orEmpty()
+                if (items.isEmpty()) return@forEach
+                item(key = "24six_${rawCategory}_title", contentType = "header") {
+                    NavigationTitle(
+                        title = displayName,
+                        modifier = Modifier.animateItem(),
+                    )
+                }
+                items.chunked(2).forEachIndexed { rowIndex, rowItems ->
+                    item(key = "24six_${rawCategory}_row_$rowIndex", contentType = "grid") {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp)
+                                .animateItem(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            rowItems.forEach { supaItem ->
+                                TrendingCategoryCard(
+                                    item = supaItem,
+                                    onClick = { play24six(supaItem) },
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                            if (rowItems.size < 2) {
+                                Spacer(Modifier.weight(1f))
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 24six Acapella (filtered across all categories)
+            val acapellaItems = trendingByCategory.values.flatten()
+                .filter { it.songName.contains("acapella", ignoreCase = true) }
+            if (acapellaItems.isNotEmpty()) {
+                item(key = "24six_Acapella_title", contentType = "header") {
+                    NavigationTitle(
+                        title = "24six Acapella",
+                        modifier = Modifier.animateItem(),
+                    )
+                }
+                acapellaItems.chunked(2).forEachIndexed { rowIndex, rowItems ->
+                    item(key = "24six_Acapella_row_$rowIndex", contentType = "grid") {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp)
+                                .animateItem(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            rowItems.forEach { supaItem ->
+                                TrendingCategoryCard(
+                                    item = supaItem,
+                                    onClick = { play24six(supaItem) },
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                            if (rowItems.size < 2) {
+                                Spacer(Modifier.weight(1f))
+                            }
+                        }
+                    }
+                }
+            }
+
             // Show featured artists
             if (featuredArtists.isNotEmpty()) {
                 item(key = "featured_artists_title", contentType = "header") {
@@ -975,4 +1076,20 @@ fun HomeScreen(
                 .padding(LocalPlayerAwareWindowInsets.current.asPaddingValues()),
         )
     }
+}
+
+@Composable
+private fun TrendingCategoryCard(
+    item: SupabaseItem.TrendingWithComparison,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val songItem = remember(item.songName, item.singerName) { item.toSongItem() }
+    YouTubeGridItem(
+        item = songItem,
+        modifier = modifier.combinedClickable(
+            onClick = onClick,
+            onLongClick = { },
+        ),
+    )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -20,6 +20,10 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toEnum
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.supabase.SupabaseItem
+import com.jtech.zemer.supabase.SupabaseRepository
+import com.jtech.zemer.supabase.TrendingWithComparisonRow
+import com.jtech.zemer.supabase.toSupabaseItem
 import com.jtech.zemer.utils.ContentWhitelistDoc
 import com.jtech.zemer.utils.IsraeliArtistRegistry
 import com.jtech.zemer.utils.ZemerContentClient
@@ -64,6 +68,7 @@ class HomeViewModel @Inject constructor(
     @ApplicationContext val context: Context,
     val database: MusicDatabase,
     val syncUtils: SyncUtils,
+    private val supabaseRepository: SupabaseRepository,
 ) : ViewModel() {
     private data class HomeArtistProfile(
         val id: String,
@@ -84,6 +89,7 @@ class HomeViewModel @Inject constructor(
         val quickPicks: List<Song> = emptyList(),
         val featuredPlaylists: List<PlaylistItem> = emptyList(),
         val trendingSongs: List<SongItem> = emptyList(),
+        val trendingByCategory: Map<String, List<SupabaseItem.TrendingWithComparison>> = emptyMap(),
         val keepListening: List<LocalItem> = emptyList(),
         val forgottenFavorites: List<Song> = emptyList(),
         val featuredAlbums: List<AlbumItem> = emptyList(),
@@ -1009,6 +1015,18 @@ class HomeViewModel @Inject constructor(
             // Now start NETWORK calls (after prep work is done)
             Timber.d("HomeViewModel: Starting NETWORK fetch at +${System.currentTimeMillis() - loadStartTime}ms")
             val trendingDeferred = viewModelScope.async(Dispatchers.IO) { loadTrendingSongs(effectiveFilters, hideExplicit) }
+            val supabaseTrendingDeferred = viewModelScope.async(Dispatchers.IO) {
+                try {
+                    supabaseRepository.getTrendingWithComparison()
+                        .groupBy<TrendingWithComparisonRow, String> { it.category }
+                        .mapValues { (_: String, rows: List<TrendingWithComparisonRow>) ->
+                            rows.map { it.toSupabaseItem() }
+                        }
+                } catch (e: Exception) {
+                    Timber.w("24six trending fetch failed: ${e.message}")
+                    emptyMap()
+                }
+            }
             val homeDeferred = viewModelScope.async(Dispatchers.IO) {
                 if (useWhitelist) {
                     loadWhitelistHome(
@@ -1041,6 +1059,7 @@ class HomeViewModel @Inject constructor(
             }
 
             val trendingSongs = trendingDeferred.await()
+            val trendingByCategory = supabaseTrendingDeferred.await()
             val home = homeDeferred.await()
             val explore = exploreDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
@@ -1309,6 +1328,7 @@ class HomeViewModel @Inject constructor(
                     isNewUser = isNewUser,
                     quickPicks = finalQuick.shuffled(Random(System.nanoTime())),
                     trendingSongs = finalTrending,
+                    trendingByCategory = trendingByCategory,
                     featuredPlaylists = finalFeaturedPlaylists,
                     keepListening = finalKeepListening,
                     forgottenFavorites = finalForgotten,


### PR DESCRIPTION
Adds 24six trending section to HomeScreen:\n- Supabase client + repository for fetching trending data\n- TrendingCategoryCard using YouTubeGridItem for consistent look with other HomeScreen cards\n- Search-to-play click handler (YouTube search → playQueue)\n- Category filter (Trending, New Singles, Acapella)\n\nPart of the 24six integration feature.