### PR TITLE
fix(login): generous timeout for anonymous credential fetch (#284)

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt
@@ -46,9 +46,9 @@ import com.jtech.zemer.constants.VisitorDataKey
 import com.jtech.zemer.utils.rememberPreference
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.utils.parseCookieString
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import com.jtech.zemer.utils.AnonymousAuthClient
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -154,7 +154,7 @@ fun LoginGateScreen(
                         isAnonymousLoading = true
                         coroutineScope.launch {
                             try {
-                                val httpClient = HttpClient()
+                                val httpClient = AnonymousAuthClient.create()
                                 val responseText = httpClient.get(
                                     "https://mc.alltech.dev/credentials"
                                 ).bodyAsText()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AccountSettings.kt
@@ -31,9 +31,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
-import io.ktor.client.HttpClient
 import io.ktor.client.statement.bodyAsText
 import io.ktor.client.request.get
+import com.jtech.zemer.utils.AnonymousAuthClient
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import android.widget.Toast
@@ -202,7 +202,7 @@ fun AccountSettings(
                     tokenTestResult = null
                     scope.launch {
                         try {
-                            val httpClient = HttpClient()
+                            val httpClient = AnonymousAuthClient.create()
                             val responseText = httpClient.get(
                                 "https://mc.alltech.dev/credentials"
                             ).bodyAsText()

--- a/app/src/main/kotlin/com/jtech/zemer/utils/AnonymousAuthClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/AnonymousAuthClient.kt
@@ -1,0 +1,34 @@
+package com.jtech.zemer.utils
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+
+/**
+ * HTTP client for the anonymous ("pooled account") credential fetch used by the login gate and the
+ * Account settings screen.
+ *
+ * A bare `HttpClient()` relies on the engine's short default timeout (~5-15 s), which fails on slow
+ * or spotty connections — issue #284: the anonymous login "times out too soon" for a user on poor
+ * service. This installs deliberately generous timeouts so the one-shot credential GET has time to
+ * complete before giving up. The credential endpoint returns a small JSON payload, so a long ceiling
+ * costs nothing on a healthy connection (the request finishes as soon as the body arrives) while
+ * giving a weak connection room to succeed.
+ */
+object AnonymousAuthClient {
+    /** Time allowed to establish the TCP/TLS connection. */
+    const val CONNECT_TIMEOUT_MS = 30_000L
+
+    /** Overall ceiling for the whole request/response. */
+    const val REQUEST_TIMEOUT_MS = 60_000L
+
+    /** Max idle time between data packets once connected. */
+    const val SOCKET_TIMEOUT_MS = 60_000L
+
+    fun create(): HttpClient = HttpClient {
+        install(HttpTimeout) {
+            connectTimeoutMillis = CONNECT_TIMEOUT_MS
+            requestTimeoutMillis = REQUEST_TIMEOUT_MS
+            socketTimeoutMillis = SOCKET_TIMEOUT_MS
+        }
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/AnonymousAuthClientTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/AnonymousAuthClientTest.kt
@@ -1,0 +1,40 @@
+package com.jtech.zemer.utils
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression guard for issue #284 ("anonymous login times out too soon"). The anonymous credential
+ * fetch used to run on a bare `HttpClient()` whose engine default timeout (~5-15 s) was too short for
+ * users on slow/spotty service. These bounds keep the ceilings generous so the guard fails loudly if
+ * someone shrinks them back toward the old defaults.
+ *
+ * The live network + Compose path itself is not JVM-unit-testable (the project has no Robolectric), so
+ * this guards the intent — the tuned timeout constants — rather than the request.
+ */
+class AnonymousAuthClientTest {
+
+    @Test
+    fun `request timeout is generous enough for slow connections`() {
+        assertTrue(
+            "request timeout must stay well above the old ~15s engine default",
+            AnonymousAuthClient.REQUEST_TIMEOUT_MS >= 60_000L
+        )
+    }
+
+    @Test
+    fun `connect timeout is generous enough for slow connections`() {
+        assertTrue(
+            "connect timeout must stay well above the old ~5-10s engine default",
+            AnonymousAuthClient.CONNECT_TIMEOUT_MS >= 30_000L
+        )
+    }
+
+    @Test
+    fun `socket timeout is generous enough for slow connections`() {
+        assertTrue(
+            "socket timeout must stay generous for weak connections",
+            AnonymousAuthClient.SOCKET_TIMEOUT_MS >= 60_000L
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Reported in #284: on a slow/spotty connection the **anonymous ("pooled account") login times out too soon** — the user "needs more time to log in."

## Cause

Both anonymous-login call sites fetched credentials on a **bare `HttpClient()`**, which relies on the engine's short default timeout (~5–15s). On a weak connection that GET to the credential endpoint doesn't finish in time, the `catch` fires, and the user sees a timeout/login-failed toast.

```kotlin
val httpClient = HttpClient()                                  // no timeout configured
httpClient.get("https://mc.alltech.dev/credentials").bodyAsText()
```

## Fix

Route both live call sites through a small shared `AnonymousAuthClient` that installs generous `HttpTimeout` bounds (30s connect, 60s request/socket). A long ceiling costs nothing on a healthy connection — the request completes the moment the small JSON body arrives — while giving a weak connection room to succeed.

- `utils/AnonymousAuthClient.kt` — new single-purpose factory (uses the same `HttpTimeout` idiom already in `utils/ZemerContentClient.kt`).
- `ui/screens/LoginGateScreen.kt` and `ui/screens/settings/AccountSettings.kt` — swap `HttpClient()` → `AnonymousAuthClient.create()` (dedupes the two near-identical bare clients).

## Tests

`AnonymousAuthClientTest` guards the tuned timeout constants so nobody shrinks them back toward the old defaults. The live network + Compose path isn't JVM-unit-testable here (no Robolectric in this project), so the test guards the intent rather than the request.

`:app:testDebugUnitTest` (new test) and `:app:assembleDebug` both pass locally.

## Notes / scope

- Deliberately **did not touch** `isInternetConnected()` (the separate onboarding pre-flight net check) — a past change there was reverted, and the evidence (a timeout toast with a reason string) points at the HTTP GET, not that boolean gate.
- There is a **third, dead copy** of this bare-client pattern in `App.kt` `fetchAnonymousTokenOnStartup()` (auto-fetch was removed; nothing calls it). Left out of scope to keep the diff focused; can route it too if you'd like.
- A **Retry** affordance would add resilience beyond a longer timeout — happy to follow up if wanted.

Fixes #284
