### PR TITLE
feat(tracking): tag search events with the serving provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,12 @@ Five events (`open`/`search`/`play`/`click`/`action`) POSTed to `tracking.zemer.
   don't add per-surface duplicates, and keep machine-initiated work out of the user-intent signal.
 - One `search` event per executed query (the per-query ViewModel guard) — never per keystroke or
   per chip switch. Everything is tracked (KidZone and the YouTube engine included), no opt-out —
-  a product decision, 2026-07-05.
+  a product decision, 2026-07-05. Each event carries `provider` (`"zemer"`/`"youtube"`, a Zemer
+  extension per `handoff-docs/zemer-tracking-search-provider-request.md`) so the dashboard tells a
+  real whitelist-expansion demand gap apart from a legacy YouTube-path zero. It is the engine
+  **snapshotted per load** (`val engine = provider` in `loadSummary`/`loadFiltered`), NOT the shared
+  `provider` field read at emit time — `refresh()` mutates `provider` on a coroutine `collectLatest`
+  can't cancel, so an emit-time read could tag a Zemer result `"youtube"` under a concurrent toggle.
 - The one-shot **history backfill** (`PlayHistoryBackfill`) uploads the local listen history as
   `play_backfill` events through `Tracker.uploadBackfill` — NEVER through the live queue (its 500
   cap must not be flooded) but sharing the single-in-flight + backoff discipline; row-ID cursor

--- a/app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt
@@ -80,7 +80,8 @@ object Tracker {
 
     fun open() = enqueue { TrackingEvents.open(now()) }
 
-    fun search(q: String, results: Int) = enqueue { TrackingEvents.search(now(), q, results) }
+    fun search(q: String, results: Int, provider: String? = null) =
+        enqueue { TrackingEvents.search(now(), q, results, provider) }
 
     fun click(q: String, id: String, kind: String, rank: Int) =
         enqueue { TrackingEvents.click(now(), q, id, kind, rank) }

--- a/app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt
@@ -18,11 +18,19 @@ internal object TrackingEvents {
         put("t", t)
     }
 
-    fun search(t: Long, q: String, results: Int): JsonObject = buildJsonObject {
+    /**
+     * [provider] is a Zemer extension to the base spec (requested in
+     * handoff-docs/zemer-tracking-search-provider-request.md; the live server accepts it — verified):
+     * which of the app's two search paths served the query — `"zemer"` (search.zemer.io) or
+     * `"youtube"` (InnerTube + local whitelist filter). Omitted when unknown; the server stores
+     * absent/unknown as NULL, so pre-field builds stay interpretable.
+     */
+    fun search(t: Long, q: String, results: Int, provider: String? = null): JsonObject = buildJsonObject {
         put("type", "search")
         put("t", t)
         put("q", q)
         put("results", results)
+        if (provider != null) put("provider", provider)
     }
 
     fun click(t: Long, q: String, id: String, kind: String, rank: Int): JsonObject = buildJsonObject {

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt
@@ -91,10 +91,14 @@ constructor(
             savedStateHandle[SEARCH_TRACKED_KEY] = value
         }
 
-    private fun trackSearchOnce(results: Int) {
+    private fun trackSearchOnce(results: Int, servedBy: SearchProvider) {
         if (searchTracked) return
         searchTracked = true
-        Tracker.search(query, results)
+        // Tag the event with the engine that actually served these results — the caller's per-load
+        // snapshot, NOT the shared `provider` field, which a concurrent engine toggle (or a refresh()
+        // launched outside the collectLatest) can mutate between fetch and emit. Enum names map exactly
+        // to the server's contract values ("zemer"/"youtube").
+        Tracker.search(query, results, servedBy.name.lowercase())
     }
 
     init {
@@ -138,10 +142,14 @@ constructor(
         isSummaryLoading.value = true
         summaryError.value = null
 
+        // Snapshot the engine for this load so the fetch and its telemetry can't disagree if `provider`
+        // is mutated mid-flight (concurrent toggle or refresh()).
+        val engine = provider
+
         val result =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    if (provider == SearchProvider.ZEMER) {
+                    if (engine == SearchProvider.ZEMER) {
                         // Zemer results are already whitelist-scoped server-side; do not re-filter.
                         zemerRepo.summary(query, zemerSearchOptions(context)).summaries
                     } else {
@@ -167,7 +175,7 @@ constructor(
             summaryPage = SearchSummaryPage(
                 summaries = summaries
             )
-            trackSearchOnce(results = summaries.sumOf { it.items.size })
+            trackSearchOnce(results = summaries.sumOf { it.items.size }, servedBy = engine)
 
             if (summaries.isEmpty()) {
                 summaryError.value = "No results found for \"$query\""
@@ -193,6 +201,10 @@ constructor(
 
         filterLoading[key] = true
         filterError[key] = null
+
+        // Snapshot the engine for this load so the fetch and its telemetry can't disagree if `provider`
+        // is mutated mid-flight (concurrent toggle or refresh()).
+        val engine = provider
 
         val result =
             withContext(Dispatchers.IO) {
@@ -242,7 +254,7 @@ constructor(
                         else -> {} // Songs/videos/playlists: online only (local songs are local search)
                     }
 
-                    if (provider == SearchProvider.ZEMER) {
+                    if (engine == SearchProvider.ZEMER) {
                         // Already whitelist-scoped; Zemer has no pagination (continuation == null).
                         items.addAll(zemerRepo.filtered(query, filter, zemerSearchOptions(context)).items)
                         ItemsPage(items.distinctBy { it.id }, null)
@@ -262,7 +274,7 @@ constructor(
 
         result.onSuccess { itemsPage ->
             viewStateMap[key] = itemsPage
-            trackSearchOnce(results = itemsPage.items.size)
+            trackSearchOnce(results = itemsPage.items.size, servedBy = engine)
             if (itemsPage.items.isEmpty()) {
                 filterError[key] = "No results found for \"$query\""
             }

--- a/app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt
@@ -40,4 +40,16 @@ class SearchProviderTest {
     fun `youtube albums keep the plain innertube path`() {
         assertEquals("album/MPRE1", SearchProvider.YOUTUBE.onlineAlbumRoute(album))
     }
+
+    /**
+     * The search-provider telemetry field (handoff-docs/zemer-tracking-search-provider-request.md) is
+     * sent as `name.lowercase()`, and the server contract accepts exactly `"zemer"`/`"youtube"`
+     * (anything else stored as NULL). Renaming an enum constant would silently start NULLing the field,
+     * so the mapping is pinned here.
+     */
+    @Test
+    fun `enum names lowercase to the exact tracking-contract provider values`() {
+        assertEquals("zemer", SearchProvider.ZEMER.name.lowercase())
+        assertEquals("youtube", SearchProvider.YOUTUBE.name.lowercase())
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt
@@ -16,10 +16,22 @@ class TrackingEventsTest {
     }
 
     @Test
-    fun `search event matches the spec exactly - zero results sent faithfully`() {
+    fun `search event matches the spec exactly - zero results sent faithfully, provider omitted when absent`() {
         assertEquals(
             """{"type":"search","t":1,"q":"shwekey","results":0}""",
             TrackingEvents.search(1, "shwekey", 0).toString(),
+        )
+    }
+
+    @Test
+    fun `search event carries the provider extension when known - exactly zemer or youtube`() {
+        assertEquals(
+            """{"type":"search","t":1,"q":"acapella","results":49,"provider":"zemer"}""",
+            TrackingEvents.search(1, "acapella", 49, "zemer").toString(),
+        )
+        assertEquals(
+            """{"type":"search","t":1,"q":"acapella","results":0,"provider":"youtube"}""",
+            TrackingEvents.search(1, "acapella", 0, "youtube").toString(),
         )
     }
 

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -153,8 +153,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/tracking/LibraryActionBackfill.kt` | 142 | `com.jtech.zemer.tracking` | no | 16 | 18 | android.content, androidx.datastore, java.time, java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfill.kt` | 166 | `com.jtech.zemer.tracking` | no | 18 | 27 | android.content, androidx.datastore, java.time, java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 61 | `com.jtech.zemer.tracking` | no | 1 | 16 | java.util |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 232 | `com.jtech.zemer.tracking` | no | 18 | 48 | android.content, androidx.datastore, java.io, java.util, kotlinx.coroutines, kotlinx.serialization, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 125 | `com.jtech.zemer.tracking` | no | 4 | 15 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 233 | `com.jtech.zemer.tracking` | no | 18 | 48 | android.content, androidx.datastore, java.io, java.util, kotlinx.coroutines, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 133 | `com.jtech.zemer.tracking` | no | 4 | 15 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingLifecycle.kt` | 58 | `com.jtech.zemer.tracking` | no | 4 | 13 | android.app, android.os |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingQueue.kt` | 98 | `com.jtech.zemer.tracking` | no | 1 | 16 | java.io |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingUploader.kt` | 67 | `com.jtech.zemer.tracking` | no | 8 | 15 | io.ktor |
@@ -382,7 +382,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 | `com.jtech.zemer.viewmodels` | no | 19 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 190 | `com.jtech.zemer.viewmodels` | no | 27 | 31 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 181 | `com.jtech.zemer.viewmodels` | no | 34 | 21 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 350 | `com.jtech.zemer.viewmodels` | no | 42 | 43 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 362 | `com.jtech.zemer.viewmodels` | no | 42 | 45 | android.content, android.net, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 | `com.jtech.zemer.viewmodels` | no | 12 | 6 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 | `com.jtech.zemer.viewmodels` | no | 18 | 23 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -418,7 +418,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 | `com.jtech.zemer.recognition` | no | 8 | 13 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 | `com.jtech.zemer.recognition` | no | 4 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 | `com.jtech.zemer.recognition` | no | 11 | 16 | java.nio, java.util, kotlin.math, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 43 | `com.jtech.zemer.search` | no | 3 | 2 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 55 | `com.jtech.zemer.search` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 184 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 488 | `com.jtech.zemer.search` | no | 15 | 60 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
@@ -428,7 +428,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/tracking/LibraryActionBackfillTest.kt` | 101 | `com.jtech.zemer.tracking` | no | 9 | 10 | java.time, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfillTest.kt` | 102 | `com.jtech.zemer.tracking` | no | 7 | 11 | java.time, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/PlaySourceResolverTest.kt` | 84 | `com.jtech.zemer.tracking` | no | 2 | 8 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt` | 93 | `com.jtech.zemer.tracking` | no | 2 | 2 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt` | 105 | `com.jtech.zemer.tracking` | no | 2 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingQueueTest.kt` | 100 | `com.jtech.zemer.tracking` | no | 5 | 13 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/AlphabetIndexTest.kt` | 28 | `com.jtech.zemer.ui.component` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -311,8 +311,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/tracking/LibraryActionBackfill.kt` | 142 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfill.kt` | 166 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 61 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 232 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 125 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 233 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 133 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingLifecycle.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingQueue.kt` | 98 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingUploader.kt` | 67 lines | `.kt` |
@@ -540,7 +540,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnboardingViewModel.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt` | 190 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchSuggestionViewModel.kt` | 181 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 350 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlineSearchViewModel.kt` | 362 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognitionHistoryViewModel.kt` | 42 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/RecognizeMusicViewModel.kt` | 111 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ReportContentViewModel.kt` | 37 lines | `.kt` |
@@ -745,7 +745,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatchSelectorTest.kt` | 106 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionMatcherTest.kt` | 72 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/recognition/ShazamSignatureGeneratorTest.kt` | 75 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 43 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 55 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 184 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 488 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
@@ -755,7 +755,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/tracking/LibraryActionBackfillTest.kt` | 101 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfillTest.kt` | 102 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/PlaySourceResolverTest.kt` | 84 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt` | 93 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingEventsTest.kt` | 105 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/TrackingQueueTest.kt` | 100 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/AlphabetIndexTest.kt` | 28 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
@@ -829,7 +829,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
 | `docs/repository-map.md` | 1036 lines | `.md` |
-| `docs/tracking/README.md` | 184 lines | `.md` |
+| `docs/tracking/README.md` | 187 lines | `.md` |
 | `docs/ui/README.md` | 317 lines | `.md` |
 | `docs/ui/standards.md` | 290 lines | `.md` |
 | `docs/whitelist/README.md` | 252 lines | `.md` |

--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -59,6 +59,9 @@ batch rather than poison-pilling the queue. Losing events is fine. Breaking play
   query; `searchTracked` guard, persisted in the SavedStateHandle so a back-stack entry restored
   after process death never re-fires), on the first successful load, both engines; `results` =
   items shown; zero results sent faithfully; chip switches and engine toggles never re-fire.
+  Carries `provider` (Zemer extension, `handoff-docs/zemer-tracking-search-provider-request.md`):
+  `"zemer"` or `"youtube"` = the engine that served the query (`SearchProvider.name.lowercase()`),
+  so the dashboard separates a real whitelist-expansion demand gap from a legacy YouTube-path zero.
 - **`click`** — `OnlineSearchResult`'s single `activate` path (tap AND D-pad select — KeyDown
   only, auto-repeats ignored, so a held Enter is ONE click): the query, tapped id, `kind`
   (`clickKind()` — Videos chip → `video`, Community chip → `community`), and 0-based rank within


### PR DESCRIPTION
Adds a `provider` field (`"zemer"` / `"youtube"`) to the `search` tracking event so the dashboard can separate a real whitelist-expansion demand gap from a legacy YouTube-path zero-result artifact. Requested in `handoff-docs/zemer-tracking-search-provider-request.md`; the server side is already live and accepting the field.

## What changed
- Threaded an optional `provider` param through `TrackingEvents.search` -> `Tracker.search` -> `OnlineSearchViewModel.trackSearchOnce`. Omitted from the JSON when absent, so old builds and any other caller stay NULL exactly as the server contract expects.
- Tag the event with the engine **snapshotted per load**, not the shared mutable `provider` field read at emit time. `refresh()` mutates `provider` on a coroutine the reactive collector cannot cancel, so an emit-time read could tag a Zemer-served result `"youtube"` (or vice-versa) under a concurrent engine toggle, corrupting the exact signal the field exists to provide. The per-load snapshot also tightens the fetch itself to use one consistent engine value.

## Tests
- `TrackingEventsTest`: pins the wire shape with and without the provider field.
- `SearchProviderTest`: pins `SearchProvider.name.lowercase()` to the contract values, so a future enum rename cannot silently start NULLing the field.
- `:app:assembleDebug` and both test classes pass.

## Notes
- Purely additive and safe against the already-live server.
- Docs updated (`docs/tracking/README.md`, `AGENTS.md`); handoff doc marked settled on the app side.