### PR TITLE
fix(nav): prevent Home tab from being ignored after search

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -903,6 +903,9 @@ class MainActivity : ComponentActivity() {
                         { searchQuery ->
                             if (searchQuery.isNotEmpty()) {
                                 onActiveChange(false)
+                                if (navController.currentDestination?.route?.startsWith("search/") == true) {
+                                    navController.popBackStack()
+                                }
                                 navController.navigate("search/${URLEncoder.encode(searchQuery, "UTF-8")}")
 
                                 if (dataStore[PauseSearchHistoryKey] != true) {
@@ -1300,12 +1303,13 @@ class MainActivity : ComponentActivity() {
                                                         searchBarScrollBehavior.state.resetHeightOffset()
                                                     }
                                                 } else {
+                                                    val isStartDest = screen.route == navController.graph.startDestinationRoute
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
                                                             saveState = true
                                                         }
                                                         launchSingleTop = true
-                                                        restoreState = true
+                                                        restoreState = !isStartDest
                                                     }
                                                 }
                                             },
@@ -1340,7 +1344,7 @@ class MainActivity : ComponentActivity() {
                                         navController.navigate(Screens.Home.route) {
                                             popUpTo(navController.graph.startDestinationId) { saveState = true }
                                             launchSingleTop = true
-                                            restoreState = true
+                                            restoreState = Screens.Home.route != navController.graph.startDestinationRoute
                                         }
                                         navController.getBackStackEntry(Screens.Home.route)
                                             .savedStateHandle["shuffleNow"] = true
@@ -1677,18 +1681,7 @@ class MainActivity : ComponentActivity() {
                                             query = query.text,
                                             onQueryChange = onQueryChange,
                                             navController = navController,
-                                            onSearch = { searchQuery ->
-                                                navController.navigate(
-                                                    "search/${URLEncoder.encode(searchQuery, "UTF-8")}"
-                                                )
-                                                if (dataStore[PauseSearchHistoryKey] != true) {
-                                                    lifecycleScope.launch(Dispatchers.IO) {
-                                                        database.query {
-                                                            insert(SearchHistory(query = searchQuery))
-                                                        }
-                                                    }
-                                                }
-                                            },
+                                            onSearch = onSearch,
                                             onDismiss = { onActiveChange(false) },
                                             pureBlack = pureBlack,
                                             firstResultFocusRequester = searchResultsFocusRequester,
@@ -1775,12 +1768,13 @@ class MainActivity : ComponentActivity() {
                                                 if (screen.route == Screens.Search.route) {
                                                     onActiveChange(true)
                                                 } else {
+                                                    val isStartDest = screen.route == navController.graph.startDestinationRoute
                                                     navController.navigate(screen.route) {
                                                         popUpTo(navController.graph.startDestinationId) {
                                                             saveState = true
                                                         }
                                                         launchSingleTop = true
-                                                        restoreState = true
+                                                        restoreState = !isStartDest
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
## Summary

- **Home tab ignored after search**: In a flat nav graph, `popUpTo(startDestinationId) { saveState = true }` + `restoreState = true` creates a save/restore key collision when the navigate target IS the start destination — the popped entries get saved and immediately restored, making the tap a no-op. Fixed by disabling `restoreState` when navigating to the start destination (bottom nav, drawer tabs, drawer shuffle).
- **Search results stacking on back stack**: Consecutive searches pushed new entries without popping the old one, so pressing back walked through every previous query. Now pops the current search result before navigating to the new one.
- **Suggestion/history tap path missed**: `OnlineSearchScreen`'s `onSearch` was a separate inline lambda that didn't get the popBackStack fix. Unified it with the shared `onSearch` handler.

## Test plan

- [ ] Search for something, tap Home tab — should navigate to Home (was ignored before)
- [ ] Search, switch to Artists, then tap Home — should go to Home (was going back to search)
- [ ] Search for "foo", then search for "bar" — pressing back should go to Home, not to "foo" results
- [ ] Tap a search suggestion/history item while on search results — should replace, not stack
- [ ] Switch between Artists/Library tabs — scroll position should be preserved
- [ ] Verify drawer tab switching works identically to bottom nav

Navigation integration tests require Compose test infrastructure (`ComposeTestRule` + `TestNavHostController`) the project doesn't have; no existing navigation tests to build on.

Fixes #178