### PR TITLE
Home tab: telemetry-ranked, zero-InnerTube rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,11 +111,62 @@ full detail in `docs/zemer_playlists/README.md`. The rules that must not regress
   is backed by its own `ZemerCuratedPlaylistsViewModel` (LatestReleases isolation pattern) so a feed
   failure can never affect the rest of Home.
 - The detail screen's **All/Albums/Songs chips reuse `LatestReleaseFilter`** and split on the
-  server's `fromAlbum`/`albums` fields (both optional — an old server just empties the Albums chip).
-  Rows, Play and Shuffle all read the same filtered list; rows never pass `albumIndex` (the shared
-  row renders a number *instead of* artwork).
+  server's `fromAlbum`/`albums` fields. The **chip row shows ONLY when the playlist has albums**
+  (`curatedChipsVisible(albumCount)`, unit-tested): a direct-picks playlist has no albums, so All ==
+  Songs and Albums is an empty dead end — those render the plain track list instead. `effectiveFilter`
+  pins the filter to ALL whenever the chips are hidden. Rows, Play and Shuffle all read the same
+  filtered list; rows never pass `albumIndex` (the shared row renders a number *instead of* artwork).
 - App↔server field changes travel as request docs in `~/zemer-fix/handoff-docs/`, never as direct
   edits to the zemer-search repo.
+
+### The home tab (telemetry-ranked rows; zero-InnerTube for content)
+
+`HomeViewModel` + `HomeScreen`. The home tab is **InnerTube-free for content** — every row is served
+from the Zemer `/home-rows` endpoint, local Room, or the flipphoneguy Latest-Releases feed. The **only**
+`YouTube.*` call left in `HomeViewModel` is the account-card identity lookup (`accountInfo()` for a
+signed-in user's name/avatar); do not add others. Full detail in `docs/home_rows/README.md`.
+
+**Project direction (a real, ongoing goal):** progressively **replace as much InnerTube as we can across
+the app** with Zemer-served, whitelist-pure data. The home tab is the first surface fully migrated — treat
+it as the template. When you touch any surface that reaches YouTube for *discovery* content (home/explore
+feeds, charts, recommendations, related, browse shelves, search-adjacent rows), prefer a Zemer endpoint —
+or a handoff request for one (`~/zemer-fix/handoff-docs/`) — over deepening the InnerTube dependency, and
+delete the InnerTube path once the Zemer source lands. **Streaming/playback itself still needs InnerTube +
+the cipher** (see §The streaming pipeline — that's the irreducible core) and is out of scope; this goal is
+about *content discovery*, where YouTube's global feeds carry almost no kosher content anyway.
+
+Rules that must not regress:
+
+- **Featured Albums / Videos / Artists / Playlists come solely from `ZemerSearchRepository.homeRows()`**
+  (`GET /home-rows`, mapped by `ZemerResultMapper.homeRows()` → `HomeRows`). Ranked by real
+  distinct-device listening (albums/videos/artists) and YouTube view count (community playlists =
+  Featured Playlists row), 30-day live window, whitelist-pure + content-filtered server-side. There is
+  **no InnerTube scrape fallback** — an empty pool (only if search.zemer.io is unreachable) just hides
+  the row. `loadHomeRows()` returning null hides all four featured rows; it never breaks Home.
+- **The ranked content gate is female/israeli/blocked-ids ONLY — NOT the famous/american quality
+  proxy** (`isAllowedRanked`, distinct from `isBlockedArtist`). Real listening reach supersedes the
+  proxy that gates the (now-removed) scrape; applying famous/american here cut the rows to near-empty.
+  Cards carry the artist channel id (`ZemerAlbum/Track.artistId`, `ZemerArtist.id`) so the one-per-artist
+  `rotateByArtist` dedup and the female/israeli check work; without it both no-op.
+- **Zemer-sourced albums/playlists open via the server route** (`onlineAlbumRoute` / `onlinePlaylistRoute`,
+  `?zemer=true`), gated on `featuredAlbumsAreZemer` / `featuredPlaylistsAreZemer`, so the opened screen
+  is whitelist-scoped and immune to on-device InnerTube bot-gating. Telemetry artist cards carry no radio
+  endpoint, so they are kept OUT of the lucky-shuffle pool (`radioEndpoint != null` filter) — a lucky
+  pick must never dead-press.
+- **A brand-new user's empty Quick Picks seeds from Zemer**, not YouTube: `seedQuickPicksFromZemer`
+  pulls the `auto-top-50` curated playlist. Returning users seed from local history; the seed is a no-op
+  when Quick Picks is non-empty and never breaks Home on failure.
+- **Every content row has a "See all" arrow** → `home_see_all/{row}` (`HomeSeeAllRow`). The pages read a
+  process-wide `HomeSeeAllStore` snapshot that `HomeViewModel` publishes each load (the FULL, un-rotated
+  filtered pool), so See-all can never disagree with the row it opened from — no re-fetch, no re-filter.
+  Featured grids are 2-column (long Hebrew+English titles truncate at 3). Latest Releases / Zemer
+  Playlists keep their own see-all screens + ViewModels.
+- **The mainstream Trending row is gone** — `YouTube.getChartsPage()` charts carry ~no whitelisted
+  artists (it filtered to empty and never displayed); the `auto-trending` / `auto-top-50` Zemer playlists
+  in the Zemer-Playlists shelf are the real trending/top surface. Don't reintroduce a charts-scraped row.
+- The `/home-rows` contract and every design decision are recorded in
+  `~/zemer-fix/handoff-docs/zemer-app-home-rows-request.md` (the app↔server thread) and
+  `home-rows-plan.md`. App↔server field changes travel there, never as edits to the zemer-search repo.
 
 ### Tracking (anonymous usage telemetry)
 

--- a/app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt
@@ -19,10 +19,16 @@ enum class SearchProvider {
 /**
  * The `online_playlist` nav route for a playlist opened from a search result. Zemer-sourced playlists
  * carry `?zemer=true` so the screen opens them through the server's `/playlist` endpoint (tracks/count/
- * cover match the search card); YouTube-sourced playlists keep the plain InnerTube path.
+ * cover match the search card); YouTube-sourced playlists keep the plain InnerTube path. [community] adds
+ * `&community=true` so the opened screen tags plays `community:<id>` (the discovery-sourced community
+ * lists — the home "Community playlists" row and the search Community chip) instead of `playlist:<id>`.
  */
-fun SearchProvider.onlinePlaylistRoute(playlistId: String): String =
-    if (this == SearchProvider.ZEMER) "online_playlist/$playlistId?zemer=true" else "online_playlist/$playlistId"
+fun SearchProvider.onlinePlaylistRoute(playlistId: String, community: Boolean = false): String =
+    if (this == SearchProvider.ZEMER) {
+        "online_playlist/$playlistId?zemer=true" + if (community) "&community=true" else ""
+    } else {
+        "online_playlist/$playlistId"
+    }
 
 /**
  * The `album` nav route for an album opened from a search result. Zemer-sourced albums carry

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -51,8 +51,10 @@ object ZemerResultMapper {
     fun ZemerTrack.toSongItem(): SongItem =
         SongItem(
             id = videoId,
+            // `artistId` is present on /home-rows video cards (null elsewhere) so the artist carries a
+            // real channel id — required for the home one-per-artist dedup + female/israeli check.
+            artists = listOf(Artist(name = artist, id = artistId)),
             title = title,
-            artists = listOf(Artist(name = artist, id = null)),
             album = null,
             // Present on /album and /zemer-playlists tracks; the search categories send none.
             duration = durationSec,
@@ -76,9 +78,11 @@ object ZemerResultMapper {
             browseId = id,
             playlistId = playlistId ?: id,
             title = title,
-            artists = if (artist.isBlank()) null else listOf(Artist(name = artist, id = null)),
+            // `artistId` present on /home-rows album cards (null elsewhere) — see [toSongItem].
+            artists = if (artist.isBlank()) null else listOf(Artist(name = artist, id = artistId)),
             year = year,
             thumbnail = thumbnail.orEmpty(),
+            explicit = explicit,
         )
 
     fun ZemerPlaylist.toPlaylistItem(formatSongCount: (Int) -> String?): PlaylistItem =
@@ -138,6 +142,38 @@ object ZemerResultMapper {
     /** Shared playlist adaptation — used for both the artist-owned `playlists` and the `community` lists. */
     private fun playlistItems(playlists: List<ZemerPlaylist>, formatSongCount: (Int) -> String?): List<PlaylistItem> =
         playlists.filter { it.id.isNotBlank() }.map { it.toPlaylistItem(formatSongCount) }.distinctBy { it.id }.dropBlocked()
+
+    /**
+     * The telemetry-ranked home rows as the app's native item types, in the server's ranked order.
+     * Each list is dropped of missing/duplicate ids and passed through [dropBlocked] (the surgical
+     * id-overrides), and `hideExplicit` is applied to albums + videos client-side (an artist is never
+     * explicit). The artist-membership whitelist is NOT re-run — these are whitelist-pure server-side,
+     * same convention as every other Zemer surface — but each card now carries its artist channel id
+     * ([ZemerAlbum.artistId]/[ZemerTrack.artistId]/[ZemerArtist.id]) so the caller can still run the
+     * home one-per-artist dedup and its female/israeli defence-in-depth. `topCommunity` is intentionally
+     * dropped here: it maps to [PlaylistItem]s the caller renders in the featured-playlists row, but that
+     * row is not wired to `/home-rows` yet, so exposing it would be dead. See [HomeRows].
+     */
+    fun homeRows(resp: ZemerHomeRowsResponse, hideExplicit: Boolean): HomeRows =
+        HomeRows(
+            albums = resp.topAlbums.filter { it.id.isNotBlank() }
+                .map { it.toAlbumItem() }
+                .filterExplicit(hideExplicit)
+                .distinctBy { it.id }
+                .dropBlocked(),
+            videos = songItems(resp.topVideos, hideExplicit),
+            artists = resp.topArtists.filter { it.id.isNotBlank() }
+                .map { it.toArtistItem() }
+                .distinctBy { it.id }
+                .dropBlocked(),
+        )
+
+    /** The three telemetry-ranked home rows in native item types (see [homeRows]). */
+    data class HomeRows(
+        val albums: List<AlbumItem>,
+        val videos: List<SongItem>,
+        val artists: List<ArtistItem>,
+    )
 
     /**
      * A Zemer `/playlist` response as playable [SongItem]s. The server already whitelist-scoped and

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -150,11 +150,16 @@ object ZemerResultMapper {
      * explicit). The artist-membership whitelist is NOT re-run — these are whitelist-pure server-side,
      * same convention as every other Zemer surface — but each card now carries its artist channel id
      * ([ZemerAlbum.artistId]/[ZemerTrack.artistId]/[ZemerArtist.id]) so the caller can still run the
-     * home one-per-artist dedup and its female/israeli defence-in-depth. `topCommunity` is intentionally
-     * dropped here: it maps to [PlaylistItem]s the caller renders in the featured-playlists row, but that
-     * row is not wired to `/home-rows` yet, so exposing it would be dead. See [HomeRows].
+     * home one-per-artist dedup and its female/israeli defence-in-depth. `topCommunity` maps to
+     * [PlaylistItem]s for the featured-playlists row (discovery-sourced, view-ranked, whitelist-pure +
+     * content-filtered server-side — same as the Community search chip); [formatSongCount] renders the
+     * localized "N songs" count and defaults to omitting it. See [HomeRows].
      */
-    fun homeRows(resp: ZemerHomeRowsResponse, hideExplicit: Boolean): HomeRows =
+    fun homeRows(
+        resp: ZemerHomeRowsResponse,
+        hideExplicit: Boolean,
+        formatSongCount: (Int) -> String? = { null },
+    ): HomeRows =
         HomeRows(
             albums = resp.topAlbums.filter { it.id.isNotBlank() }
                 .map { it.toAlbumItem() }
@@ -166,13 +171,15 @@ object ZemerResultMapper {
                 .map { it.toArtistItem() }
                 .distinctBy { it.id }
                 .dropBlocked(),
+            community = playlistItems(resp.topCommunity, formatSongCount),
         )
 
-    /** The three telemetry-ranked home rows in native item types (see [homeRows]). */
+    /** The four telemetry/discovery-ranked home rows in native item types (see [homeRows]). */
     data class HomeRows(
         val albums: List<AlbumItem>,
         val videos: List<SongItem>,
         val artists: List<ArtistItem>,
+        val community: List<PlaylistItem>,
     )
 
     /**

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -82,7 +82,6 @@ object ZemerResultMapper {
             artists = if (artist.isBlank()) null else listOf(Artist(name = artist, id = artistId)),
             year = year,
             thumbnail = thumbnail.orEmpty(),
-            explicit = explicit,
         )
 
     fun ZemerPlaylist.toPlaylistItem(formatSongCount: (Int) -> String?): PlaylistItem =
@@ -146,27 +145,24 @@ object ZemerResultMapper {
     /**
      * The telemetry-ranked home rows as the app's native item types, in the server's ranked order.
      * Each list is dropped of missing/duplicate ids and passed through [dropBlocked] (the surgical
-     * id-overrides), and `hideExplicit` is applied to albums + videos client-side (an artist is never
-     * explicit). The artist-membership whitelist is NOT re-run — these are whitelist-pure server-side,
-     * same convention as every other Zemer surface — but each card now carries its artist channel id
-     * ([ZemerAlbum.artistId]/[ZemerTrack.artistId]/[ZemerArtist.id]) so the caller can still run the
-     * home one-per-artist dedup and its female/israeli defence-in-depth. `topCommunity` maps to
-     * [PlaylistItem]s for the featured-playlists row (discovery-sourced, view-ranked, whitelist-pure +
-     * content-filtered server-side — same as the Community search chip); [formatSongCount] renders the
-     * localized "N songs" count and defaults to omitting it. See [HomeRows].
+     * id-overrides). No explicit filtering — Zemer's whitelist-pure corpus has none. The artist-membership
+     * whitelist is NOT re-run (whitelist-pure server-side), but each card carries its artist channel id
+     * ([ZemerAlbum.artistId]/[ZemerTrack.artistId]/[ZemerArtist.id]) so the caller can run the home
+     * one-per-artist dedup + female/israeli defence-in-depth. `topCommunity` maps to [PlaylistItem]s for
+     * the featured-playlists row (discovery-sourced, view-ranked, whitelist-pure + content-filtered
+     * server-side); [formatSongCount] renders the localized "N songs" count and defaults to omitting it.
+     * See [HomeRows].
      */
     fun homeRows(
         resp: ZemerHomeRowsResponse,
-        hideExplicit: Boolean,
         formatSongCount: (Int) -> String? = { null },
     ): HomeRows =
         HomeRows(
             albums = resp.topAlbums.filter { it.id.isNotBlank() }
                 .map { it.toAlbumItem() }
-                .filterExplicit(hideExplicit)
                 .distinctBy { it.id }
                 .dropBlocked(),
-            videos = songItems(resp.topVideos, hideExplicit),
+            videos = songItems(resp.topVideos, hideExplicit = false),
             artists = resp.topArtists.filter { it.id.isNotBlank() }
                 .map { it.toArtistItem() }
                 .distinctBy { it.id }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -222,6 +222,27 @@ class ZemerSearchClient @Inject constructor() {
             }
         }
 
+    /**
+     * The telemetry-ranked home rows (`GET /home-rows`). The content flags are sent explicitly (same
+     * fail-closed contract as every Zemer request — the server is default-OPEN); `kidZone=0` is always
+     * sent because the home tab is never reachable from inside the KidZone tab. The server returns the
+     * ranked top-N per row, already whitelist-scoped + content-filtered for the flags sent.
+     */
+    suspend fun homeRows(
+        allowFemale: Boolean,
+        blockVideos: Boolean,
+    ): ZemerHomeRowsResponse {
+        val response: HttpResponse = client.get("$BASE_URL/home-rows") {
+            zemerContentFlagParameters(allowFemale, blockVideos, includeKidZone = true).forEach { (name, value) ->
+                parameter(name, value)
+            }
+        }
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer home-rows returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerHomeRowsResponse.serializer(), response.bodyAsText())
+    }
+
     companion object {
         const val BASE_URL = "https://search.zemer.io"
         private const val REQUEST_TIMEOUT_MS = 8_000L

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -117,9 +117,6 @@ data class ZemerAlbum(
     val artistId: String? = null,
     val year: Int? = null,
     val thumbnail: String? = null,
-    // Present on `/home-rows` album cards so the app can honour `hideExplicit` client-side (the server
-    // can't resolve that preference for us). Absent → false on search albums, unchanged.
-    val explicit: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -46,6 +46,10 @@ data class ZemerTrack(
     val videoId: String = "",
     val title: String = "",
     val artist: String = "",
+    // The artist's YouTube channel id. Present on `/home-rows` cards (so the app's one-per-artist
+    // dedup + female/israeli defence-in-depth can run); absent (null) on the search categories, where
+    // the artist arrives as a name only. Maps to `Artist.id` — null there keeps the prior behaviour.
+    val artistId: String? = null,
     val explicit: Boolean = false,
     // `/album` tracks only; absent (null) on the search categories.
     val durationSec: Int? = null,
@@ -109,8 +113,13 @@ data class ZemerAlbum(
     val playlistId: String? = null,
     val title: String = "",
     val artist: String = "",
+    // Present on `/home-rows` cards (see [ZemerTrack.artistId]); absent on the search categories.
+    val artistId: String? = null,
     val year: Int? = null,
     val thumbnail: String? = null,
+    // Present on `/home-rows` album cards so the app can honour `hideExplicit` client-side (the server
+    // can't resolve that preference for us). Absent → false on search albums, unchanged.
+    val explicit: Boolean = false,
 )
 
 @Serializable
@@ -123,6 +132,24 @@ data class ZemerPlaylist(
     // to the whitelist at open time, so this — not the raw `total` — is the count to surface (showing
     // `total` would over-count vs. what the user gets when they open it). Absent on older server builds.
     @SerialName("whitelisted") val songCount: Int? = null,
+)
+
+/**
+ * Wire model for `GET /home-rows` (search.zemer.io) — the telemetry-ranked home tab rows, each ranked
+ * by real distinct-device listening over a 30-day live window (contract: `handoff-docs/home-rows-plan.md`).
+ * Every list is already whitelist-scoped and content-filtered (female / blocked-ids / kidZone) server-side
+ * for the flags sent, so the app does NOT re-run the artist-membership whitelist; it re-applies only the
+ * client-owned checks as defence-in-depth (female/israeli via [ZemerTrack.artistId], `hideExplicit`).
+ *
+ * [topCommunity] stays empty until the app tags `community:<playlistId>` playback; the lenient parser
+ * ([zemerResponseJson]) tolerates the key being absent on older servers.
+ */
+@Serializable
+data class ZemerHomeRowsResponse(
+    val topAlbums: List<ZemerAlbum> = emptyList(),
+    val topVideos: List<ZemerTrack> = emptyList(),
+    val topArtists: List<ZemerArtist> = emptyList(),
+    val topCommunity: List<ZemerPlaylist> = emptyList(),
 )
 
 /**

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -121,6 +121,19 @@ class ZemerSearchRepository @Inject constructor(
         client.album(browseId, options.allowFemale, options.blockVideos).toAlbumPage(playlistId)
 
     /**
+     * The telemetry-ranked home rows (albums / videos / artists), already whitelist-scoped and
+     * content-filtered server-side for the flags sent, mapped to the app's native item types. Like the
+     * curated playlists this is deliberately NOT cached: a plain re-fetch per home load is the endpoint's
+     * freshness contract and guarantees a response fetched under one flag set is never rendered under
+     * another. Ranked order is preserved; the caller applies its one-per-artist rotation + fallback.
+     */
+    suspend fun homeRows(options: ZemerSearchOptions): ZemerResultMapper.HomeRows =
+        ZemerResultMapper.homeRows(
+            client.homeRows(options.allowFemale, options.blockVideos),
+            options.hideExplicit,
+        )
+
+    /**
      * The hand-curated "Zemer Playlists" section, in editorial order (rendered as received). Not
      * cached — the doc'd contract is a plain re-fetch on screen open (single-digit-ms server reads),
      * which also guarantees a response fetched under one flag set is never shown under another.

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -130,7 +130,6 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun homeRows(options: ZemerSearchOptions): ZemerResultMapper.HomeRows =
         ZemerResultMapper.homeRows(
             client.homeRows(options.allowFemale, options.blockVideos),
-            options.hideExplicit,
             formatSongCount,
         )
 

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -131,6 +131,7 @@ class ZemerSearchRepository @Inject constructor(
         ZemerResultMapper.homeRows(
             client.homeRows(options.allowFemale, options.blockVideos),
             options.hideExplicit,
+            formatSongCount,
         )
 
     /**

--- a/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
@@ -15,6 +15,10 @@ object PlaySource {
     fun artist(id: String) = "artist:$id"
     fun album(id: String) = "album:$id"
     fun playlist(id: String) = "playlist:$id"
+    // A discovery-sourced community playlist (the home "Community playlists" row + the search Community
+    // chip open the same screen). Distinct from [playlist] (artist-owned) so the server can rank the
+    // community home row by real per-playlist engagement. `id` is the bare YouTube playlist id (`PL…`).
+    fun community(id: String) = "community:$id"
     fun zemer(id: String) = "zemer:$id"
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -370,10 +370,11 @@ fun HomeScreen(
                                     navController.navigate("album/${item.id}")
                                 }
                             is ArtistItem -> navController.navigate("artist/${item.id}")
-                            // Featured playlists: Zemer community playlists open via the server /playlist path.
+                            // Featured playlists: Zemer community playlists open via the server /playlist path
+                            // and tag plays `community:<id>` (they're the discovery-sourced community row).
                             is PlaylistItem ->
                                 if (featuredPlaylistsAreZemer) {
-                                    navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id))
+                                    navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id, community = true))
                                 } else {
                                     navController.navigate("online_playlist/${item.id}")
                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -71,6 +71,8 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.LocalAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.search.onlineAlbumRoute
 import com.jtech.zemer.tracking.TrackImpressionsByKey
 import com.jtech.zemer.tracking.TrackingSurface
 import com.jtech.zemer.ui.component.AlbumGridItem
@@ -82,7 +84,6 @@ import com.jtech.zemer.ui.component.ZemerCuratedPlaylistGridItem
 import com.jtech.zemer.ui.component.SongGridItem
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.YouTubeGridItem
-import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
@@ -138,6 +139,9 @@ fun HomeScreen(
     val featuredAlbums = homeUiState.featuredAlbums
     val featuredArtists = homeUiState.featuredArtists
     val featuredVideos = homeUiState.featuredVideos
+    // Featured albums are Zemer-sourced (telemetry-ranked) rather than the scrape fallback: open them via
+    // the Zemer album route so the album screen loads through the server (immune to InnerTube bot-gating).
+    val featuredAlbumsAreZemer = homeUiState.featuredAlbumsAreZemer
     val latestReleasesViewModel: LatestReleasesViewModel = hiltViewModel()
     val latestReleases by latestReleasesViewModel.releases.collectAsState()
     val zemerPlaylistsViewModel: ZemerCuratedPlaylistsViewModel = hiltViewModel()
@@ -159,7 +163,10 @@ fun HomeScreen(
                     addAll(featuredVideos)
                 }
                 addAll(featuredAlbums)
-                addAll(featuredArtists)
+                // Telemetry-ranked (Zemer) artist cards carry no InnerTube radio endpoint, so the lucky
+                // shuffle can't start radio from them — keep only artists that can actually play (the
+                // scrape-fallback ones) in the pool, so a lucky pick never dead-presses.
+                addAll(featuredArtists.filter { it.radioEndpoint != null })
             }
         }
 
@@ -354,7 +361,14 @@ fun HomeScreen(
                                 )
                             )
 
-                            is AlbumItem -> navController.navigate("album/${item.id}")
+                            // Only the featured-albums row passes an AlbumItem through ytGridItem, so this
+                            // branch is the featured album; route Zemer-sourced ones via the server album path.
+                            is AlbumItem ->
+                                if (featuredAlbumsAreZemer) {
+                                    navController.navigate(SearchProvider.ZEMER.onlineAlbumRoute(item))
+                                } else {
+                                    navController.navigate("album/${item.id}")
+                                }
                             is ArtistItem -> navController.navigate("artist/${item.id}")
                             is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -69,6 +69,7 @@ import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
+import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.tracking.TrackImpressionsByKey
 import com.jtech.zemer.tracking.TrackingSurface
@@ -139,6 +140,8 @@ fun HomeScreen(
     // Featured albums are Zemer-sourced (telemetry-ranked) rather than the scrape fallback: open them via
     // the Zemer album route so the album screen loads through the server (immune to InnerTube bot-gating).
     val featuredAlbumsAreZemer = homeUiState.featuredAlbumsAreZemer
+    // Same for featured playlists: Zemer community playlists open via the server /playlist route.
+    val featuredPlaylistsAreZemer = homeUiState.featuredPlaylistsAreZemer
     val latestReleasesViewModel: LatestReleasesViewModel = hiltViewModel()
     val latestReleases by latestReleasesViewModel.releases.collectAsState()
     val zemerPlaylistsViewModel: ZemerCuratedPlaylistsViewModel = hiltViewModel()
@@ -367,7 +370,13 @@ fun HomeScreen(
                                     navController.navigate("album/${item.id}")
                                 }
                             is ArtistItem -> navController.navigate("artist/${item.id}")
-                            is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
+                            // Featured playlists: Zemer community playlists open via the server /playlist path.
+                            is PlaylistItem ->
+                                if (featuredPlaylistsAreZemer) {
+                                    navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id))
+                                } else {
+                                    navController.navigate("online_playlist/${item.id}")
+                                }
                         }
                     },
                     onLongClick = {
@@ -633,6 +642,7 @@ fun HomeScreen(
                     item(key = "featured_playlists_title", contentType = "header") {
                         NavigationTitle(
                             title = stringResource(R.string.featured_playlists),
+                            onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FEATURED_PLAYLISTS.slug}") },
                             modifier = Modifier.animateItem()
                         )
                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -21,7 +20,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
@@ -30,7 +28,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
 import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -66,13 +63,13 @@ import com.jtech.zemer.db.entities.Artist
 import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.Song
-import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.LocalAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
+import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.tracking.TrackImpressionsByKey
 import com.jtech.zemer.tracking.TrackingSurface
 import com.jtech.zemer.ui.component.AlbumGridItem
@@ -469,6 +466,7 @@ fun HomeScreen(
                     item(key = "quick_picks_title", contentType = "header") {
                         NavigationTitle(
                             title = stringResource(R.string.quick_picks),
+                            onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.QUICK_PICKS.slug}") },
                             modifier = Modifier.animateItem()
                         )
                     }
@@ -661,6 +659,7 @@ fun HomeScreen(
                     item(key = "keep_listening_title", contentType = "header") {
                         NavigationTitle(
                             title = stringResource(R.string.keep_listening),
+                            onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.KEEP_LISTENING.slug}") },
                             modifier = Modifier.animateItem()
                         )
                     }
@@ -705,6 +704,7 @@ fun HomeScreen(
                     item(key = "forgotten_favorites_title", contentType = "header") {
                         NavigationTitle(
                             title = stringResource(R.string.forgotten_favorites),
+                            onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FORGOTTEN_FAVORITES.slug}") },
                             modifier = Modifier.animateItem()
                         )
                     }
@@ -801,6 +801,7 @@ fun HomeScreen(
                 item(key = "featured_artists_title", contentType = "header") {
                     NavigationTitle(
                         title = stringResource(R.string.featured_artists),
+                        onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FEATURED_ARTISTS.slug}") },
                         modifier = Modifier.animateItem()
                     )
                 }
@@ -828,6 +829,7 @@ fun HomeScreen(
                 item(key = "featured_albums_title", contentType = "header") {
                     NavigationTitle(
                         title = stringResource(R.string.featured_albums),
+                        onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FEATURED_ALBUMS.slug}") },
                         modifier = Modifier.animateItem()
                     )
                 }
@@ -854,6 +856,7 @@ fun HomeScreen(
                 item(key = "featured_videos_title", contentType = "header") {
                     NavigationTitle(
                         title = stringResource(R.string.featured_videos),
+                        onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FEATURED_VIDEOS.slug}") },
                         modifier = Modifier.animateItem()
                     )
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -133,7 +133,6 @@ fun HomeScreen(
 
     val quickPicks = homeUiState.quickPicks
     val featuredPlaylists = homeUiState.featuredPlaylists
-    val trendingSongs = homeUiState.trendingSongs
     val forgottenFavorites = homeUiState.forgottenFavorites
     val keepListening = homeUiState.keepListening
     val featuredAlbums = homeUiState.featuredAlbums
@@ -154,14 +153,13 @@ fun HomeScreen(
             (quickPicks + forgottenFavorites + keepListening).filter { it is Song || it is Album }
         }
     val allYtItems =
-        remember(featuredVideos, featuredAlbums, featuredArtists, trendingSongs, blockVideos) {
+        remember(featuredVideos, featuredAlbums, featuredArtists, blockVideos) {
             buildList {
                 if (!blockVideos) {
                     addAll(featuredVideos)
                 }
                 addAll(featuredAlbums)
                 addAll(featuredArtists)
-                addAll(trendingSongs)
             }
         }
 
@@ -174,7 +172,6 @@ fun HomeScreen(
     val uniqueFeaturedArtists = remember(featuredArtists) { featuredArtists.distinctBy { it.id } }
     val uniqueFeaturedAlbums = remember(featuredAlbums) { featuredAlbums.distinctBy { it.id } }
     val uniqueFeaturedVideos = remember(featuredVideos) { featuredVideos.distinctBy { it.id } }
-    val uniqueTrendingSongs = remember(trendingSongs) { trendingSongs.distinctBy { it.id } }
 
     val isLoading: Boolean = homeUiState.isLoading
     val isRefreshing = homeUiState.isRefreshing
@@ -446,7 +443,6 @@ fun HomeScreen(
             featuredArtists.isNotEmpty() ||
                 featuredAlbums.isNotEmpty() ||
                 (!blockVideos && featuredVideos.isNotEmpty()) ||
-                trendingSongs.isNotEmpty() ||
                 latestReleases.isNotEmpty() ||
                 zemerPlaylists.isNotEmpty()
         val shouldShowShimmer = isLoading || (!hasLocalHomeContent && !hasRemoteHomeContent)
@@ -783,93 +779,6 @@ fun HomeScreen(
                                 )
                             }
                         }
-                }
-            }
-
-            trendingSongs.takeIf { it.isNotEmpty() }?.let { songs ->
-                item(key = "trending_title", contentType = "header") {
-                    NavigationTitle(
-                        title = stringResource(R.string.trending),
-                        modifier = Modifier.animateItem()
-                    )
-                }
-
-                item(key = "trending_list", contentType = "grid") {
-                    // Declared here, not hoisted to the screen: the row's scroll position keeps the
-                    // same lifetime it has always had (reset when the section leaves composition).
-                    val trendingGridState = rememberLazyGridState()
-                    TrackImpressionsByKey(
-                        surface = TrackingSurface.home("trending"),
-                        state = trendingGridState,
-                        parent = lazylistState,
-                        parentKey = "trending_list",
-                        idOfKey = rememberRowImpressionIds(uniqueTrendingSongs) { it.id },
-                    )
-                    LazyHorizontalGrid(
-                        state = trendingGridState,
-                        rows = GridCells.Fixed(2),
-                        contentPadding = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal).asPaddingValues(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(ListItemHeight * 2.5f)
-                            .animateItem()
-                    ) {
-                        items(
-                            items = uniqueTrendingSongs,
-                            key = { it.id },
-                            contentType = { "yt_song" }
-                        ) { song ->
-                            YouTubeListItem(
-                                item = song,
-                                isActive = mediaMetadata?.id == song.id,
-                                isPlaying = isPlaying,
-                                trailingContent = {
-                                    IconButton(
-                                        onClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            menuState.show {
-                                                YouTubeSongMenu(
-                                                    song = song,
-                                                    navController = navController,
-                                                    onDismiss = menuState::dismiss,
-                                                )
-                                            }
-                                        }
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.more_vert),
-                                            contentDescription = null,
-                                        )
-                                    }
-                                },
-                                modifier = Modifier
-                                    .width(horizontalLazyGridItemWidth)
-                                    .combinedClickable(
-                                        onClick = {
-                                            playerConnection.playQueue(
-                                                YouTubeQueue(
-                                                    song.endpoint ?: WatchEndpoint(videoId = song.id),
-                                                    song.toMediaMetadata(),
-                                                    database = database
-                                                )
-                                            )
-                                        },
-                                        onLongClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            menuState.show {
-                                                YouTubeSongMenu(
-                                                    song = song,
-                                                    navController = navController,
-                                                    onDismiss = menuState::dismiss,
-                                                )
-                                            }
-                                        }
-                                    )
-                            )
-                        }
-                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -162,7 +162,11 @@ fun HomeScreen(
                 if (!blockVideos) {
                     addAll(featuredVideos)
                 }
-                addAll(featuredAlbums)
+                // A featured (Zemer) album is lucky-playable only with a real OLAK playlist id: when
+                // /home-rows sends none, toAlbumItem falls playlistId back to the MPRE browseId, which
+                // YouTubeAlbumRadio's InnerTube lookup can't resolve — a lucky pick on it would dead-press.
+                // Keep only albums with a distinct (resolvable) playlist id, same guard as the artists below.
+                addAll(featuredAlbums.filter { it.playlistId != it.id })
                 // Telemetry-ranked (Zemer) artist cards carry no InnerTube radio endpoint, so the lucky
                 // shuffle can't start radio from them — keep only artists that can actually play (the
                 // scrape-fallback ones) in the pool, so a lucky pick never dead-presses.

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -117,7 +117,9 @@ private fun <T : YTItem> YtItemGrid(
     val scope = rememberCoroutineScope()
 
     LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
+        // Two across, not three: album/artist titles here run long (full Hebrew + English names), and a
+        // third-of-screen cell chops them mid-word. Two columns give the title + "artist · year" room.
+        columns = GridCells.Fixed(2),
         contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
     ) {
         items(items = items, key = { it.id }) { item ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -34,7 +34,6 @@ import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
-import com.jtech.zemer.constants.GridThumbnailHeight
 import com.jtech.zemer.db.entities.Album
 import com.jtech.zemer.db.entities.Artist
 import com.jtech.zemer.db.entities.LocalItem
@@ -118,7 +117,7 @@ private fun <T : YTItem> YtItemGrid(
     val scope = rememberCoroutineScope()
 
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+        columns = GridCells.Fixed(3),
         contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
     ) {
         items(items = items, key = { it.id }) { item ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -145,9 +145,10 @@ private fun <T : YTItem> YtItemGrid(
                                 if (zemerAlbums) navController.navigate(SearchProvider.ZEMER.onlineAlbumRoute(item))
                                 else navController.navigate("album/${item.id}")
                             is ArtistItem -> navController.navigate("artist/${item.id}")
-                            // Community playlists are Zemer-sourced: open via the server /playlist route.
+                            // Community playlists are Zemer-sourced: open via the server /playlist route and
+                            // tag plays `community:<id>` (the discovery-sourced community row).
                             is PlaylistItem ->
-                                if (zemerPlaylists) navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id))
+                                if (zemerPlaylists) navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id, community = true))
                                 else navController.navigate("online_playlist/${item.id}")
                         }
                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -2,6 +2,7 @@ package com.jtech.zemer.ui.screens
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -44,6 +45,7 @@ import com.jtech.zemer.search.onlineAlbumRoute
 import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.ui.component.AlbumListItem
 import com.jtech.zemer.ui.component.ArtistListItem
+import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.YouTubeGridItem
@@ -63,7 +65,10 @@ import com.jtech.zemer.viewmodels.HomeSeeAllStore
  * (a grid for the online Featured rows, a list for the local Quick Picks / Keep Listening / Forgotten
  * Favorites). It renders straight from [HomeSeeAllStore] — the snapshot Home published on its last load
  * — so what you see here is exactly what the row was built from, uncapped, and can never disagree with
- * it. An empty snapshot (See-all somehow opened before Home loaded) is just an empty page.
+ * it. Home publishes each local row's snapshot as soon as the row is shown (and the featured rows once
+ * the network load completes), so the data is present before its "See all" arrow is reachable; an empty
+ * snapshot (e.g. process-death restore straight onto this screen, before Home has loaded) shows a neutral
+ * placeholder rather than a bare blank page.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,18 +79,36 @@ fun HomeSeeAllScreen(
 ) {
     val data by HomeSeeAllStore.data.collectAsState()
 
-    when (row) {
-        HomeSeeAllRow.FEATURED_ALBUMS ->
-            YtItemGrid(data.featuredAlbums, navController, zemerAlbums = data.featuredAlbumsAreZemer)
-        HomeSeeAllRow.FEATURED_ARTISTS ->
-            YtItemGrid(data.featuredArtists, navController)
-        HomeSeeAllRow.FEATURED_VIDEOS ->
-            YtItemGrid(data.featuredVideos, navController)
-        HomeSeeAllRow.FEATURED_PLAYLISTS ->
-            YtItemGrid(data.featuredPlaylists, navController, zemerPlaylists = data.featuredPlaylistsAreZemer)
-        HomeSeeAllRow.QUICK_PICKS -> SongList(data.quickPicks, navController)
-        HomeSeeAllRow.FORGOTTEN_FAVORITES -> SongList(data.forgottenFavorites, navController)
-        HomeSeeAllRow.KEEP_LISTENING -> LocalItemList(data.keepListening, navController)
+    val rowIsEmpty = when (row) {
+        HomeSeeAllRow.FEATURED_ALBUMS -> data.featuredAlbums.isEmpty()
+        HomeSeeAllRow.FEATURED_ARTISTS -> data.featuredArtists.isEmpty()
+        HomeSeeAllRow.FEATURED_VIDEOS -> data.featuredVideos.isEmpty()
+        HomeSeeAllRow.FEATURED_PLAYLISTS -> data.featuredPlaylists.isEmpty()
+        HomeSeeAllRow.QUICK_PICKS -> data.quickPicks.isEmpty()
+        HomeSeeAllRow.FORGOTTEN_FAVORITES -> data.forgottenFavorites.isEmpty()
+        HomeSeeAllRow.KEEP_LISTENING -> data.keepListening.isEmpty()
+    }
+
+    if (rowIsEmpty) {
+        EmptyPlaceholder(
+            icon = R.drawable.queue_music,
+            text = stringResource(R.string.home_see_all_empty),
+            modifier = Modifier.windowInsetsPadding(LocalPlayerAwareWindowInsets.current),
+        )
+    } else {
+        when (row) {
+            HomeSeeAllRow.FEATURED_ALBUMS ->
+                YtItemGrid(data.featuredAlbums, navController, zemerAlbums = data.featuredAlbumsAreZemer)
+            HomeSeeAllRow.FEATURED_ARTISTS ->
+                YtItemGrid(data.featuredArtists, navController)
+            HomeSeeAllRow.FEATURED_VIDEOS ->
+                YtItemGrid(data.featuredVideos, navController)
+            HomeSeeAllRow.FEATURED_PLAYLISTS ->
+                YtItemGrid(data.featuredPlaylists, navController, zemerPlaylists = data.featuredPlaylistsAreZemer)
+            HomeSeeAllRow.QUICK_PICKS -> SongList(data.quickPicks, navController)
+            HomeSeeAllRow.FORGOTTEN_FAVORITES -> SongList(data.forgottenFavorites, navController)
+            HomeSeeAllRow.KEEP_LISTENING -> LocalItemList(data.keepListening, navController)
+        }
     }
 
     TopAppBar(
@@ -112,7 +135,6 @@ private fun <T : YTItem> YtItemGrid(
     zemerPlaylists: Boolean = false,
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val haptic = LocalHapticFeedback.current
     val isPlaying by playerConnection.isPlaying.collectAsState()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -27,7 +27,6 @@ import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.models.YTItem
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
@@ -137,8 +136,10 @@ private fun <T : YTItem> YtItemGrid(
                 modifier = Modifier.combinedClickable(
                     onClick = {
                         when (item) {
-                            is SongItem -> playerConnection.playQueue(
-                                YouTubeQueue(item.endpoint ?: WatchEndpoint(videoId = item.id), item.toMediaMetadata(), database),
+                            // The only SongItems in this grid are the Featured Videos row — open the video
+                            // player (matching the Home row), not audio playback.
+                            is SongItem -> navController.navigate(
+                                videoRoute(item.id, item.title, item.artists.joinToString(" • ") { it.name }),
                             )
                             // Featured albums are Zemer-sourced: open via the server route (bot-gate-proof).
                             is AlbumItem ->
@@ -156,7 +157,9 @@ private fun <T : YTItem> YtItemGrid(
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         menuState.show {
                             when (item) {
-                                is SongItem -> YouTubeSongMenu(song = item, navController = navController, onDismiss = menuState::dismiss)
+                                // Videos row: isVideo = true so the menu offers "Download video" (video),
+                                // not the audio "Download".
+                                is SongItem -> YouTubeSongMenu(song = item, navController = navController, onDismiss = menuState::dismiss, isVideo = true)
                                 is AlbumItem -> YouTubeAlbumMenu(albumItem = item, navController = navController, onDismiss = menuState::dismiss)
                                 is ArtistItem -> YouTubeArtistMenu(artist = item, onDismiss = menuState::dismiss)
                                 is PlaylistItem -> YouTubePlaylistMenu(playlist = item, coroutineScope = scope, onDismiss = menuState::dismiss)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -1,0 +1,264 @@
+package com.jtech.zemer.ui.screens
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.WatchEndpoint
+import com.metrolist.innertube.models.YTItem
+import com.jtech.zemer.LocalDatabase
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.LocalPlayerConnection
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.db.entities.Album
+import com.jtech.zemer.db.entities.Artist
+import com.jtech.zemer.db.entities.LocalItem
+import com.jtech.zemer.db.entities.Playlist
+import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.search.onlineAlbumRoute
+import com.jtech.zemer.ui.component.AlbumListItem
+import com.jtech.zemer.ui.component.ArtistListItem
+import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.SongListItem
+import com.jtech.zemer.ui.component.YouTubeGridItem
+import com.jtech.zemer.ui.menu.AlbumMenu
+import com.jtech.zemer.ui.menu.ArtistMenu
+import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
+import com.jtech.zemer.ui.menu.YouTubeArtistMenu
+import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.viewmodels.HomeSeeAllRow
+import com.jtech.zemer.viewmodels.HomeSeeAllStore
+
+/**
+ * The generic "See all" page for a Home row: the row's full, already-filtered list as a vertical page
+ * (a grid for the online Featured rows, a list for the local Quick Picks / Keep Listening / Forgotten
+ * Favorites). It renders straight from [HomeSeeAllStore] — the snapshot Home published on its last load
+ * — so what you see here is exactly what the row was built from, uncapped, and can never disagree with
+ * it. An empty snapshot (See-all somehow opened before Home loaded) is just an empty page.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeSeeAllScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    row: HomeSeeAllRow,
+) {
+    val data by HomeSeeAllStore.data.collectAsState()
+
+    when (row) {
+        HomeSeeAllRow.FEATURED_ALBUMS ->
+            YtItemGrid(data.featuredAlbums, navController, zemerAlbums = data.featuredAlbumsAreZemer)
+        HomeSeeAllRow.FEATURED_ARTISTS ->
+            YtItemGrid(data.featuredArtists, navController, zemerAlbums = false)
+        HomeSeeAllRow.FEATURED_VIDEOS ->
+            YtItemGrid(data.featuredVideos, navController, zemerAlbums = false)
+        HomeSeeAllRow.QUICK_PICKS -> SongList(data.quickPicks, navController)
+        HomeSeeAllRow.FORGOTTEN_FAVORITES -> SongList(data.forgottenFavorites, navController)
+        HomeSeeAllRow.KEEP_LISTENING -> LocalItemList(data.keepListening, navController)
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(row.titleRes)) },
+        navigationIcon = {
+            // The app's IconButton (long-press = back to Home), matching the other See-all screens.
+            com.jtech.zemer.ui.component.IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}
+
+/** Online Featured rows (albums / artists / videos) as a grid, click + long-press mirroring Home. */
+@Composable
+private fun <T : YTItem> YtItemGrid(
+    items: List<T>,
+    navController: NavController,
+    zemerAlbums: Boolean,
+) {
+    val menuState = LocalMenuState.current
+    val database = LocalDatabase.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val haptic = LocalHapticFeedback.current
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+        contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+    ) {
+        items(items = items, key = { it.id }) { item ->
+            YouTubeGridItem(
+                item = item,
+                isActive = item.id in listOf(mediaMetadata?.album?.id, mediaMetadata?.id),
+                isPlaying = isPlaying,
+                coroutineScope = scope,
+                thumbnailRatio = 1f,
+                fillMaxWidth = true,
+                modifier = Modifier.combinedClickable(
+                    onClick = {
+                        when (item) {
+                            is SongItem -> playerConnection.playQueue(
+                                YouTubeQueue(item.endpoint ?: WatchEndpoint(videoId = item.id), item.toMediaMetadata(), database),
+                            )
+                            // Featured albums are Zemer-sourced: open via the server route (bot-gate-proof).
+                            is AlbumItem ->
+                                if (zemerAlbums) navController.navigate(SearchProvider.ZEMER.onlineAlbumRoute(item))
+                                else navController.navigate("album/${item.id}")
+                            is ArtistItem -> navController.navigate("artist/${item.id}")
+                            is PlaylistItem -> Unit // Featured rows never contain playlists.
+                        }
+                    },
+                    onLongClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        menuState.show {
+                            when (item) {
+                                is SongItem -> YouTubeSongMenu(song = item, navController = navController, onDismiss = menuState::dismiss)
+                                is AlbumItem -> YouTubeAlbumMenu(albumItem = item, navController = navController, onDismiss = menuState::dismiss)
+                                is ArtistItem -> YouTubeArtistMenu(artist = item, onDismiss = menuState::dismiss)
+                                is PlaylistItem -> Unit
+                            }
+                        }
+                    },
+                ),
+            )
+        }
+    }
+}
+
+/** Local Song rows (Quick Picks, Forgotten Favorites) as a list, click plays / toggles, menu on hold. */
+@Composable
+private fun SongList(songs: List<Song>, navController: NavController) {
+    val menuState = LocalMenuState.current
+    val database = LocalDatabase.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val haptic = LocalHapticFeedback.current
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+
+    LazyColumn(contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()) {
+        items(items = songs, key = { it.id }) { originalSong ->
+            val song by database.song(originalSong.id).collectAsState(initial = originalSong)
+            val shown = song ?: originalSong
+            SongListItem(
+                song = shown,
+                showInLibraryIcon = true,
+                isActive = shown.id == mediaMetadata?.id,
+                isPlaying = isPlaying,
+                trailingContent = {
+                    IconButton(onClick = {
+                        menuState.show { SongMenu(originalSong = shown, navController = navController, onDismiss = menuState::dismiss) }
+                    }) {
+                        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
+                    }
+                },
+                modifier = Modifier.combinedClickable(
+                    onClick = {
+                        if (shown.id == mediaMetadata?.id) playerConnection.playPause()
+                        else playerConnection.playQueue(YouTubeQueue.radio(shown.toMediaMetadata(), database))
+                    },
+                    onLongClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        menuState.show { SongMenu(originalSong = shown, navController = navController, onDismiss = menuState::dismiss) }
+                    },
+                ),
+            )
+        }
+    }
+}
+
+/** Keep Listening: a mixed local list (songs, albums, artists), each routed to its own destination. */
+@Composable
+private fun LocalItemList(items: List<LocalItem>, navController: NavController) {
+    val menuState = LocalMenuState.current
+    val database = LocalDatabase.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val haptic = LocalHapticFeedback.current
+    val scope = rememberCoroutineScope()
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+
+    LazyColumn(contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()) {
+        items(items = items, key = { it.id }) { item ->
+            when (item) {
+                is Song -> SongListItem(
+                    song = item,
+                    isActive = item.id == mediaMetadata?.id,
+                    isPlaying = isPlaying,
+                    trailingContent = {
+                        IconButton(onClick = {
+                            menuState.show { SongMenu(originalSong = item, navController = navController, onDismiss = menuState::dismiss) }
+                        }) { Icon(painterResource(R.drawable.more_vert), contentDescription = null) }
+                    },
+                    modifier = Modifier.combinedClickable(
+                        onClick = {
+                            if (item.id == mediaMetadata?.id) playerConnection.playPause()
+                            else playerConnection.playQueue(YouTubeQueue.radio(item.toMediaMetadata(), database))
+                        },
+                        onLongClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            menuState.show { SongMenu(originalSong = item, navController = navController, onDismiss = menuState::dismiss) }
+                        },
+                    ),
+                )
+                is Album -> AlbumListItem(
+                    album = item,
+                    isActive = item.id == mediaMetadata?.album?.id,
+                    isPlaying = isPlaying,
+                    modifier = Modifier.combinedClickable(
+                        onClick = { navController.navigate("album/${item.id}") },
+                        onLongClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            menuState.show { AlbumMenu(originalAlbum = item, navController = navController, onDismiss = menuState::dismiss) }
+                        },
+                    ),
+                )
+                is Artist -> ArtistListItem(
+                    artist = item,
+                    modifier = Modifier.combinedClickable(
+                        onClick = { navController.navigate("artist/${item.id}") },
+                        onLongClick = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            menuState.show { ArtistMenu(originalArtist = item, coroutineScope = scope, onDismiss = menuState::dismiss) }
+                        },
+                    ),
+                )
+                is Playlist -> Unit // Home's Keep Listening never contains playlists.
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -43,6 +42,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
+import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.ui.component.AlbumListItem
 import com.jtech.zemer.ui.component.ArtistListItem
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -53,6 +53,7 @@ import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
+import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.HomeSeeAllRow
@@ -78,9 +79,11 @@ fun HomeSeeAllScreen(
         HomeSeeAllRow.FEATURED_ALBUMS ->
             YtItemGrid(data.featuredAlbums, navController, zemerAlbums = data.featuredAlbumsAreZemer)
         HomeSeeAllRow.FEATURED_ARTISTS ->
-            YtItemGrid(data.featuredArtists, navController, zemerAlbums = false)
+            YtItemGrid(data.featuredArtists, navController)
         HomeSeeAllRow.FEATURED_VIDEOS ->
-            YtItemGrid(data.featuredVideos, navController, zemerAlbums = false)
+            YtItemGrid(data.featuredVideos, navController)
+        HomeSeeAllRow.FEATURED_PLAYLISTS ->
+            YtItemGrid(data.featuredPlaylists, navController, zemerPlaylists = data.featuredPlaylistsAreZemer)
         HomeSeeAllRow.QUICK_PICKS -> SongList(data.quickPicks, navController)
         HomeSeeAllRow.FORGOTTEN_FAVORITES -> SongList(data.forgottenFavorites, navController)
         HomeSeeAllRow.KEEP_LISTENING -> LocalItemList(data.keepListening, navController)
@@ -106,7 +109,8 @@ fun HomeSeeAllScreen(
 private fun <T : YTItem> YtItemGrid(
     items: List<T>,
     navController: NavController,
-    zemerAlbums: Boolean,
+    zemerAlbums: Boolean = false,
+    zemerPlaylists: Boolean = false,
 ) {
     val menuState = LocalMenuState.current
     val database = LocalDatabase.current
@@ -141,7 +145,10 @@ private fun <T : YTItem> YtItemGrid(
                                 if (zemerAlbums) navController.navigate(SearchProvider.ZEMER.onlineAlbumRoute(item))
                                 else navController.navigate("album/${item.id}")
                             is ArtistItem -> navController.navigate("artist/${item.id}")
-                            is PlaylistItem -> Unit // Featured rows never contain playlists.
+                            // Community playlists are Zemer-sourced: open via the server /playlist route.
+                            is PlaylistItem ->
+                                if (zemerPlaylists) navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id))
+                                else navController.navigate("online_playlist/${item.id}")
                         }
                     },
                     onLongClick = {
@@ -151,7 +158,7 @@ private fun <T : YTItem> YtItemGrid(
                                 is SongItem -> YouTubeSongMenu(song = item, navController = navController, onDismiss = menuState::dismiss)
                                 is AlbumItem -> YouTubeAlbumMenu(albumItem = item, navController = navController, onDismiss = menuState::dismiss)
                                 is ArtistItem -> YouTubeArtistMenu(artist = item, onDismiss = menuState::dismiss)
-                                is PlaylistItem -> Unit
+                                is PlaylistItem -> YouTubePlaylistMenu(playlist = item, coroutineScope = scope, onDismiss = menuState::dismiss)
                             }
                         }
                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -255,14 +255,19 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable(
         // Optional `zemer` flag (default false) routes a Zemer-search playlist open through the
-        // server's `/playlist` endpoint; existing `online_playlist/{id}` links keep the default.
-        route = "online_playlist/{playlistId}?zemer={zemer}",
+        // server's `/playlist` endpoint; `community` (default false) tags its plays `community:<id>`
+        // (discovery-sourced community lists) instead of `playlist:<id>`. Plain links keep both defaults.
+        route = "online_playlist/{playlistId}?zemer={zemer}&community={community}",
         arguments =
         listOf(
             navArgument("playlistId") {
                 type = NavType.StringType
             },
             navArgument("zemer") {
+                type = NavType.BoolType
+                defaultValue = false
+            },
+            navArgument("community") {
                 type = NavType.BoolType
                 defaultValue = false
             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -44,6 +44,8 @@ import com.jtech.zemer.ui.screens.settings.StorageSettings
 import com.jtech.zemer.ui.screens.settings.StreamSourceSettings
 import com.jtech.zemer.ui.screens.settings.UpdaterScreen
 import com.jtech.zemer.ui.screens.settings.integrations.IntegrationScreen
+import androidx.compose.runtime.LaunchedEffect
+import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.viewmodels.HomeViewModel
 
 
@@ -92,6 +94,15 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("zemer_playlists") {
         ZemerPlaylistsScreen(navController, scrollBehavior)
+    }
+    composable(
+        route = "home_see_all/{row}",
+        arguments = listOf(navArgument("row") { type = NavType.StringType }),
+    ) {
+        // An unknown/absent row slug is a broken deep link, not a crash — pop back to Home.
+        val row = HomeSeeAllRow.fromSlug(it.arguments?.getString("row"))
+        if (row == null) LaunchedEffect(Unit) { navController.navigateUp() }
+        else HomeSeeAllScreen(navController, scrollBehavior, row)
     }
     composable("charts_screen") {
        ChartsScreen(navController)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -90,7 +90,6 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
-import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.FontSizeRange
@@ -377,7 +376,7 @@ fun OnlinePlaylistScreen(
                                             ListQueue(
                                                 title = playlist.title,
                                                 items = songs.map { it.toMediaItem() },
-                                                playSource = PlaySource.playlist(playlist.id),
+                                                playSource = viewModel.playSource,
                                             )
                                         )
                                     }.takeIf { songs.isNotEmpty() },
@@ -386,7 +385,7 @@ fun OnlinePlaylistScreen(
                                             ListQueue(
                                                 title = playlist.title,
                                                 items = songs.map { it.toMediaItem() }.shuffled(),
-                                                playSource = PlaySource.playlist(playlist.id),
+                                                playSource = viewModel.playSource,
                                             )
                                         )
                                     }.takeIf { playlist.shuffleEndpoint != null },
@@ -458,7 +457,7 @@ fun OnlinePlaylistScreen(
                                                         title = playlist.title,
                                                         items = filteredSongs.map { it.second.toMediaItem() },
                                                         startIndex = index,
-                                                        playSource = PlaySource.playlist(playlist.id)
+                                                        playSource = viewModel.playSource
                                                     )
                                                 )
                                             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -388,7 +388,11 @@ fun OnlinePlaylistScreen(
                                                 playSource = viewModel.playSource,
                                             )
                                         )
-                                    }.takeIf { playlist.shuffleEndpoint != null },
+                                        // Shuffle just reorders the already-loaded `songs`, so a Zemer
+                                        // playlist (whole filtered list up front, no `shuffleEndpoint`) can
+                                        // offer it whenever there are songs — same as the curated screen.
+                                        // YouTube playlists keep the endpoint gate.
+                                    }.takeIf { if (viewModel.isZemer) songs.isNotEmpty() else playlist.shuffleEndpoint != null },
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
@@ -112,6 +112,12 @@ internal fun isCuratedChipEmpty(
 ): Boolean = if (filter == LatestReleaseFilter.ALBUMS) albumCount == 0 else visibleSongCount == 0
 
 /**
+ * Whether to show the All/Albums/Songs chip row. Only when the playlist actually has albums: with none,
+ * ALL and SONGS are identical and ALBUMS is an empty dead end, so the plain track list is shown instead.
+ */
+internal fun curatedChipsVisible(albumCount: Int): Boolean = albumCount > 0
+
+/**
  * Detail screen for one hand-curated "Zemer Playlists" entry. Deliberately its OWN small screen —
  * the id is a server slug, not a YouTube playlist id, so it must never route through the
  * YouTube-playlist screen (whose save/like/menu actions all assume a YouTube id). Header + All/
@@ -150,8 +156,13 @@ fun ZemerCuratedPlaylistScreen(
     val loadedPage = (state as? UiState.Loaded)?.page
     val loadedSongs = loadedPage?.songs.orEmpty()
     var filter by rememberSaveable { mutableStateOf(LatestReleaseFilter.ALL) }
-    val visibleSongs = remember(loadedPage, filter) {
-        filterCuratedTracks(loadedSongs, loadedPage?.albumTrackIds.orEmpty(), filter)
+    // A playlist of only direct song picks carries no albums: All == Songs and Albums is empty, so the
+    // chips are redundant + a dead end. Hide the chip row for those and pin the filter to ALL, so a
+    // stale ALBUMS/SONGS selection can never apply once the chips are gone.
+    val hasAlbums = curatedChipsVisible(loadedPage?.albums.orEmpty().size)
+    val effectiveFilter = if (hasAlbums) filter else LatestReleaseFilter.ALL
+    val visibleSongs = remember(loadedPage, effectiveFilter) {
+        filterCuratedTracks(loadedSongs, loadedPage?.albumTrackIds.orEmpty(), effectiveFilter)
     }
 
     // Measured once for the whole list from its highest position, so every row shares one width —
@@ -292,20 +303,24 @@ fun ZemerCuratedPlaylistScreen(
                         }
                     }
 
-                    // All / Albums / Songs — scrolls with the list, like the Latest Releases screen.
-                    item(key = "filter") {
-                        ChipsRow(
-                            chips = listOf(
-                                LatestReleaseFilter.ALL to stringResource(R.string.filter_all),
-                                LatestReleaseFilter.ALBUMS to stringResource(R.string.filter_albums),
-                                LatestReleaseFilter.SONGS to stringResource(R.string.filter_songs),
-                            ),
-                            currentValue = filter,
-                            onValueUpdate = { filter = it },
-                        )
+                    // All / Albums / Songs — scrolls with the list, like the Latest Releases screen. Shown
+                    // only when the playlist actually has albums; an all-songs playlist renders the plain
+                    // track list (the three chips would be two duplicates + an empty Albums).
+                    if (hasAlbums) {
+                        item(key = "filter") {
+                            ChipsRow(
+                                chips = listOf(
+                                    LatestReleaseFilter.ALL to stringResource(R.string.filter_all),
+                                    LatestReleaseFilter.ALBUMS to stringResource(R.string.filter_albums),
+                                    LatestReleaseFilter.SONGS to stringResource(R.string.filter_songs),
+                                ),
+                                currentValue = filter,
+                                onValueUpdate = { filter = it },
+                            )
+                        }
                     }
 
-                    if (isCuratedChipEmpty(filter, uiState.page.albums.size, visibleSongs.size)) {
+                    if (isCuratedChipEmpty(effectiveFilter, uiState.page.albums.size, visibleSongs.size)) {
                         item(key = "empty_playlist") {
                             Column(
                                 modifier = Modifier
@@ -323,7 +338,7 @@ fun ZemerCuratedPlaylistScreen(
 
                     // Albums chip: the curated albums as browsable rows (tap opens the album screen
                     // via the server /album path). Play/Shuffle above still play the chip's tracks.
-                    if (filter == LatestReleaseFilter.ALBUMS) {
+                    if (effectiveFilter == LatestReleaseFilter.ALBUMS) {
                         items(
                             items = uiState.page.albums,
                             key = { it.browseId },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -202,7 +202,14 @@ fun OnlineSearchResult(
 
                 is AlbumItem -> navController.navigate(searchProvider.onlineAlbumRoute(item))
                 is ArtistItem -> navController.navigate("artist/${item.id}")
-                is PlaylistItem -> navController.navigate(searchProvider.onlinePlaylistRoute(item.id))
+                // A playlist on the Community chip is a discovery-sourced community list — tag its plays
+                // `community:<id>` (same source as the home Community row). Featured/artist-owned stay `playlist:`.
+                is PlaylistItem -> navController.navigate(
+                    searchProvider.onlinePlaylistRoute(
+                        item.id,
+                        community = searchFilter?.value == FILTER_COMMUNITY_PLAYLIST.value,
+                    )
+                )
             }
         }
         val longClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -179,7 +179,7 @@ fun OnlineSearchResult(
         // ONE activation path for tap and D-pad select: fires the telemetry click, then the
         // existing navigation/playback behavior (search-tapped songs play with source "search").
         val activate = {
-            Tracker.click(viewModel.query, item.id, clickKind(item, searchFilter?.value), rank)
+            Tracker.click(viewModel.query, item.id, clickKind(item, searchFilter?.value, searchProvider), rank)
             when (item) {
                 is SongItem -> {
                     val isVideoFilter = !blockVideos && searchFilter?.value == FILTER_VIDEO.value
@@ -202,12 +202,13 @@ fun OnlineSearchResult(
 
                 is AlbumItem -> navController.navigate(searchProvider.onlineAlbumRoute(item))
                 is ArtistItem -> navController.navigate("artist/${item.id}")
-                // A playlist on the Community chip is a discovery-sourced community list — tag its plays
-                // `community:<id>` (same source as the home Community row). Featured/artist-owned stay `playlist:`.
+                // A discovery-sourced community playlist tags its plays `community:<id>` (same source as the
+                // home Community row); featured/artist-owned stay `playlist:`. Community-ness covers the
+                // Community chip AND the Zemer summary preview, not just the chip — see [playlistIsCommunity].
                 is PlaylistItem -> navController.navigate(
                     searchProvider.onlinePlaylistRoute(
                         item.id,
-                        community = searchFilter?.value == FILTER_COMMUNITY_PLAYLIST.value,
+                        community = playlistIsCommunity(searchFilter?.value, searchProvider),
                     )
                 )
             }
@@ -497,11 +498,24 @@ private fun summaryItemKey(sectionTitle: String, id: String, index: Int) = "$sec
 
 private fun filteredItemKey(id: String) = "filtered_$id"
 
-private fun clickKind(item: YTItem, filterValue: String?): String = when (item) {
+private fun clickKind(item: YTItem, filterValue: String?, provider: SearchProvider): String = when (item) {
     is SongItem -> if (filterValue == FILTER_VIDEO.value) "video" else "song"
     is AlbumItem -> "album"
     is ArtistItem -> "artist"
-    is PlaylistItem -> if (filterValue == FILTER_COMMUNITY_PLAYLIST.value) "community" else "playlist"
+    is PlaylistItem -> if (playlistIsCommunity(filterValue, provider)) "community" else "playlist"
+}
+
+/**
+ * Whether a tapped [PlaylistItem] is a discovery-sourced community playlist (tagged `community:<id>` and
+ * counted "community" for telemetry) vs. an artist-owned/featured one. The Community chip is community; and
+ * with no chip picked the Zemer engine's only playlist section IS the community preview
+ * (ZemerResultMapper's TITLE_PLAYLISTS = categories.community), so a Zemer-summary playlist is community
+ * too. The Featured chip and the YouTube engine are plain playlists (the `else`).
+ */
+private fun playlistIsCommunity(filterValue: String?, provider: SearchProvider): Boolean = when {
+    filterValue == FILTER_COMMUNITY_PLAYLIST.value -> true
+    filterValue == null -> provider == SearchProvider.ZEMER
+    else -> false
 }
 
 private fun mapItemToFilter(item: YTItem): com.metrolist.innertube.YouTube.SearchFilter? =

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
@@ -6,6 +6,7 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Song
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,7 @@ enum class HomeSeeAllRow(val slug: String, @StringRes val titleRes: Int) {
     FEATURED_ALBUMS("featured-albums", R.string.featured_albums),
     FEATURED_ARTISTS("featured-artists", R.string.featured_artists),
     FEATURED_VIDEOS("featured-videos", R.string.featured_videos),
+    FEATURED_PLAYLISTS("featured-playlists", R.string.featured_playlists),
     KEEP_LISTENING("keep-listening", R.string.keep_listening),
     FORGOTTEN_FAVORITES("forgotten-favorites", R.string.forgotten_favorites),
     QUICK_PICKS("quick-picks", R.string.quick_picks),
@@ -35,12 +37,15 @@ data class HomeSeeAllData(
     val featuredAlbums: List<AlbumItem> = emptyList(),
     val featuredArtists: List<ArtistItem> = emptyList(),
     val featuredVideos: List<SongItem> = emptyList(),
+    val featuredPlaylists: List<PlaylistItem> = emptyList(),
     val keepListening: List<LocalItem> = emptyList(),
     val forgottenFavorites: List<Song> = emptyList(),
     val quickPicks: List<Song> = emptyList(),
     // True when [featuredAlbums] is Zemer-sourced (telemetry) rather than the InnerTube scrape fallback,
     // so the See-all opens those albums through the server album route — same rule as the Home row.
     val featuredAlbumsAreZemer: Boolean = false,
+    // Same, for [featuredPlaylists]: Zemer community playlists open via the server /playlist route.
+    val featuredPlaylistsAreZemer: Boolean = false,
 )
 
 /**

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
@@ -1,0 +1,60 @@
+package com.jtech.zemer.viewmodels
+
+import androidx.annotation.StringRes
+import com.jtech.zemer.R
+import com.jtech.zemer.db.entities.LocalItem
+import com.jtech.zemer.db.entities.Song
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.SongItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Which Home row a "See all" screen is showing. The [slug] is the nav argument (stable, route-safe)
+ * and [titleRes] reuses the Home section's own title string, so the See-all header always matches the
+ * row it opened from.
+ */
+enum class HomeSeeAllRow(val slug: String, @StringRes val titleRes: Int) {
+    FEATURED_ALBUMS("featured-albums", R.string.featured_albums),
+    FEATURED_ARTISTS("featured-artists", R.string.featured_artists),
+    FEATURED_VIDEOS("featured-videos", R.string.featured_videos),
+    KEEP_LISTENING("keep-listening", R.string.keep_listening),
+    FORGOTTEN_FAVORITES("forgotten-favorites", R.string.forgotten_favorites),
+    QUICK_PICKS("quick-picks", R.string.quick_picks),
+    ;
+
+    companion object {
+        fun fromSlug(slug: String?): HomeSeeAllRow? = entries.firstOrNull { it.slug == slug }
+    }
+}
+
+/** The full (un-capped, un-rotated) Home rows, already content-filtered, that back the See-all screens. */
+data class HomeSeeAllData(
+    val featuredAlbums: List<AlbumItem> = emptyList(),
+    val featuredArtists: List<ArtistItem> = emptyList(),
+    val featuredVideos: List<SongItem> = emptyList(),
+    val keepListening: List<LocalItem> = emptyList(),
+    val forgottenFavorites: List<Song> = emptyList(),
+    val quickPicks: List<Song> = emptyList(),
+    // True when [featuredAlbums] is Zemer-sourced (telemetry) rather than the InnerTube scrape fallback,
+    // so the See-all opens those albums through the server album route — same rule as the Home row.
+    val featuredAlbumsAreZemer: Boolean = false,
+)
+
+/**
+ * A process-wide snapshot of the full Home rows, published by [HomeViewModel] on every load and read by
+ * the See-all screens. Same pattern as the Latest-Releases store: the See-all screen shows exactly what
+ * Home already computed and filtered (no re-fetch, no re-filter, so the two can never disagree), just
+ * un-capped and as a vertical page. Empty until Home has loaded once — a See-all opened before then shows
+ * an empty page, which cannot happen in practice because Home loads on app start.
+ */
+object HomeSeeAllStore {
+    private val _data = MutableStateFlow(HomeSeeAllData())
+    val data: StateFlow<HomeSeeAllData> = _data.asStateFlow()
+
+    fun publish(data: HomeSeeAllData) {
+        _data.value = data
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -83,7 +83,6 @@ class HomeViewModel @Inject constructor(
         val isNewUser: Boolean = true,
         val quickPicks: List<Song> = emptyList(),
         val featuredPlaylists: List<PlaylistItem> = emptyList(),
-        val trendingSongs: List<SongItem> = emptyList(),
         val keepListening: List<LocalItem> = emptyList(),
         val forgottenFavorites: List<Song> = emptyList(),
         val featuredAlbums: List<AlbumItem> = emptyList(),
@@ -248,33 +247,6 @@ class HomeViewModel @Inject constructor(
             .shuffled()
             .distinctBy { it.id }
             .take(8)
-    }
-
-    private suspend fun loadTrendingSongs(filters: ContentFilterConfig, hideExplicit: Boolean): List<SongItem> {
-        val start = System.currentTimeMillis()
-        val allowedIds = WhitelistCache.allowedEntries(database, filters).map { it.artistId }.toSet()
-        // Fail closed: with no whitelisted artists there is nothing to show — never fall back to raw charts.
-        // Reached only when the whitelist is empty; the whitelist-present path below is unchanged.
-        if (allowedIds.isEmpty()) {
-            Timber.w("HomeViewModel: whitelist empty — trending fail-closed (no raw charts)")
-            return emptyList()
-        }
-        val charts = YouTube.getChartsPage().getOrNull()
-        Timber.d("NET: YouTube.getChartsPage() took ${System.currentTimeMillis() - start}ms")
-        if (charts == null) return emptyList()
-        val allSongs = charts.sections
-            .flatMap { it.items }
-            .filterIsInstance<SongItem>()
-            .filterExplicit(hideExplicit)
-        val whitelisted =
-            if (allowedIds.isEmpty()) allSongs
-            else allSongs.filter { item -> item.artists?.any { it.id in allowedIds } == true }
-
-        val chosen = when {
-            whitelisted.isNotEmpty() -> whitelisted
-            else -> allSongs
-        }
-        return chosen.distinctBy { it.id }.take(30)
     }
 
     private suspend fun loadKeepListening(): List<LocalItem> {
@@ -1008,7 +980,6 @@ class HomeViewModel @Inject constructor(
 
             // Now start NETWORK calls (after prep work is done)
             Timber.d("HomeViewModel: Starting NETWORK fetch at +${System.currentTimeMillis() - loadStartTime}ms")
-            val trendingDeferred = viewModelScope.async(Dispatchers.IO) { loadTrendingSongs(effectiveFilters, hideExplicit) }
             val homeDeferred = viewModelScope.async(Dispatchers.IO) {
                 if (useWhitelist) {
                     loadWhitelistHome(
@@ -1040,7 +1011,6 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
-            val trendingSongs = trendingDeferred.await()
             val home = homeDeferred.await()
             val explore = exploreDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
@@ -1193,11 +1163,6 @@ class HomeViewModel @Inject constructor(
                 }
             }
             Timber.d("HomeViewModel: finalQuick=${finalQuick.size} (original=${quick.size}, rotated=${recentAwareQuick.size})")
-            val finalTrending = rotateByArtist(
-                trendingSongs.filter { song -> song.isAllowed() },
-                maxPerArtist = 1,
-                target = 30,
-            )
             val finalFeaturedPlaylists = rotateByArtist(
                 featuredPlaylists.filter { it.isAllowed() },
                 maxPerArtist = 1,
@@ -1272,7 +1237,6 @@ class HomeViewModel @Inject constructor(
             }
 
             collectSongArtists(finalQuick)
-            collectSongItems(finalTrending)
             collectPlaylistItems(finalFeaturedPlaylists)
             collectAlbumItems(finalFeaturedAlbums)
             collectArtistItems(finalFeaturedArtists)
@@ -1308,7 +1272,6 @@ class HomeViewModel @Inject constructor(
                     isRefreshing = false,
                     isNewUser = isNewUser,
                     quickPicks = finalQuick.shuffled(Random(System.nanoTime())),
-                    trendingSongs = finalTrending,
                     featuredPlaylists = finalFeaturedPlaylists,
                     keepListening = finalKeepListening,
                     forgottenFavorites = finalForgotten,

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -1023,8 +1023,14 @@ class HomeViewModel @Inject constructor(
             // Telemetry-ranked featured rows, in parallel with the rest. Independent of the whitelist
             // scrape: the corpus is whitelist-pure, so these are served whether or not `useWhitelist`.
             val homeRowsDeferred = viewModelScope.async(Dispatchers.IO) { loadHomeRows() }
+            // YouTube.home()/explore() render NOTHING on the home tab (their `homePage`/`explorePage` are
+            // stored but never drawn). `home()` matters only as the cold-start seed for an empty Quick Picks
+            // (`seedQuickPicksFromHomePage`, which no-ops when quick is non-empty); `explore()` only fed a
+            // dedup bookkeeping set. So fetch them ONLY on a cold start (no local quick picks) — every
+            // returning-user home load skips two round-trips that produced nothing on screen.
+            val coldStart = quick.isEmpty()
             val homeDeferred = viewModelScope.async(Dispatchers.IO) {
-                if (useWhitelist) {
+                if (useWhitelist && coldStart) {
                     loadWhitelistHome(
                         hideExplicit,
                         baseProfiles,
@@ -1033,13 +1039,12 @@ class HomeViewModel @Inject constructor(
                         recentArtistIds.toSet(),
                     )
                 } else {
-                    // Fail closed: no whitelist -> no raw YouTube home feed (reached only when whitelist is empty).
-                    Timber.w("HomeViewModel: whitelist empty — home feed fail-closed (no raw content)")
+                    // No whitelist -> fail-closed (no raw feed); not cold start -> home() renders nothing, skip it.
                     null
                 }
             }
             val exploreDeferred = viewModelScope.async(Dispatchers.IO) {
-                if (useWhitelist) {
+                if (useWhitelist && coldStart) {
                     loadWhitelistExplore(
                         hideExplicit,
                         baseProfiles,
@@ -1048,8 +1053,6 @@ class HomeViewModel @Inject constructor(
                         recentArtistIds.toSet(),
                     )
                 } else {
-                    // Fail closed: no whitelist -> no raw YouTube explore feed (reached only when whitelist is empty).
-                    Timber.w("HomeViewModel: whitelist empty — explore feed fail-closed (no raw content)")
                     null
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -27,6 +27,9 @@ import com.jtech.zemer.utils.mirrorFirst
 import com.jtech.zemer.utils.ContentFilterConfig
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.SyncUtils
+import com.jtech.zemer.search.ZemerResultMapper
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.utils.WhitelistCache
 import com.jtech.zemer.utils.dataStore
 import com.jtech.zemer.utils.getSuspend
@@ -59,11 +62,19 @@ import timber.log.Timber
 import javax.inject.Inject
 import kotlin.random.Random
 
+/**
+ * Minimum items a telemetry-ranked `/home-rows` row must have (AFTER the one-per-artist rotation and the
+ * content filter) to be shown as-is. Below this the app keeps its InnerTube scrape for that row, per-row —
+ * a near-empty home row is never shipped (contract: `handoff-docs/zemer-app-home-rows-request.md`).
+ */
+private const val MIN_HOME_ROW = 4
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     @ApplicationContext val context: Context,
     val database: MusicDatabase,
     val syncUtils: SyncUtils,
+    private val zemerSearchRepository: ZemerSearchRepository,
 ) : ViewModel() {
     private data class HomeArtistProfile(
         val id: String,
@@ -88,6 +99,10 @@ class HomeViewModel @Inject constructor(
         val featuredAlbums: List<AlbumItem> = emptyList(),
         val featuredArtists: List<ArtistItem> = emptyList(),
         val featuredVideos: List<SongItem> = emptyList(),
+        // True when [featuredAlbums] came from the telemetry `/home-rows` endpoint (Zemer-sourced) rather
+        // than the InnerTube scrape fallback — the row then opens albums through the Zemer album route so
+        // the album screen loads via the server (immune to on-device InnerTube bot-gating).
+        val featuredAlbumsAreZemer: Boolean = false,
         val homePage: HomePage? = null,
         val explorePage: ExplorePage? = null,
     )
@@ -602,6 +617,28 @@ class HomeViewModel @Inject constructor(
         return (primaryPick + pickFrom(fallbackPool, remaining)).take(targetCount)
     }
 
+    /**
+     * The telemetry-ranked home rows (Top Albums / Videos / Artists) from the Zemer `/home-rows`
+     * endpoint — real distinct-device listening, already whitelist-scoped + content-filtered server-side
+     * for the current content flags. Returns null on any failure, which makes every row fall back to the
+     * InnerTube scrape (the caller's per-row `< MIN_HOME_ROW` guard). Telemetry must never break Home.
+     */
+    private suspend fun loadHomeRows(): ZemerResultMapper.HomeRows? {
+        val start = System.currentTimeMillis()
+        return runCatching { zemerSearchRepository.homeRows(zemerSearchOptions(context)) }
+            .onSuccess {
+                Timber.d(
+                    "NET: /home-rows -> albums=%d videos=%d artists=%d in %dms",
+                    it.albums.size, it.videos.size, it.artists.size, System.currentTimeMillis() - start,
+                )
+            }
+            .getOrElse {
+                Timber.w(it, "HomeViewModel: /home-rows fetch failed — rows fall back to scrape")
+                reportException(it)
+                null
+            }
+    }
+
     private suspend fun loadFeaturedContent(
         hideExplicit: Boolean,
         artistProfiles: List<HomeArtistProfile>,
@@ -980,6 +1017,9 @@ class HomeViewModel @Inject constructor(
 
             // Now start NETWORK calls (after prep work is done)
             Timber.d("HomeViewModel: Starting NETWORK fetch at +${System.currentTimeMillis() - loadStartTime}ms")
+            // Telemetry-ranked featured rows, in parallel with the rest. Independent of the whitelist
+            // scrape: the corpus is whitelist-pure, so these are served whether or not `useWhitelist`.
+            val homeRowsDeferred = viewModelScope.async(Dispatchers.IO) { loadHomeRows() }
             val homeDeferred = viewModelScope.async(Dispatchers.IO) {
                 if (useWhitelist) {
                     loadWhitelistHome(
@@ -1013,6 +1053,7 @@ class HomeViewModel @Inject constructor(
 
             val home = homeDeferred.await()
             val explore = exploreDeferred.await()
+            val homeRows = homeRowsDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
 
             // Featured playlists loaded after (uses sharedUsedArtists which is mutable)
@@ -1038,6 +1079,22 @@ class HomeViewModel @Inject constructor(
             fun AlbumItem.isAllowed(): Boolean = !isBlockedArtist(this.artists?.mapNotNull { it.id } ?: emptyList())
             fun ArtistItem.isAllowed(): Boolean = !isBlockedArtist(listOfNotNull(this.id))
             fun PlaylistItem.isAllowed(): Boolean = !isBlockedArtist(listOfNotNull(this.author?.id))
+
+            // Content gate for the telemetry-ranked rows: female (when blocked) + Israeli only, NOT the
+            // famous/american quality proxy that `isBlockedArtist` applies. Real listening reach is a
+            // better signal than the proxy, and applying it here cut the ranked rows to near-empty
+            // (handoff REPLY 3). Blocked-ids already dropped in the mapper; this is defence-in-depth over
+            // the server's own female/blocked filtering, so it needs each card's real artist channel id.
+            fun isBlockedRanked(ids: List<String>): Boolean {
+                if (ids.any { IsraeliArtistRegistry.isIsraeli(it) }) return true
+                val profiles = ids.mapNotNull { profileById[it] }
+                if (!allowFemale && profiles.any { it.isFemale == true }) return true
+                return false
+            }
+
+            fun SongItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())
+            fun AlbumItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())
+            fun ArtistItem.isAllowedRanked(): Boolean = !isBlockedRanked(listOfNotNull(this.id))
 
             fun Song.isAllowed(): Boolean = !isBlockedArtist(this.artists.map { it.id })
             fun LocalItem.isAllowed(): Boolean = when (this) {
@@ -1140,15 +1197,6 @@ class HomeViewModel @Inject constructor(
             Timber.d("HomeViewModel: quickPicks flow - quick=${quick.size}, filtered=${filteredQuick.size}, rotated=${recentAwareQuick.size}")
             sharedUsedArtists.addAll(recentAwareQuick.flatMap { it.artistIds() })
 
-            val featuredTriple = loadFeaturedContent(
-                hideExplicit,
-                baseProfiles,
-                allowFemale,
-                selectionRandom,
-                sharedUsedArtists,
-                recentArtistIds.toSet(),
-            )
-
             // CRITICAL: Never show fewer items than already displayed to user
             val finalQuick = when {
                 recentAwareQuick.size >= quick.size -> recentAwareQuick
@@ -1178,12 +1226,39 @@ class HomeViewModel @Inject constructor(
                 maxPerArtist = 1,
                 target = 20,
             )
-            val finalFeaturedAlbums = featuredTriple.first.filter { it.isAllowed() }
-                .let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
-            val finalFeaturedArtists = featuredTriple.second.filter { it.isAllowed() }
-                .let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
-            val finalFeaturedVideos = featuredTriple.third.filter { it.isAllowed() }
-                .let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
+            // Telemetry-ranked featured rows first (real listening reach, ranked-row content gate), then
+            // the one-per-artist rotation. Below MIN_HOME_ROW a row falls back to the InnerTube scrape —
+            // per-row, so a thin videos row never blanks albums. The scrape (loadFeaturedContent) is run
+            // ONCE and only when at least one row is thin, so an all-healthy home makes zero artist()
+            // calls; a de-whitelisted/blocked pool that empties a row still self-heals via the scrape.
+            val rankedAlbums = rotateByArtist(
+                homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
+            )
+            val rankedArtists = rotateByArtist(
+                homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
+            )
+            val rankedVideos = rotateByArtist(
+                homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
+            )
+            val albumsNeedScrape = rankedAlbums.size < MIN_HOME_ROW
+            val artistsNeedScrape = rankedArtists.size < MIN_HOME_ROW
+            // Under blockVideos the server returns no videos and the row is hidden anyway — a deliberately
+            // empty videos row must NOT drag in the scrape (which would defeat the no-scrape-when-healthy
+            // win for every blockVideos user). Only a thin row while videos ARE allowed is a real gap.
+            val videosNeedScrape = !filters.blockVideos && rankedVideos.size < MIN_HOME_ROW
+            val featuredTriple = if (albumsNeedScrape || artistsNeedScrape || videosNeedScrape) {
+                Timber.d("HomeViewModel: /home-rows thin (a=%b ar=%b v=%b) — scraping fallback", albumsNeedScrape, artistsNeedScrape, videosNeedScrape)
+                loadFeaturedContent(hideExplicit, baseProfiles, allowFemale, selectionRandom, sharedUsedArtists, recentArtistIds.toSet())
+            } else {
+                Triple(emptyList<AlbumItem>(), emptyList<ArtistItem>(), emptyList<SongItem>())
+            }
+            val finalFeaturedAlbums = if (!albumsNeedScrape) rankedAlbums else
+                featuredTriple.first.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
+            val finalFeaturedArtists = if (!artistsNeedScrape) rankedArtists else
+                featuredTriple.second.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
+            val finalFeaturedVideos = if (!videosNeedScrape) rankedVideos else
+                featuredTriple.third.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
+            val featuredAlbumsAreZemer = !albumsNeedScrape && finalFeaturedAlbums.isNotEmpty()
             val isNewUser = finalQuick.isEmpty() && keepListening.isEmpty()
 
             val usedArtistIds = mutableSetOf<String>()
@@ -1257,12 +1332,13 @@ class HomeViewModel @Inject constructor(
             }
 
             Timber.d(
-                "HomeViewModel: load -> featuredArtists=%d playlists=%d albums=%d videos=%d quick=%d",
-                featuredTriple.second.size,
+                "HomeViewModel: load -> featuredArtists=%d playlists=%d albums=%d videos=%d quick=%d zemerAlbums=%b",
+                finalFeaturedArtists.size,
                 featuredPlaylists.size,
-                featuredTriple.first.size,
-                featuredTriple.third.size,
-                finalQuick.size
+                finalFeaturedAlbums.size,
+                finalFeaturedVideos.size,
+                finalQuick.size,
+                featuredAlbumsAreZemer,
             )
 
             Timber.d("HomeViewModel: Updating final UI state at +${System.currentTimeMillis() - loadStartTime}ms")
@@ -1278,6 +1354,7 @@ class HomeViewModel @Inject constructor(
                     featuredAlbums = finalFeaturedAlbums,
                     featuredArtists = finalFeaturedArtists,
                     featuredVideos = finalFeaturedVideos,
+                    featuredAlbumsAreZemer = featuredAlbumsAreZemer,
                     homePage = filteredHome,
                     explorePage = filteredExplore,
                 )

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -24,7 +24,6 @@ import com.jtech.zemer.utils.ContentWhitelistDoc
 import com.jtech.zemer.utils.IsraeliArtistRegistry
 import com.jtech.zemer.utils.ZemerContentClient
 import com.jtech.zemer.utils.mirrorFirst
-import com.jtech.zemer.utils.ContentFilterConfig
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.SyncUtils
 import com.jtech.zemer.search.ZemerResultMapper
@@ -1259,6 +1258,24 @@ class HomeViewModel @Inject constructor(
             val finalFeaturedVideos = if (!videosNeedScrape) rankedVideos else
                 featuredTriple.third.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
             val featuredAlbumsAreZemer = !albumsNeedScrape && finalFeaturedAlbums.isNotEmpty()
+
+            // Publish the FULL (un-rotated, un-capped) filtered rows for the "See all" screens — exactly
+            // the source each Home row draws from, so See-all can never disagree with the row. Featured
+            // rows use their actual source (ranked pool when healthy, scrape when it fell back).
+            HomeSeeAllStore.publish(
+                HomeSeeAllData(
+                    featuredAlbums = if (!albumsNeedScrape) homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }
+                    else featuredTriple.first.filter { it.isAllowed() },
+                    featuredArtists = if (!artistsNeedScrape) homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }
+                    else featuredTriple.second.filter { it.isAllowed() },
+                    featuredVideos = if (!videosNeedScrape) homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }
+                    else featuredTriple.third.filter { it.isAllowed() },
+                    keepListening = keepListening.filter { it.isAllowed() },
+                    forgottenFavorites = forgotten.filter { it.isAllowed() },
+                    quickPicks = filteredQuick,
+                    featuredAlbumsAreZemer = featuredAlbumsAreZemer,
+                ),
+            )
             val isNewUser = finalQuick.isEmpty() && keepListening.isEmpty()
 
             val usedArtistIds = mutableSetOf<String>()

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -112,6 +112,13 @@ class HomeViewModel @Inject constructor(
     @Volatile
     private var homeArtistProfilesCache: List<HomeArtistProfile> = emptyList()
 
+    // The community-playlist ids the row showed on the last load. Community `PlaylistItem`s carry no
+    // artist id, so they get none of `rotateByArtist`'s recently-used-artist avoidance — this is the
+    // equivalent for them: the next refresh prefers ids NOT just shown, so an 8-of-16 row turns over
+    // fully each pull-to-refresh instead of ~half-repeating. In-memory (resets on restart) is enough.
+    @Volatile
+    private var recentCommunityIds: Set<String> = emptySet()
+
     // Cache song IDs for instant load on next app start
     private suspend fun loadCachedLocalData(): Triple<List<Song>, List<Song>, List<LocalItem>> {
         val cachedIds = context.dataStore.getSuspend(com.jtech.zemer.constants.HomeCacheKey, "")
@@ -744,7 +751,14 @@ class HomeViewModel @Inject constructor(
             val finalFeaturedAlbums = rotateByArtist(albumsPool, maxPerArtist = 1, target = 20)
             val finalFeaturedArtists = rotateByArtist(artistsPool, maxPerArtist = 1, target = 20)
             val finalFeaturedVideos = rotateByArtist(videosPool, maxPerArtist = 1, target = 20)
-            val finalFeaturedPlaylists = rotateByArtist(communityPool, maxPerArtist = 1, target = 8)
+            // Community has no artist id (so no rotateByArtist recent-avoidance): shuffle, then prefer the
+            // playlists NOT shown on the previous load so a pull-to-refresh turns the 8-of-16 row over fully.
+            val communityShuffled = communityPool.shuffled(Random(System.nanoTime()))
+            val finalFeaturedPlaylists = (
+                communityShuffled.filterNot { it.id in recentCommunityIds } +
+                    communityShuffled.filter { it.id in recentCommunityIds }
+                ).take(8)
+            recentCommunityIds = finalFeaturedPlaylists.map { it.id }.toSet()
             val featuredAlbumsAreZemer = finalFeaturedAlbums.isNotEmpty()
             val featuredPlaylistsAreZemer = finalFeaturedPlaylists.isNotEmpty()
             val finalKeepListening = rotateByArtist(

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -102,6 +102,10 @@ class HomeViewModel @Inject constructor(
         // than the InnerTube scrape fallback — the row then opens albums through the Zemer album route so
         // the album screen loads via the server (immune to on-device InnerTube bot-gating).
         val featuredAlbumsAreZemer: Boolean = false,
+        // True when [featuredPlaylists] came from the `/home-rows` community pool (Zemer-sourced) rather
+        // than the InnerTube artist-playlist scrape fallback — the row then opens playlists via the Zemer
+        // `/playlist` route (whitelist-scoped, filter-matched to the card).
+        val featuredPlaylistsAreZemer: Boolean = false,
         val homePage: HomePage? = null,
         val explorePage: ExplorePage? = null,
     )
@@ -1055,16 +1059,6 @@ class HomeViewModel @Inject constructor(
             val homeRows = homeRowsDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
 
-            // Featured playlists loaded after (uses sharedUsedArtists which is mutable)
-            val featuredPlaylists = loadFeaturedPlaylists(
-                hideExplicit,
-                baseProfiles,
-                allowFemale,
-                selectionRandom,
-                sharedUsedArtists,
-                recentArtistIds.toSet(),
-            )
-
             fun isBlockedArtist(ids: List<String>): Boolean {
                 if (ids.any { IsraeliArtistRegistry.isIsraeli(it) }) return true
                 val profiles = ids.mapNotNull { profileById[it] }
@@ -1094,6 +1088,10 @@ class HomeViewModel @Inject constructor(
             fun SongItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())
             fun AlbumItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())
             fun ArtistItem.isAllowedRanked(): Boolean = !isBlockedRanked(listOfNotNull(this.id))
+            // Community playlists carry no curator channel id, so this is effectively a pass-through: the
+            // server already applies the female-owner hide + member survival + blocked-ids, and the mapper
+            // re-drops blocked ids. Defined for symmetry with the other ranked rows.
+            fun PlaylistItem.isAllowedRanked(): Boolean = !isBlockedRanked(listOfNotNull(this.author?.id))
 
             fun Song.isAllowed(): Boolean = !isBlockedArtist(this.artists.map { it.id })
             fun LocalItem.isAllowed(): Boolean = when (this) {
@@ -1210,11 +1208,20 @@ class HomeViewModel @Inject constructor(
                 }
             }
             Timber.d("HomeViewModel: finalQuick=${finalQuick.size} (original=${quick.size}, rotated=${recentAwareQuick.size})")
-            val finalFeaturedPlaylists = rotateByArtist(
-                featuredPlaylists.filter { it.isAllowed() },
-                maxPerArtist = 1,
-                target = 8,
-            )
+            // Featured Playlists from the telemetry endpoint's discovery-ranked community pool (view-ranked,
+            // whitelist-pure + content-filtered server-side). Below MIN_HOME_ROW it falls back to the
+            // InnerTube artist-playlist scrape — run ONLY then, so a healthy home makes zero playlist
+            // scrape calls and this is the last InnerTube row to retire.
+            val communityPool = homeRows?.community.orEmpty().filter { it.isAllowedRanked() }
+            val rankedCommunity = rotateByArtist(communityPool, maxPerArtist = 1, target = 8)
+            val playlistsNeedScrape = rankedCommunity.size < MIN_HOME_ROW
+            val scrapedPlaylists = if (playlistsNeedScrape) {
+                loadFeaturedPlaylists(hideExplicit, baseProfiles, allowFemale, selectionRandom, sharedUsedArtists, recentArtistIds.toSet())
+                    .filter { it.isAllowed() }
+            } else emptyList()
+            val finalFeaturedPlaylists = if (!playlistsNeedScrape) rankedCommunity
+            else rotateByArtist(scrapedPlaylists, maxPerArtist = 1, target = 8)
+            val featuredPlaylistsAreZemer = !playlistsNeedScrape && finalFeaturedPlaylists.isNotEmpty()
             val finalKeepListening = rotateByArtist(
                 keepListening.filter { it.isAllowed() },
                 maxPerArtist = 1,
@@ -1270,10 +1277,12 @@ class HomeViewModel @Inject constructor(
                     else featuredTriple.second.filter { it.isAllowed() },
                     featuredVideos = if (!videosNeedScrape) homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }
                     else featuredTriple.third.filter { it.isAllowed() },
+                    featuredPlaylists = if (!playlistsNeedScrape) communityPool else scrapedPlaylists,
                     keepListening = keepListening.filter { it.isAllowed() },
                     forgottenFavorites = forgotten.filter { it.isAllowed() },
                     quickPicks = filteredQuick,
                     featuredAlbumsAreZemer = featuredAlbumsAreZemer,
+                    featuredPlaylistsAreZemer = featuredPlaylistsAreZemer,
                 ),
             )
             val isNewUser = finalQuick.isEmpty() && keepListening.isEmpty()
@@ -1351,7 +1360,7 @@ class HomeViewModel @Inject constructor(
             Timber.d(
                 "HomeViewModel: load -> featuredArtists=%d playlists=%d albums=%d videos=%d quick=%d zemerAlbums=%b",
                 finalFeaturedArtists.size,
-                featuredPlaylists.size,
+                finalFeaturedPlaylists.size,
                 finalFeaturedAlbums.size,
                 finalFeaturedVideos.size,
                 finalQuick.size,
@@ -1372,6 +1381,7 @@ class HomeViewModel @Inject constructor(
                     featuredArtists = finalFeaturedArtists,
                     featuredVideos = finalFeaturedVideos,
                     featuredAlbumsAreZemer = featuredAlbumsAreZemer,
+                    featuredPlaylistsAreZemer = featuredPlaylistsAreZemer,
                     homePage = filteredHome,
                     explorePage = filteredExplore,
                 )

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jtech.zemer.constants.ArtistProfilesCacheKey
 import com.jtech.zemer.constants.ArtistProfilesCacheTimestampKey
-import com.jtech.zemer.constants.HideExplicitKey
 import com.jtech.zemer.constants.HomeRecentArtistsKey
 import com.jtech.zemer.constants.InnerTubeCookieKey
 import com.jtech.zemer.constants.OnboardingCompleteKey
@@ -76,9 +75,6 @@ class HomeViewModel @Inject constructor(
         val isIsraeli: Boolean?,
         val isFemale: Boolean?,
         val isFamous: Boolean?,
-        val isKids: Boolean?,
-        val isDJ: Boolean?,
-        val isGroup: Boolean?,
     )
 
     data class HomeUiState(
@@ -362,9 +358,6 @@ class HomeViewModel @Inject constructor(
                         isIsraeli = IsraeliArtistRegistry.isIsraeli(id),
                         isFemale = doc.getBoolean("isFemale"),
                         isFamous = doc.getBoolean("isFamous"),
-                        isKids = doc.getBoolean("isKids"),
-                        isDJ = doc.getBoolean("isDJ"),
-                        isGroup = doc.getBoolean("isGroup"),
                     )
                 }
             },
@@ -379,9 +372,6 @@ class HomeViewModel @Inject constructor(
             isIsraeli = IsraeliArtistRegistry.isIsraeli(resolvedId),
             isFemale = isFemale,
             isFamous = isFamous,
-            isKids = isKids,
-            isDJ = isDJ,
-            isGroup = isGroup,
         )
     }
 
@@ -389,7 +379,9 @@ class HomeViewModel @Inject constructor(
         return try {
             json.split("||").mapNotNull { entry ->
                 val parts = entry.split("|")
-                if (parts.size < 8) return@mapNotNull null
+                // 6 fields as of the featured-content teardown; an older 9-field cache still parses (the
+                // trailing isKids/isDJ/isGroup columns are simply ignored), so no forced refetch on upgrade.
+                if (parts.size < 6) return@mapNotNull null
                 HomeArtistProfile(
                     id = parts[0],
                     name = parts[1],
@@ -397,9 +389,6 @@ class HomeViewModel @Inject constructor(
                     isIsraeli = parts[3].toBooleanStrictOrNull(),
                     isFemale = parts[4].toBooleanStrictOrNull(),
                     isFamous = parts[5].toBooleanStrictOrNull(),
-                    isKids = parts[6].toBooleanStrictOrNull(),
-                    isDJ = parts[7].toBooleanStrictOrNull(),
-                    isGroup = parts.getOrNull(8)?.toBooleanStrictOrNull(),
                 )
             }
         } catch (e: Exception) {
@@ -411,7 +400,7 @@ class HomeViewModel @Inject constructor(
     private suspend fun saveArtistProfilesToCache(profiles: List<HomeArtistProfile>) {
         try {
             val json = profiles.joinToString("||") { p ->
-                "${p.id}|${p.name}|${p.isAmerican}|${p.isIsraeli}|${p.isFemale}|${p.isFamous}|${p.isKids}|${p.isDJ}|${p.isGroup}"
+                "${p.id}|${p.name}|${p.isAmerican}|${p.isIsraeli}|${p.isFemale}|${p.isFamous}"
             }
             context.dataStore.edit { prefs ->
                 prefs[ArtistProfilesCacheKey] = json
@@ -423,59 +412,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun SongItem.isBlocked(
-        profileById: Map<String, HomeArtistProfile>,
-        allowFemale: Boolean
-    ): Boolean {
-        val ids = this.artists?.mapNotNull { it.id }.orEmpty()
-        val profiles = ids.mapNotNull { profileById[it] }
-        if (!allowFemale && profiles.any { it.isFemale == true }) return true
-        if (profiles.any { it.isAmerican != true }) return true
-        if (profiles.any { it.isIsraeli == true }) return true
-        if (profiles.any { it.isFamous != true }) return true
-        return false
-    }
-
-    private fun AlbumItem.isBlocked(
-        profileById: Map<String, HomeArtistProfile>,
-        allowFemale: Boolean
-    ): Boolean {
-        val ids = this.artists?.mapNotNull { it.id }.orEmpty()
-        val profiles = ids.mapNotNull { profileById[it] }
-        if (!allowFemale && profiles.any { it.isFemale == true }) return true
-        if (profiles.any { it.isAmerican != true }) return true
-        if (profiles.any { it.isIsraeli == true }) return true
-        if (profiles.any { it.isFamous != true }) return true
-        return false
-    }
-
-    private fun ArtistItem.isBlocked(
-        profileById: Map<String, HomeArtistProfile>,
-        allowFemale: Boolean
-    ): Boolean {
-        val profile = profileById[id]
-        if (!allowFemale && profile?.isFemale == true) return true
-        if (profile?.isAmerican != true) return true
-        if (profile?.isIsraeli == true) return true
-        if (profile?.isFamous != true) return true
-        return false
-    }
-
-    private fun PlaylistItem.isBlocked(
-        profileById: Map<String, HomeArtistProfile>,
-        allowFemale: Boolean
-    ): Boolean {
-        val authorId = author?.id
-        if (authorId != null) {
-            val profile = profileById[authorId]
-            if (!allowFemale && profile?.isFemale == true) return true
-            if (profile?.isAmerican != true) return true
-            if (profile?.isIsraeli == true) return true
-            if (profile?.isFamous != true) return true
-        }
-        return false
-    }
-
     /**
      * The telemetry-ranked home rows (Top Albums / Videos / Artists / Community) from the Zemer
      * `/home-rows` endpoint — real distinct-device listening / view counts, already whitelist-scoped +
@@ -484,18 +420,22 @@ class HomeViewModel @Inject constructor(
      */
     private suspend fun loadHomeRows(): ZemerResultMapper.HomeRows? {
         val start = System.currentTimeMillis()
-        return runCatching { zemerSearchRepository.homeRows(zemerSearchOptions(context)) }
-            .onSuccess {
+        return try {
+            zemerSearchRepository.homeRows(zemerSearchOptions(context)).also {
                 Timber.d(
                     "NET: /home-rows -> albums=%d videos=%d artists=%d community=%d in %dms",
                     it.albums.size, it.videos.size, it.artists.size, it.community.size, System.currentTimeMillis() - start,
                 )
             }
-            .getOrElse {
-                Timber.w(it, "HomeViewModel: /home-rows fetch failed — featured rows hide this load")
-                reportException(it)
-                null
-            }
+        } catch (e: java.util.concurrent.CancellationException) {
+            // Cooperative cancellation (VM cleared while the fetch is in flight) must propagate — not be
+            // caught and logged as a Crashlytics non-fatal. Matches the load()/refresh() catch boundaries.
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "HomeViewModel: /home-rows fetch failed — featured rows hide this load")
+            reportException(e)
+            null
+        }
     }
 
     /**
@@ -506,9 +446,16 @@ class HomeViewModel @Inject constructor(
      */
     private suspend fun seedQuickPicksFromZemer(existing: List<Song>): List<Song> {
         if (existing.isNotEmpty()) return existing
-        val candidateSongs = runCatching {
-            zemerSearchRepository.curatedPlaylist(QUICK_PICKS_SEED_PLAYLIST, zemerSearchOptions(context))?.songs
-        }.getOrNull().orEmpty().distinctBy { it.id }.take(40)
+        val candidateSongs = (
+            try {
+                zemerSearchRepository.curatedPlaylist(QUICK_PICKS_SEED_PLAYLIST, zemerSearchOptions(context))?.songs
+            } catch (e: java.util.concurrent.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "HomeViewModel: Quick Picks seed fetch failed")
+                null
+            }
+            ).orEmpty().distinctBy { it.id }.take(40)
 
         if (candidateSongs.isEmpty()) return existing
 
@@ -551,7 +498,6 @@ class HomeViewModel @Inject constructor(
                 .orEmpty()
                 .split(",")
                 .filter { it.isNotBlank() }
-            val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
 
             // Start LOCAL data loading immediately (parallel with prep work)
             val parallelStartTime = System.currentTimeMillis()
@@ -579,14 +525,26 @@ class HomeViewModel @Inject constructor(
 
             // Show local data immediately while network loads
             if (quick.isNotEmpty() || forgotten.isNotEmpty() || keepListening.isNotEmpty()) {
+                val shownQuick = quick.shuffled(Random(System.nanoTime()))
                 uiState.update {
                     it.copy(
-                        quickPicks = quick.shuffled(Random(System.nanoTime())),
+                        quickPicks = shownQuick,
                         forgottenFavorites = forgotten,
                         keepListening = keepListening,
                         isNewUser = quick.isEmpty() && keepListening.isEmpty()
                     )
                 }
+                // Publish the local rows to the See-all store NOW — not only after the /home-rows await — so
+                // tapping a local row's "See all" during the network window shows these songs, not a blank
+                // page. Only the local fields are updated (copy of the current snapshot), so a pull-to-refresh
+                // keeps the previous load's still-visible featured rows until the final publish replaces them.
+                HomeSeeAllStore.publish(
+                    HomeSeeAllStore.data.value.copy(
+                        quickPicks = shownQuick,
+                        forgottenFavorites = forgotten,
+                        keepListening = keepListening,
+                    ),
+                )
                 Timber.d("HomeViewModel: Showing local data first - quick=${quick.size}, forgotten=${forgotten.size}, keep=${keepListening.size}")
             }
 
@@ -595,22 +553,7 @@ class HomeViewModel @Inject constructor(
             val artistProfiles = prepDeferred.await()
             Timber.d("HomeViewModel: Prep work done at +${System.currentTimeMillis() - loadStartTime}ms")
 
-            val allowedEntries = WhitelistCache.allowedEntries(database, filters)
-            val allowedIds = allowedEntries.map { it.artistId }.toSet()
-            val useWhitelist = filters.filtersEnabled && allowedEntries.isNotEmpty()
-            val effectiveFilters = if (useWhitelist) filters else filters.copy(filtersEnabled = false)
-            val eligibleProfiles = artistProfiles
-                .filter { it.isAmerican == true }
-                .filter { it.isIsraeli != true }
-                .filter { it.isFamous == true }
             val profileById = artistProfiles.associateBy { it.id }
-            val baseProfiles = if (useWhitelist) {
-                eligibleProfiles.filter { it.id in allowedIds }
-            } else {
-                eligibleProfiles
-            }
-            val sharedUsedArtists = recentArtistIds.toMutableSet()
-            val selectionRandom = Random(System.nanoTime())
 
             // Now start NETWORK calls (after prep work is done). The home tab is InnerTube-free for content:
             // every row is served from the Zemer `/home-rows` endpoint, local Room, or the releases feed.
@@ -618,6 +561,11 @@ class HomeViewModel @Inject constructor(
             // a new user's empty Quick Picks is seeded from Zemer (below), not the YouTube home feed.
             Timber.d("HomeViewModel: Starting NETWORK fetch at +${System.currentTimeMillis() - loadStartTime}ms")
             val homeRowsDeferred = viewModelScope.async(Dispatchers.IO) { loadHomeRows() }
+            // Cold start (empty local library): seed Quick Picks from the Zemer audience Top 50, not YouTube.
+            // It is independent of /home-rows, so run it CONCURRENTLY — cold-start first paint then waits on
+            // max(RTT), not the sum. A returning user's Quick Picks is non-empty, so the seed short-circuits
+            // to a no-op with no network call.
+            val quickSeededDeferred = viewModelScope.async(Dispatchers.IO) { seedQuickPicksFromZemer(quick) }
             val homeRows = homeRowsDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
 
@@ -713,8 +661,8 @@ class HomeViewModel @Inject constructor(
                 return result.take(target)
             }
 
-            // Cold start (empty local library): seed Quick Picks from the Zemer audience Top 50, not YouTube.
-            val quickSeeded = seedQuickPicksFromZemer(quick)
+            // Cold start (empty local library): the Zemer audience Top 50 seed, launched concurrently above.
+            val quickSeeded = quickSeededDeferred.await()
 
             val filteredQuick = quickSeeded.filter { song -> song.isAllowed() }
             val fallbackQuick = runCatching {
@@ -724,7 +672,6 @@ class HomeViewModel @Inject constructor(
             val quickPool = freshQuick.ifEmpty { filteredQuick }
             val recentAwareQuick = rotateByArtist(quickPool.ifEmpty { fallbackQuick }, 1, 20)
             Timber.d("HomeViewModel: quickPicks flow - quick=${quick.size}, filtered=${filteredQuick.size}, rotated=${recentAwareQuick.size}")
-            sharedUsedArtists.addAll(recentAwareQuick.flatMap { it.artistIds() })
 
             // CRITICAL: Never show fewer items than already displayed to user
             val finalQuick = when {
@@ -740,6 +687,9 @@ class HomeViewModel @Inject constructor(
                 }
             }
             Timber.d("HomeViewModel: finalQuick=${finalQuick.size} (original=${quick.size}, rotated=${recentAwareQuick.size})")
+            // The Quick Picks row is shown in a per-load shuffle; its "See all" must lead with that SAME
+            // order (the See-all contract), so shuffle ONCE here and use it for both the row and the snapshot.
+            val displayedQuick = finalQuick.shuffled(Random(System.nanoTime()))
             // Featured rows come ONLY from the Zemer /home-rows endpoint — the ranked-row content gate
             // (female/israeli/blocked-ids, not the famous/american proxy) then the one-per-artist rotation.
             // No InnerTube: an empty pool (only possible if search.zemer.io is unreachable) just hides the
@@ -792,7 +742,7 @@ class HomeViewModel @Inject constructor(
                     featuredPlaylists = displayedFirst(finalFeaturedPlaylists, communityPool) { it.id },
                     keepListening = displayedFirst(finalKeepListening, keepListeningAllowed) { it.id },
                     forgottenFavorites = displayedFirst(finalForgotten, forgottenAllowed) { it.id },
-                    quickPicks = displayedFirst(finalQuick, filteredQuick) { it.id },
+                    quickPicks = displayedFirst(displayedQuick, filteredQuick) { it.id },
                     featuredAlbumsAreZemer = featuredAlbumsAreZemer,
                     featuredPlaylistsAreZemer = featuredPlaylistsAreZemer,
                 ),
@@ -870,7 +820,7 @@ class HomeViewModel @Inject constructor(
                     isLoading = false,
                     isRefreshing = false,
                     isNewUser = isNewUser,
-                    quickPicks = finalQuick.shuffled(Random(System.nanoTime())),
+                    quickPicks = displayedQuick,
                     featuredPlaylists = finalFeaturedPlaylists,
                     keepListening = finalKeepListening,
                     forgottenFavorites = finalForgotten,

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -38,16 +38,11 @@ import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.filterExplicit
-import com.metrolist.innertube.pages.ExplorePage
-import com.metrolist.innertube.pages.HomePage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -62,11 +57,10 @@ import javax.inject.Inject
 import kotlin.random.Random
 
 /**
- * Minimum items a telemetry-ranked `/home-rows` row must have (AFTER the one-per-artist rotation and the
- * content filter) to be shown as-is. Below this the app keeps its InnerTube scrape for that row, per-row —
- * a near-empty home row is never shipped (contract: `handoff-docs/zemer-app-home-rows-request.md`).
+ * The curated Zemer playlist whose tracks seed Quick Picks for a brand-new user (empty local library),
+ * so the cold-start seed is Zemer-sourced rather than a YouTube home-feed fetch. The audience Top 50.
  */
-private const val MIN_HOME_ROW = 4
+private const val QUICK_PICKS_SEED_PLAYLIST = "auto-top-50"
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -98,16 +92,13 @@ class HomeViewModel @Inject constructor(
         val featuredAlbums: List<AlbumItem> = emptyList(),
         val featuredArtists: List<ArtistItem> = emptyList(),
         val featuredVideos: List<SongItem> = emptyList(),
-        // True when [featuredAlbums] came from the telemetry `/home-rows` endpoint (Zemer-sourced) rather
-        // than the InnerTube scrape fallback — the row then opens albums through the Zemer album route so
-        // the album screen loads via the server (immune to on-device InnerTube bot-gating).
+        // True when [featuredAlbums] is non-empty (all featured content is Zemer-sourced now) — the row
+        // opens albums through the Zemer album route so the album screen loads via the server (immune to
+        // on-device InnerTube bot-gating).
         val featuredAlbumsAreZemer: Boolean = false,
-        // True when [featuredPlaylists] came from the `/home-rows` community pool (Zemer-sourced) rather
-        // than the InnerTube artist-playlist scrape fallback — the row then opens playlists via the Zemer
-        // `/playlist` route (whitelist-scoped, filter-matched to the card).
+        // True when [featuredPlaylists] is non-empty (all featured content is Zemer-sourced now) — the row
+        // opens playlists via the Zemer `/playlist` route (whitelist-scoped, filter-matched to the card).
         val featuredPlaylistsAreZemer: Boolean = false,
-        val homePage: HomePage? = null,
-        val explorePage: ExplorePage? = null,
     )
 
     val uiState = MutableStateFlow(HomeUiState())
@@ -118,7 +109,6 @@ class HomeViewModel @Inject constructor(
     private var hasLoadedOnce = false
     @Volatile
     private var isProcessingAccountData = false
-    private val isLoadingMore = MutableStateFlow(false)
     @Volatile
     private var homeArtistProfilesCache: List<HomeArtistProfile> = emptyList()
 
@@ -224,49 +214,6 @@ class HomeViewModel @Inject constructor(
         return distinct
     }
 
-    private suspend fun loadFeaturedPlaylists(
-        hideExplicit: Boolean,
-        artistProfiles: List<HomeArtistProfile>,
-        allowFemale: Boolean,
-        random: Random,
-        usedArtists: MutableSet<String>,
-        recentExclusions: Set<String>,
-    ): List<PlaylistItem> {
-        val start = System.currentTimeMillis()
-        val selectedArtists = selectWeightedArtists(
-            artistProfiles,
-            allowFemale,
-            12,
-            Random(random.nextLong()),
-            usedArtists,
-            recentExclusions,
-        )
-        if (selectedArtists.isEmpty()) return emptyList()
-
-        val playlistItems = coroutineScope {
-            selectedArtists.map { profile ->
-                async {
-                    YouTube.artist(profile.id).getOrNull()?.sections
-                        ?.flatMap { it.items }
-                        ?.filterExplicit(hideExplicit)
-                        ?.filterIsInstance<PlaylistItem>()
-                        ?.filter { item ->
-                            item.title.contains("playlist", ignoreCase = true) ||
-                                item.title.contains("by", ignoreCase = true) ||
-                                item.title.contains("mix", ignoreCase = true) ||
-                                item.author?.name?.isNotBlank() == true
-                        }
-                }
-            }.awaitAll().filterNotNull().flatten()
-        }
-        Timber.d("NET: loadFeaturedPlaylists (${selectedArtists.size} artists) took ${System.currentTimeMillis() - start}ms")
-
-        return playlistItems
-            .shuffled()
-            .distinctBy { it.id }
-            .take(8)
-    }
-
     private suspend fun loadKeepListening(): List<LocalItem> {
         val toTimeStamp = System.currentTimeMillis()
         val fromTimeStamp = toTimeStamp - 86400000 * 7 * 2
@@ -311,38 +258,6 @@ class HomeViewModel @Inject constructor(
         }
         Timber.d("HomeViewModel: Keep listening loaded - ${keepListeningSongs.size} songs, ${keepListeningAlbums.size} albums, ${keepListeningArtists.size} artists (total: ${combined.size})")
         return combined.distinctBy { it.id }
-    }
-
-    private suspend fun loadHomePage(hideExplicit: Boolean): HomePage? {
-        val start = System.currentTimeMillis()
-        val homeResult = YouTube.home()
-        Timber.d("NET: YouTube.home() took ${System.currentTimeMillis() - start}ms")
-        if (homeResult.isSuccess) {
-            val page = homeResult.getOrNull()!!
-            return page.copy(
-                sections = page.sections.mapNotNull { section ->
-                    val filteredItems = section.items.filterExplicit(hideExplicit)
-                    if (filteredItems.isEmpty()) null else section.copy(items = filteredItems)
-                }
-            )
-        } else {
-            homeResult.exceptionOrNull()?.let { reportException(it) }
-        }
-        return null
-    }
-
-    private suspend fun loadExplorePage(hideExplicit: Boolean): ExplorePage? {
-        val start = System.currentTimeMillis()
-        return YouTube.explore().also {
-            Timber.d("NET: YouTube.explore() took ${System.currentTimeMillis() - start}ms")
-        }.mapCatching { page ->
-            val rawAlbums = page.newReleaseAlbums
-            val finalAlbums = rawAlbums.filterExplicit(hideExplicit).filterIsInstance<AlbumItem>()
-            page.copy(newReleaseAlbums = finalAlbums)
-        }.getOrElse {
-            reportException(it)
-            null
-        }
     }
 
     private suspend fun loadHomeArtistProfiles(force: Boolean = false): List<HomeArtistProfile> {
@@ -554,304 +469,39 @@ class HomeViewModel @Inject constructor(
         return false
     }
 
-    private fun selectWeightedArtists(
-        profiles: List<HomeArtistProfile>,
-        allowFemale: Boolean,
-        targetCount: Int,
-        random: Random,
-        used: MutableSet<String>? = null,
-        recentExclusions: Set<String> = emptySet(),
-    ): List<HomeArtistProfile> {
-        if (targetCount <= 0) return emptyList()
-        val base = profiles
-            .filter { it.isAmerican == true }
-            .filter { it.isKids != true }
-            .filter { it.isIsraeli != true }
-            .filter { it.isFamous != false }
-            .filter { allowFemale || it.isFemale != true }
-            .filter { used?.contains(it.id) != true }
-        if (base.isEmpty()) return emptyList()
-
-        fun pickFrom(pool: List<HomeArtistProfile>, remainingTarget: Int): List<HomeArtistProfile> {
-            if (pool.isEmpty() || remainingTarget <= 0) return emptyList()
-            val bucketRng = Random(random.nextLong())
-            val buckets = listOf(
-                0.50f to pool.filter { it.isFamous == true }.shuffled(Random(bucketRng.nextLong())),
-                0.25f to pool.filter { it.isDJ == true }.shuffled(Random(bucketRng.nextLong())),
-                0.15f to pool.filter { it.isGroup == true }.shuffled(Random(bucketRng.nextLong())),
-                0.10f to pool.shuffled(Random(bucketRng.nextLong())),
-            )
-
-            val chosen = mutableListOf<HomeArtistProfile>()
-            val seen = mutableSetOf<String>()
-
-            buckets.forEach { (ratio, bucket) ->
-                if (bucket.isEmpty()) return@forEach
-                val goal = (remainingTarget * ratio).toInt().coerceAtLeast(1)
-                bucket.forEach { candidate ->
-                    if (chosen.size >= remainingTarget) return@forEach
-                    if (seen.add(candidate.id)) {
-                        chosen += candidate
-                        used?.add(candidate.id)
-                        if (chosen.size >= goal) return@forEach
-                    }
-                }
-            }
-
-            if (chosen.size < remainingTarget) {
-                pool.shuffled(Random(bucketRng.nextLong())).forEach { candidate ->
-                    if (chosen.size >= remainingTarget) return@forEach
-                    if (seen.add(candidate.id)) {
-                        chosen += candidate
-                        used?.add(candidate.id)
-                    }
-                }
-            }
-
-            return chosen.take(remainingTarget)
-        }
-
-        val primaryPool = base.filterNot { it.id in recentExclusions }
-        val primaryPick = pickFrom(primaryPool, targetCount)
-        if (primaryPick.size >= targetCount || recentExclusions.isEmpty()) return primaryPick.take(targetCount)
-
-        val remaining = targetCount - primaryPick.size
-        val fallbackPool = base.filter { candidate -> candidate.id !in primaryPick.map { it.id } }
-        return (primaryPick + pickFrom(fallbackPool, remaining)).take(targetCount)
-    }
-
     /**
-     * The telemetry-ranked home rows (Top Albums / Videos / Artists) from the Zemer `/home-rows`
-     * endpoint — real distinct-device listening, already whitelist-scoped + content-filtered server-side
-     * for the current content flags. Returns null on any failure, which makes every row fall back to the
-     * InnerTube scrape (the caller's per-row `< MIN_HOME_ROW` guard). Telemetry must never break Home.
+     * The telemetry-ranked home rows (Top Albums / Videos / Artists / Community) from the Zemer
+     * `/home-rows` endpoint — real distinct-device listening / view counts, already whitelist-scoped +
+     * content-filtered server-side. Returns null on any failure; every featured row then reads as empty
+     * and simply hides (no InnerTube fallback). Telemetry must never break Home.
      */
     private suspend fun loadHomeRows(): ZemerResultMapper.HomeRows? {
         val start = System.currentTimeMillis()
         return runCatching { zemerSearchRepository.homeRows(zemerSearchOptions(context)) }
             .onSuccess {
                 Timber.d(
-                    "NET: /home-rows -> albums=%d videos=%d artists=%d in %dms",
-                    it.albums.size, it.videos.size, it.artists.size, System.currentTimeMillis() - start,
+                    "NET: /home-rows -> albums=%d videos=%d artists=%d community=%d in %dms",
+                    it.albums.size, it.videos.size, it.artists.size, it.community.size, System.currentTimeMillis() - start,
                 )
             }
             .getOrElse {
-                Timber.w(it, "HomeViewModel: /home-rows fetch failed — rows fall back to scrape")
+                Timber.w(it, "HomeViewModel: /home-rows fetch failed — featured rows hide this load")
                 reportException(it)
                 null
             }
     }
 
-    private suspend fun loadFeaturedContent(
-        hideExplicit: Boolean,
-        artistProfiles: List<HomeArtistProfile>,
-        allowFemale: Boolean,
-        random: Random,
-        usedArtists: MutableSet<String>,
-        recentExclusions: Set<String>,
-    ): Triple<List<AlbumItem>, List<ArtistItem>, List<SongItem>> {
-        val start = System.currentTimeMillis()
-        val weightedArtists = selectWeightedArtists(
-            artistProfiles,
-            allowFemale,
-            15,
-            Random(random.nextLong()),
-            usedArtists,
-            recentExclusions,
-        )
-        if (weightedArtists.isEmpty()) return Triple(emptyList(), emptyList(), emptyList())
-
-        val albums = mutableListOf<AlbumItem>()
-        val artists = mutableListOf<ArtistItem>()
-        val videos = mutableListOf<SongItem>()
-
-        coroutineScope {
-            val deferredArtistPages = weightedArtists.take(15).map { profile ->
-                async {
-                    YouTube.artist(profile.id).getOrNull()
-                }
-            }
-            val artistPages = deferredArtistPages.awaitAll().filterNotNull()
-            Timber.d("NET: loadFeaturedContent fetched ${artistPages.size}/${weightedArtists.size} artists in ${System.currentTimeMillis() - start}ms")
-            artistPages.forEach { artistPage ->
-                artists.add(artistPage.artist)
-                val artistAlbums = artistPage.sections
-                    .flatMap { it.items }
-                    .filterExplicit(hideExplicit)
-                    .filterIsInstance<AlbumItem>()
-                    .take(2)
-                albums.addAll(artistAlbums)
-
-                val artistVideos = artistPage.sections
-                    .filter { section ->
-                        section.title.contains("video", ignoreCase = true) ||
-                            section.title.contains("short", ignoreCase = true)
-                    }
-                    .flatMap { section ->
-                        section.items.filterIsInstance<SongItem>()
-                    }
-                videos.addAll(artistVideos)
-            }
-        }
-
-        return Triple(
-            albums.shuffled().take(20),
-            artists.shuffled().take(20),
-            videos.distinctBy { it.id }.shuffled().take(20)
-        )
-    }
-
-    private suspend fun loadWhitelistHome(
-        hideExplicit: Boolean,
-        artistProfiles: List<HomeArtistProfile>,
-        allowFemale: Boolean,
-        random: Random,
-        recentExclusions: Set<String>,
-    ): HomePage? {
-        val start = System.currentTimeMillis()
-        val filters = ContentFilterState.state.value
-        val allowed = WhitelistCache.allowedEntries(database, filters)
-        if (allowed.isEmpty()) return null
-        val profileById = artistProfiles.associateBy { it.id }
-        val candidates = allowed.mapNotNull { profileById[it.artistId] }
-        val selected = selectWeightedArtists(candidates, allowFemale, 10, Random(random.nextLong()), recentExclusions = recentExclusions)
-        val sections = mutableListOf<HomePage.Section>()
-        val allSongs = mutableListOf<SongItem>()
-        val allAlbums = mutableListOf<AlbumItem>()
-        val allVideos = mutableListOf<SongItem>()
-
-        coroutineScope {
-            val pages = selected.map { entry ->
-                async { YouTube.artist(entry.id).getOrNull() }
-            }.awaitAll().filterNotNull()
-            Timber.d("NET: loadWhitelistHome fetched ${pages.size}/${selected.size} artists in ${System.currentTimeMillis() - start}ms")
-
-            pages.forEach { artistPage ->
-                val songs = artistPage.sections.flatMap { it.items }
-                    .filterExplicit(hideExplicit)
-                    .filterIsInstance<SongItem>()
-                    .distinctBy { it.id }
-                    .take(10)
-                allSongs.addAll(songs)
-
-                val albums = artistPage.sections.flatMap { it.items }
-                    .filterExplicit(hideExplicit)
-                    .filterIsInstance<AlbumItem>()
-                    .distinctBy { it.id }
-                    .take(5)
-                allAlbums.addAll(albums)
-
-                val videos = artistPage.sections
-                    .filter { section ->
-                        section.title.contains("video", ignoreCase = true) ||
-                            section.title.contains("short", ignoreCase = true)
-                    }
-                    .flatMap { section ->
-                        section.items.filterIsInstance<SongItem>()
-                    }
-                allVideos.addAll(videos)
-            }
-        }
-
-        allSongs.distinctBy { it.id }.take(30).also { songs ->
-            if (songs.isNotEmpty()) {
-                sections.add(
-                    HomePage.Section(
-                        title = "Songs",
-                        label = null,
-                        thumbnail = songs.firstOrNull()?.thumbnail,
-                        items = songs,
-                        endpoint = null,
-                    )
-                )
-            }
-        }
-
-        allAlbums.distinctBy { it.id }.take(20).also { albums ->
-            if (albums.isNotEmpty()) {
-                sections.add(
-                    HomePage.Section(
-                        title = "Albums",
-                        label = null,
-                        thumbnail = albums.firstOrNull()?.thumbnail,
-                        items = albums,
-                        endpoint = null,
-                    )
-                )
-            }
-        }
-
-        allVideos.distinctBy { it.id }.take(20).also { videos ->
-            if (videos.isNotEmpty()) {
-                sections.add(
-                    HomePage.Section(
-                        title = "Videos",
-                        label = null,
-                        thumbnail = videos.firstOrNull()?.thumbnail,
-                        items = videos,
-                        endpoint = null,
-                    )
-                )
-            }
-        }
-
-        return HomePage(
-            chips = null,
-            sections = sections,
-            continuation = null
-        )
-    }
-
-    private suspend fun loadWhitelistExplore(
-        hideExplicit: Boolean,
-        artistProfiles: List<HomeArtistProfile>,
-        allowFemale: Boolean,
-        random: Random,
-        recentExclusions: Set<String>,
-    ): ExplorePage? {
-        val start = System.currentTimeMillis()
-        val filters = ContentFilterState.state.value
-        val allowed = WhitelistCache.allowedEntries(database, filters)
-        if (allowed.isEmpty()) return null
-
-        val profileById = artistProfiles.associateBy { it.id }
-        val candidates = allowed.mapNotNull { profileById[it.artistId] }
-        val selected = selectWeightedArtists(
-            candidates,
-            allowFemale,
-            12,
-            Random(random.nextLong()),
-            recentExclusions = recentExclusions,
-        )
-        val albums = mutableListOf<AlbumItem>()
-
-        coroutineScope {
-            val pages = selected.map { entry ->
-                async { YouTube.artist(entry.id).getOrNull() }
-            }.awaitAll().filterNotNull()
-            Timber.d("NET: loadWhitelistExplore fetched ${pages.size}/${selected.size} artists in ${System.currentTimeMillis() - start}ms")
-
-            pages.forEach { artistPage ->
-                albums += artistPage.sections.flatMap { it.items }
-                    .filterExplicit(hideExplicit)
-                    .filterIsInstance<AlbumItem>()
-            }
-        }
-
-        return ExplorePage(
-            newReleaseAlbums = albums.distinctBy { it.id },
-            moodAndGenres = emptyList()
-        )
-    }
-
-    private suspend fun seedQuickPicksFromHomePage(page: HomePage, hideExplicit: Boolean, existing: List<Song>): List<Song> {
+    /**
+     * Seeds an empty Quick Picks for a brand-new user (no local listening yet) from a Zemer source —
+     * the audience Top 50 curated playlist — instead of YouTube's home feed. Whitelist-pure and
+     * content-filtered server-side. No-ops (returns [existing]) when Quick Picks already has content or
+     * the fetch fails, so Home never breaks and, in normal use, home makes no InnerTube call.
+     */
+    private suspend fun seedQuickPicksFromZemer(existing: List<Song>): List<Song> {
         if (existing.isNotEmpty()) return existing
-        val candidateSongs = page.sections
-            .flatMap { it.items }
-            .filterExplicit(hideExplicit)
-            .filterIsInstance<SongItem>()
-            .distinctBy { it.id }
-            .take(40)
+        val candidateSongs = runCatching {
+            zemerSearchRepository.curatedPlaylist(QUICK_PICKS_SEED_PLAYLIST, zemerSearchOptions(context))?.songs
+        }.getOrNull().orEmpty().distinctBy { it.id }.take(40)
 
         if (candidateSongs.isEmpty()) return existing
 
@@ -861,69 +511,6 @@ class HomeViewModel @Inject constructor(
 
         val seeded = database.getSongsByIds(candidateSongs.map { it.id })
         return if (seeded.isNotEmpty()) seeded.take(20) else existing
-    }
-
-    private fun selectWeightedSongs(
-        songs: List<Song>,
-        profileById: Map<String, HomeArtistProfile>,
-        allowFemale: Boolean,
-        targetCount: Int,
-        random: Random
-    ): List<Song> {
-        if (songs.isEmpty() || targetCount <= 0) return emptyList()
-
-        val base = songs.filter { song ->
-            val artistIds = song.artists.mapNotNull { it.id }
-            val profiles = artistIds.mapNotNull { profileById[it] }
-            if (profiles.isEmpty()) return@filter false
-            if (!allowFemale && profiles.any { it.isFemale == true }) return@filter false
-            if (profiles.any { it.isAmerican != true }) return@filter false
-            if (profiles.any { it.isIsraeli == true }) return@filter false
-            if (profiles.any { it.isFamous != true }) return@filter false
-            true
-        }
-        if (base.isEmpty()) return emptyList()
-
-        val rng = Random(random.nextLong())
-        val byProfile = base.groupBy { song ->
-            song.artists.mapNotNull { it.id }.firstNotNullOfOrNull { profileById[it] }
-        }
-
-        val famous = byProfile.filterKeys { it?.isFamous == true }.values.flatten().shuffled(Random(rng.nextLong()))
-        val dj = byProfile.filterKeys { it?.isDJ == true }.values.flatten().shuffled(Random(rng.nextLong()))
-        val group = byProfile.filterKeys { it?.isGroup == true }.values.flatten().shuffled(Random(rng.nextLong()))
-        val buckets = listOf(
-            0.50f to famous,
-            0.25f to dj,
-            0.15f to group,
-            0.10f to base.shuffled(Random(rng.nextLong())),
-        )
-
-        val chosen = mutableListOf<Song>()
-        val seenSong = mutableSetOf<String>()
-
-        buckets.forEach { (ratio, bucket) ->
-            if (bucket.isEmpty()) return@forEach
-            val goal = (targetCount * ratio).toInt().coerceAtLeast(1)
-            bucket.forEach { song ->
-                if (chosen.size >= targetCount) return@forEach
-                if (seenSong.add(song.id)) {
-                    chosen += song
-                    if (chosen.size >= goal) return@forEach
-                }
-            }
-        }
-
-        if (chosen.size < targetCount) {
-            base.shuffled(Random(rng.nextLong())).forEach { song ->
-                if (chosen.size >= targetCount) return@forEach
-                if (seenSong.add(song.id)) {
-                    chosen += song
-                }
-            }
-        }
-
-        return chosen.take(targetCount)
     }
 
     private suspend fun load(force: Boolean = false) {
@@ -1018,47 +605,12 @@ class HomeViewModel @Inject constructor(
             val sharedUsedArtists = recentArtistIds.toMutableSet()
             val selectionRandom = Random(System.nanoTime())
 
-            // Now start NETWORK calls (after prep work is done)
+            // Now start NETWORK calls (after prep work is done). The home tab is InnerTube-free for content:
+            // every row is served from the Zemer `/home-rows` endpoint, local Room, or the releases feed.
+            // YouTube.home()/explore() (which rendered nothing) and the InnerTube featured scrape are gone;
+            // a new user's empty Quick Picks is seeded from Zemer (below), not the YouTube home feed.
             Timber.d("HomeViewModel: Starting NETWORK fetch at +${System.currentTimeMillis() - loadStartTime}ms")
-            // Telemetry-ranked featured rows, in parallel with the rest. Independent of the whitelist
-            // scrape: the corpus is whitelist-pure, so these are served whether or not `useWhitelist`.
             val homeRowsDeferred = viewModelScope.async(Dispatchers.IO) { loadHomeRows() }
-            // YouTube.home()/explore() render NOTHING on the home tab (their `homePage`/`explorePage` are
-            // stored but never drawn). `home()` matters only as the cold-start seed for an empty Quick Picks
-            // (`seedQuickPicksFromHomePage`, which no-ops when quick is non-empty); `explore()` only fed a
-            // dedup bookkeeping set. So fetch them ONLY on a cold start (no local quick picks) — every
-            // returning-user home load skips two round-trips that produced nothing on screen.
-            val coldStart = quick.isEmpty()
-            val homeDeferred = viewModelScope.async(Dispatchers.IO) {
-                if (useWhitelist && coldStart) {
-                    loadWhitelistHome(
-                        hideExplicit,
-                        baseProfiles,
-                        allowFemale,
-                        selectionRandom,
-                        recentArtistIds.toSet(),
-                    )
-                } else {
-                    // No whitelist -> fail-closed (no raw feed); not cold start -> home() renders nothing, skip it.
-                    null
-                }
-            }
-            val exploreDeferred = viewModelScope.async(Dispatchers.IO) {
-                if (useWhitelist && coldStart) {
-                    loadWhitelistExplore(
-                        hideExplicit,
-                        baseProfiles,
-                        allowFemale,
-                        selectionRandom,
-                        recentArtistIds.toSet(),
-                    )
-                } else {
-                    null
-                }
-            }
-
-            val home = homeDeferred.await()
-            val explore = exploreDeferred.await()
             val homeRows = homeRowsDeferred.await()
             Timber.d("HomeViewModel: NETWORK data ready at +${System.currentTimeMillis() - loadStartTime}ms")
 
@@ -1154,38 +706,8 @@ class HomeViewModel @Inject constructor(
                 return result.take(target)
             }
 
-            fun HomePage?.filtered(): HomePage? {
-                if (this == null) return null
-                val filteredSections = sections.mapNotNull { section ->
-                    val filteredItems = section.items.mapNotNull { item ->
-                        when (item) {
-                            is SongItem -> item.takeUnless { it.isBlocked(profileById, allowFemale) }
-                            is AlbumItem -> item.takeUnless { it.isBlocked(profileById, allowFemale) }
-                            is ArtistItem -> item.takeUnless { it.isBlocked(profileById, allowFemale) }
-                            is PlaylistItem -> item.takeUnless { it.isBlocked(profileById, allowFemale) }
-                        }
-                    }
-                    if (filteredItems.isEmpty()) return@mapNotNull null
-                    val rotated = rotateByArtist(filteredItems, maxPerArtist = 1, target = filteredItems.size)
-                    if (rotated.isEmpty()) null else section.copy(items = rotated)
-                }
-                if (filteredSections.isEmpty()) return null
-                return copy(sections = filteredSections)
-            }
-
-            fun ExplorePage?.filtered(): ExplorePage? {
-                if (this == null) return null
-                val albums = newReleaseAlbums.filterIsInstance<AlbumItem>()
-                    .filter { !it.isBlocked(profileById, allowFemale) }
-                return copy(newReleaseAlbums = albums)
-            }
-
-            val filteredHome = home.filtered()
-            val filteredExplore = explore.filtered()
-
-            val quickSeeded = if (filteredHome != null) {
-                seedQuickPicksFromHomePage(filteredHome, hideExplicit, quick)
-            } else quick
+            // Cold start (empty local library): seed Quick Picks from the Zemer audience Top 50, not YouTube.
+            val quickSeeded = seedQuickPicksFromZemer(quick)
 
             val filteredQuick = quickSeeded.filter { song -> song.isAllowed() }
             val fallbackQuick = runCatching {
@@ -1211,20 +733,20 @@ class HomeViewModel @Inject constructor(
                 }
             }
             Timber.d("HomeViewModel: finalQuick=${finalQuick.size} (original=${quick.size}, rotated=${recentAwareQuick.size})")
-            // Featured Playlists from the telemetry endpoint's discovery-ranked community pool (view-ranked,
-            // whitelist-pure + content-filtered server-side). Below MIN_HOME_ROW it falls back to the
-            // InnerTube artist-playlist scrape — run ONLY then, so a healthy home makes zero playlist
-            // scrape calls and this is the last InnerTube row to retire.
+            // Featured rows come ONLY from the Zemer /home-rows endpoint — the ranked-row content gate
+            // (female/israeli/blocked-ids, not the famous/american proxy) then the one-per-artist rotation.
+            // No InnerTube: an empty pool (only possible if search.zemer.io is unreachable) just hides the
+            // row rather than falling back to a scrape. All featured content is therefore Zemer-sourced.
+            val albumsPool = homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }
+            val artistsPool = homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }
+            val videosPool = homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }
             val communityPool = homeRows?.community.orEmpty().filter { it.isAllowedRanked() }
-            val rankedCommunity = rotateByArtist(communityPool, maxPerArtist = 1, target = 8)
-            val playlistsNeedScrape = rankedCommunity.size < MIN_HOME_ROW
-            val scrapedPlaylists = if (playlistsNeedScrape) {
-                loadFeaturedPlaylists(hideExplicit, baseProfiles, allowFemale, selectionRandom, sharedUsedArtists, recentArtistIds.toSet())
-                    .filter { it.isAllowed() }
-            } else emptyList()
-            val finalFeaturedPlaylists = if (!playlistsNeedScrape) rankedCommunity
-            else rotateByArtist(scrapedPlaylists, maxPerArtist = 1, target = 8)
-            val featuredPlaylistsAreZemer = !playlistsNeedScrape && finalFeaturedPlaylists.isNotEmpty()
+            val finalFeaturedAlbums = rotateByArtist(albumsPool, maxPerArtist = 1, target = 20)
+            val finalFeaturedArtists = rotateByArtist(artistsPool, maxPerArtist = 1, target = 20)
+            val finalFeaturedVideos = rotateByArtist(videosPool, maxPerArtist = 1, target = 20)
+            val finalFeaturedPlaylists = rotateByArtist(communityPool, maxPerArtist = 1, target = 8)
+            val featuredAlbumsAreZemer = finalFeaturedAlbums.isNotEmpty()
+            val featuredPlaylistsAreZemer = finalFeaturedPlaylists.isNotEmpty()
             val finalKeepListening = rotateByArtist(
                 keepListening.filter { it.isAllowed() },
                 maxPerArtist = 1,
@@ -1235,52 +757,15 @@ class HomeViewModel @Inject constructor(
                 maxPerArtist = 1,
                 target = 20,
             )
-            // Telemetry-ranked featured rows first (real listening reach, ranked-row content gate), then
-            // the one-per-artist rotation. Below MIN_HOME_ROW a row falls back to the InnerTube scrape —
-            // per-row, so a thin videos row never blanks albums. The scrape (loadFeaturedContent) is run
-            // ONCE and only when at least one row is thin, so an all-healthy home makes zero artist()
-            // calls; a de-whitelisted/blocked pool that empties a row still self-heals via the scrape.
-            val rankedAlbums = rotateByArtist(
-                homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
-            )
-            val rankedArtists = rotateByArtist(
-                homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
-            )
-            val rankedVideos = rotateByArtist(
-                homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }, maxPerArtist = 1, target = 20,
-            )
-            val albumsNeedScrape = rankedAlbums.size < MIN_HOME_ROW
-            val artistsNeedScrape = rankedArtists.size < MIN_HOME_ROW
-            // Under blockVideos the server returns no videos and the row is hidden anyway — a deliberately
-            // empty videos row must NOT drag in the scrape (which would defeat the no-scrape-when-healthy
-            // win for every blockVideos user). Only a thin row while videos ARE allowed is a real gap.
-            val videosNeedScrape = !filters.blockVideos && rankedVideos.size < MIN_HOME_ROW
-            val featuredTriple = if (albumsNeedScrape || artistsNeedScrape || videosNeedScrape) {
-                Timber.d("HomeViewModel: /home-rows thin (a=%b ar=%b v=%b) — scraping fallback", albumsNeedScrape, artistsNeedScrape, videosNeedScrape)
-                loadFeaturedContent(hideExplicit, baseProfiles, allowFemale, selectionRandom, sharedUsedArtists, recentArtistIds.toSet())
-            } else {
-                Triple(emptyList<AlbumItem>(), emptyList<ArtistItem>(), emptyList<SongItem>())
-            }
-            val finalFeaturedAlbums = if (!albumsNeedScrape) rankedAlbums else
-                featuredTriple.first.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
-            val finalFeaturedArtists = if (!artistsNeedScrape) rankedArtists else
-                featuredTriple.second.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
-            val finalFeaturedVideos = if (!videosNeedScrape) rankedVideos else
-                featuredTriple.third.filter { it.isAllowed() }.let { rotateByArtist(it, maxPerArtist = 1, target = 20) }
-            val featuredAlbumsAreZemer = !albumsNeedScrape && finalFeaturedAlbums.isNotEmpty()
 
-            // Publish the FULL (un-rotated, un-capped) filtered rows for the "See all" screens — exactly
-            // the source each Home row draws from, so See-all can never disagree with the row. Featured
-            // rows use their actual source (ranked pool when healthy, scrape when it fell back).
+            // Publish the FULL (un-rotated, un-capped) filtered pools for the "See all" screens — exactly
+            // the pool each Home row draws from, so See-all can never disagree with the row.
             HomeSeeAllStore.publish(
                 HomeSeeAllData(
-                    featuredAlbums = if (!albumsNeedScrape) homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }
-                    else featuredTriple.first.filter { it.isAllowed() },
-                    featuredArtists = if (!artistsNeedScrape) homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }
-                    else featuredTriple.second.filter { it.isAllowed() },
-                    featuredVideos = if (!videosNeedScrape) homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }
-                    else featuredTriple.third.filter { it.isAllowed() },
-                    featuredPlaylists = if (!playlistsNeedScrape) communityPool else scrapedPlaylists,
+                    featuredAlbums = albumsPool,
+                    featuredArtists = artistsPool,
+                    featuredVideos = videosPool,
+                    featuredPlaylists = communityPool,
                     keepListening = keepListening.filter { it.isAllowed() },
                     forgottenFavorites = forgotten.filter { it.isAllowed() },
                     quickPicks = filteredQuick,
@@ -1327,19 +812,6 @@ class HomeViewModel @Inject constructor(
                 items.mapNotNull { it.author?.id }.forEach(usedArtistIds::add)
             }
 
-            fun collectHomeSections(sections: List<HomePage.Section>) {
-                sections.forEach { section ->
-                    section.items.forEach { item ->
-                        when (item) {
-                            is SongItem -> collectSongItems(listOf(item))
-                            is AlbumItem -> collectAlbumItems(listOf(item))
-                            is ArtistItem -> collectArtistItems(listOf(item))
-                            is PlaylistItem -> collectPlaylistItems(listOf(item))
-                        }
-                    }
-                }
-            }
-
             collectSongArtists(finalQuick)
             collectPlaylistItems(finalFeaturedPlaylists)
             collectAlbumItems(finalFeaturedAlbums)
@@ -1349,8 +821,6 @@ class HomeViewModel @Inject constructor(
             collectSongArtists(finalKeepListening.filterIsInstance<Song>())
             collectLocalAlbums(finalKeepListening.filterIsInstance<Album>())
             collectLocalArtists(finalKeepListening.filterIsInstance<Artist>())
-            collectHomeSections(filteredHome?.sections.orEmpty())
-            collectAlbumItems(filteredExplore?.newReleaseAlbums.orEmpty())
 
             context.dataStore.edit { prefs ->
                 val buffer = LinkedHashSet<String>()
@@ -1385,8 +855,6 @@ class HomeViewModel @Inject constructor(
                     featuredVideos = finalFeaturedVideos,
                     featuredAlbumsAreZemer = featuredAlbumsAreZemer,
                     featuredPlaylistsAreZemer = featuredPlaylistsAreZemer,
-                    homePage = filteredHome,
-                    explorePage = filteredExplore,
                 )
             }
             hasLoadedOnce = true
@@ -1400,84 +868,6 @@ class HomeViewModel @Inject constructor(
             reportException(e)
         } finally {
             uiState.update { it.copy(isLoading = false) }
-        }
-    }
-
-    fun loadMoreYouTubeItems(continuation: String?) {
-        if (continuation == null || isLoadingMore.value) return
-        if (ContentFilterState.state.value.filtersEnabled) return
-
-        viewModelScope.launch(Dispatchers.IO) {
-            val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
-            val allowFemale = ContentFilterState.state.value.allowFemaleSingers
-            val profileById = homeArtistProfilesCache.associateBy { it.id }
-            isLoadingMore.value = true
-            IsraeliArtistRegistry.ensureLoaded()
-            val nextSections = YouTube.home(continuation).getOrNull()
-            if (nextSections != null) {
-                uiState.update { state ->
-                    val existingSections = state.homePage?.sections.orEmpty()
-                    val mergedSections = (existingSections + nextSections.sections).mapNotNull { section ->
-                        val filteredItems = section.items
-                            .filterExplicit(hideExplicit)
-                            .filterNot { item ->
-                                when (item) {
-                                    is SongItem -> {
-                                        val profiles = item.artists?.mapNotNull { profileById[it.id] }.orEmpty()
-                                        val blockedByProfile = profiles.any { profile ->
-                                            (!allowFemale && profile.isFemale == true) ||
-                                                profile.isAmerican != true ||
-                                                profile.isIsraeli == true ||
-                                                profile.isFamous != true
-                                        }
-                                        blockedByProfile || item.artists?.any { IsraeliArtistRegistry.isIsraeli(it.id) } == true
-                                    }
-
-                                    is AlbumItem -> {
-                                        val profiles = item.artists?.mapNotNull { profileById[it.id] }.orEmpty()
-                                        val blockedByProfile = profiles.any { profile ->
-                                            (!allowFemale && profile.isFemale == true) ||
-                                                profile.isAmerican != true ||
-                                                profile.isIsraeli == true ||
-                                                profile.isFamous != true
-                                        }
-                                        blockedByProfile || item.artists?.any { IsraeliArtistRegistry.isIsraeli(it.id) } == true
-                                    }
-
-                                    is ArtistItem -> {
-                                        val profile = profileById[item.id]
-                                        val blockedByProfile = profile?.let {
-                                            (!allowFemale && it.isFemale == true) ||
-                                                it.isAmerican != true ||
-                                                it.isIsraeli == true ||
-                                                it.isFamous != true
-                                        } == true
-                                        blockedByProfile || IsraeliArtistRegistry.isIsraeli(item.id)
-                                    }
-
-                                    is PlaylistItem -> {
-                                        val profile = profileById[item.author?.id]
-                                        val blockedByProfile = profile?.let {
-                                            (!allowFemale && it.isFemale == true) ||
-                                                it.isAmerican != true ||
-                                                it.isIsraeli == true ||
-                                                it.isFamous != true
-                                        } == true
-                                        blockedByProfile || IsraeliArtistRegistry.isIsraeli(item.author?.id)
-                                    }
-                                }
-                            }
-                        if (filteredItems.isEmpty()) null else section.copy(items = filteredItems)
-                    }
-                    val updatedHome = (state.homePage ?: HomePage(null, emptyList(), null)).copy(
-                        chips = state.homePage?.chips,
-                        sections = mergedSections,
-                        continuation = nextSections.continuation
-                    )
-                    state.copy(homePage = updatedHome)
-                }
-            }
-            isLoadingMore.value = false
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -750,7 +750,10 @@ class HomeViewModel @Inject constructor(
             val communityPool = homeRows?.community.orEmpty().filter { it.isAllowedRanked() }
             val finalFeaturedAlbums = rotateByArtist(albumsPool, maxPerArtist = 1, target = 20)
             val finalFeaturedArtists = rotateByArtist(artistsPool, maxPerArtist = 1, target = 20)
-            val finalFeaturedVideos = rotateByArtist(videosPool, maxPerArtist = 1, target = 20)
+            // Videos are content-limited (only ~19 whitelisted music videos clear the 30-day reach floor,
+            // ~14 distinct artists) — a 20-slot row would just show all of them every time. Cap the shown
+            // count so the row stays curated AND has headroom to turn over on refresh (server RESPONSE 18).
+            val finalFeaturedVideos = rotateByArtist(videosPool, maxPerArtist = 1, target = 8)
             // Community has no artist id (so no rotateByArtist recent-avoidance): shuffle, then prefer the
             // playlists NOT shown on the previous load so a pull-to-refresh turns the 8-of-16 row over fully.
             val communityShuffled = communityPool.shuffled(Random(System.nanoTime()))
@@ -772,17 +775,24 @@ class HomeViewModel @Inject constructor(
                 target = 20,
             )
 
-            // Publish the FULL (un-rotated, un-capped) filtered pools for the "See all" screens — exactly
-            // the pool each Home row draws from, so See-all can never disagree with the row.
+            // Publish the FULL filtered pool for each "See all" screen, but LED BY the items the Home row is
+            // currently showing, in the row's order — so tapping the arrow continues from exactly what you
+            // were looking at, then the rest of the pool. (De-duped by id; the row is a subset of the pool.)
+            fun <T> displayedFirst(displayed: List<T>, pool: List<T>, idOf: (T) -> String): List<T> {
+                val shown = displayed.mapTo(HashSet()) { idOf(it) }
+                return displayed + pool.filterNot { idOf(it) in shown }
+            }
+            val keepListeningAllowed = keepListening.filter { it.isAllowed() }
+            val forgottenAllowed = forgotten.filter { it.isAllowed() }
             HomeSeeAllStore.publish(
                 HomeSeeAllData(
-                    featuredAlbums = albumsPool,
-                    featuredArtists = artistsPool,
-                    featuredVideos = videosPool,
-                    featuredPlaylists = communityPool,
-                    keepListening = keepListening.filter { it.isAllowed() },
-                    forgottenFavorites = forgotten.filter { it.isAllowed() },
-                    quickPicks = filteredQuick,
+                    featuredAlbums = displayedFirst(finalFeaturedAlbums, albumsPool) { it.id },
+                    featuredArtists = displayedFirst(finalFeaturedArtists, artistsPool) { it.id },
+                    featuredVideos = displayedFirst(finalFeaturedVideos, videosPool) { it.id },
+                    featuredPlaylists = displayedFirst(finalFeaturedPlaylists, communityPool) { it.id },
+                    keepListening = displayedFirst(finalKeepListening, keepListeningAllowed) { it.id },
+                    forgottenFavorites = displayedFirst(finalForgotten, forgottenAllowed) { it.id },
+                    quickPicks = displayedFirst(finalQuick, filteredQuick) { it.id },
                     featuredAlbumsAreZemer = featuredAlbumsAreZemer,
                     featuredPlaylistsAreZemer = featuredPlaylistsAreZemer,
                 ),

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -75,6 +75,10 @@ class HomeViewModel @Inject constructor(
         val isIsraeli: Boolean?,
         val isFemale: Boolean?,
         val isFamous: Boolean?,
+        // Read only by the ranked kids gate (isBlockedRanked): a kids-only artist stays out of the adult
+        // Home. Distinct from the whitelist's isKidZone (which drives the KidZone tab), and from isDJ/isGroup
+        // (removed with the weighted-selection teardown, which were their only readers).
+        val isKids: Boolean?,
     )
 
     data class HomeUiState(
@@ -358,6 +362,7 @@ class HomeViewModel @Inject constructor(
                         isIsraeli = IsraeliArtistRegistry.isIsraeli(id),
                         isFemale = doc.getBoolean("isFemale"),
                         isFamous = doc.getBoolean("isFamous"),
+                        isKids = doc.getBoolean("isKids"),
                     )
                 }
             },
@@ -372,6 +377,7 @@ class HomeViewModel @Inject constructor(
             isIsraeli = IsraeliArtistRegistry.isIsraeli(resolvedId),
             isFemale = isFemale,
             isFamous = isFamous,
+            isKids = isKids,
         )
     }
 
@@ -379,9 +385,10 @@ class HomeViewModel @Inject constructor(
         return try {
             json.split("||").mapNotNull { entry ->
                 val parts = entry.split("|")
-                // 6 fields as of the featured-content teardown; an older 9-field cache still parses (the
-                // trailing isKids/isDJ/isGroup columns are simply ignored), so no forced refetch on upgrade.
-                if (parts.size < 6) return@mapNotNull null
+                // 7 fields (id|name|isAmerican|isIsraeli|isFemale|isFamous|isKids). An original 9-field
+                // cache still parses — parts[6] is isKids in that layout too, and the trailing isDJ/isGroup
+                // are ignored — so upgrading from the released format needs no forced refetch.
+                if (parts.size < 7) return@mapNotNull null
                 HomeArtistProfile(
                     id = parts[0],
                     name = parts[1],
@@ -389,6 +396,7 @@ class HomeViewModel @Inject constructor(
                     isIsraeli = parts[3].toBooleanStrictOrNull(),
                     isFemale = parts[4].toBooleanStrictOrNull(),
                     isFamous = parts[5].toBooleanStrictOrNull(),
+                    isKids = parts[6].toBooleanStrictOrNull(),
                 )
             }
         } catch (e: Exception) {
@@ -400,7 +408,7 @@ class HomeViewModel @Inject constructor(
     private suspend fun saveArtistProfilesToCache(profiles: List<HomeArtistProfile>) {
         try {
             val json = profiles.joinToString("||") { p ->
-                "${p.id}|${p.name}|${p.isAmerican}|${p.isIsraeli}|${p.isFemale}|${p.isFamous}"
+                "${p.id}|${p.name}|${p.isAmerican}|${p.isIsraeli}|${p.isFemale}|${p.isFamous}|${p.isKids}"
             }
             context.dataStore.edit { prefs ->
                 prefs[ArtistProfilesCacheKey] = json
@@ -583,7 +591,7 @@ class HomeViewModel @Inject constructor(
             fun ArtistItem.isAllowed(): Boolean = !isBlockedArtist(listOfNotNull(this.id))
             fun PlaylistItem.isAllowed(): Boolean = !isBlockedArtist(listOfNotNull(this.author?.id))
 
-            // Content gate for the telemetry-ranked rows: female (when blocked) + Israeli only, NOT the
+            // Content gate for the telemetry-ranked rows: female (when blocked) + Israeli + kids-only, NOT the
             // famous/american quality proxy that `isBlockedArtist` applies. Real listening reach is a
             // better signal than the proxy, and applying it here cut the ranked rows to near-empty
             // (handoff REPLY 3). Blocked-ids already dropped in the mapper; this is defence-in-depth over
@@ -592,6 +600,10 @@ class HomeViewModel @Inject constructor(
                 if (ids.any { IsraeliArtistRegistry.isIsraeli(it) }) return true
                 val profiles = ids.mapNotNull { profileById[it] }
                 if (!allowFemale && profiles.any { it.isFemale == true }) return true
+                // Kids-only artists belong in KidZone, not the adult Home — restore the pre-teardown
+                // exclusion (selectWeightedArtists' `isKids != true`). isKids is a per-artist flag, distinct
+                // from the whitelist's isKidZone that the server's kidZone filter keys on.
+                if (profiles.any { it.isKids == true }) return true
                 return false
             }
 

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt
@@ -12,6 +12,7 @@ import com.jtech.zemer.constants.HideExplicitKey
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.search.ZemerSearchRepository
 import com.jtech.zemer.search.zemerSearchOptions
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.utils.dataStore
 import com.jtech.zemer.utils.getSuspend
 import com.jtech.zemer.utils.filterWhitelisted
@@ -42,6 +43,15 @@ class OnlinePlaylistViewModel @Inject constructor(
     // A Zemer-sourced playlist opens through the server's `/playlist` endpoint (already whitelist-scoped)
     // so its tracks/count/cover match the search card, instead of the InnerTube + local-whitelist path.
     private val isZemer = savedStateHandle.get<Boolean>("zemer") == true
+
+    // A discovery-sourced community playlist (home "Community playlists" row / search Community chip);
+    // its plays are tagged `community:<id>` so the server can rank the community home row by real
+    // engagement. Artist-owned playlists stay `playlist:<id>`. See [playSource].
+    private val isCommunity = savedStateHandle.get<Boolean>("community") == true
+
+    /** The tracking source for plays started from this screen (used by both Play and Shuffle). */
+    val playSource: String =
+        if (isCommunity) PlaySource.community(playlistId) else PlaySource.playlist(playlistId)
 
     val playlist = MutableStateFlow<PlaylistItem?>(null)
     val playlistSongs = MutableStateFlow<List<SongItem>>(emptyList())

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OnlinePlaylistViewModel.kt
@@ -42,7 +42,10 @@ class OnlinePlaylistViewModel @Inject constructor(
 
     // A Zemer-sourced playlist opens through the server's `/playlist` endpoint (already whitelist-scoped)
     // so its tracks/count/cover match the search card, instead of the InnerTube + local-whitelist path.
-    private val isZemer = savedStateHandle.get<Boolean>("zemer") == true
+    // Exposed because a Zemer playlist has no `shuffleEndpoint` (the whole filtered list arrives up front),
+    // so the screen gates its Shuffle button on a non-empty song list instead — matching the curated
+    // "Zemer Playlists" screen — rather than on the InnerTube-only endpoint.
+    val isZemer = savedStateHandle.get<Boolean>("zemer") == true
 
     // A discovery-sourced community playlist (home "Community playlists" row / search Community chip);
     // its plays are tagged `community:<id>` so the server can rank the community home row by real

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -6,6 +6,10 @@
     <string name="crop_album_art_desc">Fill the player with the cover art instead of fitting it (edges may be cropped)</string>
     <string name="not_applicable">N/A</string>
 
+    <!-- Home rows -->
+    <string name="featured_playlists">Community playlists</string>
+    <string name="home_see_all_empty">Nothing here yet</string>
+
     <string name="local_history">Local</string>
     <string name="remote_history">Remote</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="mood_and_genres">Mood and Genres</string>
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
-    <string name="featured_playlists">Community playlists</string>
     <string name="forgotten_favorites">Forgotten favorites</string>
     <string name="keep_listening">Keep listening</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="mood_and_genres">Mood and Genres</string>
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
-    <string name="featured_playlists">Random playlists</string>
+    <string name="featured_playlists">Community playlists</string>
     <string name="forgotten_favorites">Forgotten favorites</string>
     <string name="keep_listening">Keep listening</string>
 

--- a/app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt
@@ -23,6 +23,16 @@ class SearchProviderTest {
         assertEquals("online_playlist/PL1", SearchProvider.YOUTUBE.onlinePlaylistRoute("PL1"))
     }
 
+    @Test
+    fun `community flag adds community=true so plays tag community not playlist`() {
+        assertEquals(
+            "online_playlist/PL1?zemer=true&community=true",
+            SearchProvider.ZEMER.onlinePlaylistRoute("PL1", community = true),
+        )
+        // Default (artist-owned / non-community) is unchanged.
+        assertEquals("online_playlist/PL1?zemer=true", SearchProvider.ZEMER.onlinePlaylistRoute("PL1", community = false))
+    }
+
     private val album = AlbumItem(
         browseId = "MPRE1",
         playlistId = "OLAK1",

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -485,4 +485,96 @@ class ZemerResultMapperTest {
             ZemerResultMapper.filtered(resp, SearchFilter.FILTER_SONG, hideExplicit = false).items.map { it.id },
         )
     }
+
+    // --- /home-rows mapping (telemetry-ranked home tab rows) ---
+
+    @Test
+    fun `home rows map to native items carrying the artist channel id`() {
+        // The channel id is the whole reason topAlbums/topVideos carry artistId: the home tab runs a
+        // one-per-artist dedup + a female/israeli check on it, which no-op when the id is null.
+        val resp = ZemerHomeRowsResponse(
+            topAlbums = listOf(
+                ZemerAlbum(id = "MPRE1", playlistId = "OLAK1", title = "Al", artist = "A", artistId = "UCa", year = 2026, thumbnail = "th"),
+            ),
+            topVideos = listOf(ZemerTrack(videoId = "v1", title = "Vid", artist = "B", artistId = "UCb")),
+            topArtists = listOf(ZemerArtist("UCc", "C", "art")),
+            topCommunity = listOf(ZemerPlaylist("c1", "Community", "Cur", "t")), // ignored — not wired yet
+        )
+
+        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+
+        val album = rows.albums.single()
+        assertEquals("MPRE1", album.browseId)
+        assertEquals("OLAK1", album.playlistId) // kept, so the card is playable / opens via the server
+        assertEquals("UCa", album.artists?.single()?.id)
+
+        val video = rows.videos.single()
+        assertEquals("v1", video.id)
+        assertEquals("UCb", video.artists.single().id)
+        assertEquals("https://i.ytimg.com/vi/v1/hqdefault.jpg", video.thumbnail) // derived from videoId
+
+        val artist = rows.artists.single()
+        assertEquals("UCc", artist.id)
+        assertEquals("art", artist.thumbnail)
+    }
+
+    @Test
+    fun `home rows honor hideExplicit on albums and videos`() {
+        val resp = ZemerHomeRowsResponse(
+            topAlbums = listOf(
+                ZemerAlbum(id = "clean", title = "C", artist = "A", explicit = false),
+                ZemerAlbum(id = "dirty", title = "D", artist = "A", explicit = true),
+            ),
+            topVideos = listOf(
+                ZemerTrack(videoId = "cv", title = "C", artist = "A", explicit = false),
+                ZemerTrack(videoId = "dv", title = "D", artist = "A", explicit = true),
+            ),
+        )
+
+        val hidden = ZemerResultMapper.homeRows(resp, hideExplicit = true)
+        assertEquals(listOf("clean"), hidden.albums.map { it.id })
+        assertEquals(listOf("cv"), hidden.videos.map { it.id })
+
+        val shown = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        assertEquals(listOf("clean", "dirty"), shown.albums.map { it.id })
+        assertEquals(listOf("cv", "dv"), shown.videos.map { it.id })
+    }
+
+    @Test
+    fun `home rows drop blank and duplicate ids per row`() {
+        val resp = ZemerHomeRowsResponse(
+            topAlbums = listOf(
+                ZemerAlbum(id = "", title = "x", artist = "A"),
+                ZemerAlbum(id = "al", title = "y", artist = "A"),
+                ZemerAlbum(id = "al", title = "dup", artist = "A"),
+            ),
+            topVideos = listOf(ZemerTrack(videoId = "", title = "x", artist = "A"), ZemerTrack(videoId = "v", title = "y", artist = "A")),
+            topArtists = listOf(ZemerArtist("", "x"), ZemerArtist("UC", "y"), ZemerArtist("UC", "dup")),
+        )
+
+        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        assertEquals(listOf("al"), rows.albums.map { it.id })
+        assertEquals(listOf("v"), rows.videos.map { it.id })
+        assertEquals(listOf("UC"), rows.artists.map { it.id })
+    }
+
+    @Test
+    fun `home rows apply blocked-id overrides to albums and videos`() {
+        BlockedIdsCache.updateAll(mapOf("blockedAlbum" to "global", "blockedVideo" to "global"))
+        ContentFilterState.current = ContentFilterConfig(filtersEnabled = true)
+        val resp = ZemerHomeRowsResponse(
+            topAlbums = listOf(
+                ZemerAlbum(id = "okAlbum", title = "A", artist = "A"),
+                ZemerAlbum(id = "blockedAlbum", title = "B", artist = "A"),
+            ),
+            topVideos = listOf(
+                ZemerTrack(videoId = "okVideo", title = "A", artist = "A"),
+                ZemerTrack(videoId = "blockedVideo", title = "B", artist = "A"),
+            ),
+        )
+
+        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        assertEquals(listOf("okAlbum"), rows.albums.map { it.id })
+        assertEquals(listOf("okVideo"), rows.videos.map { it.id })
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -501,7 +501,7 @@ class ZemerResultMapperTest {
             topCommunity = listOf(ZemerPlaylist("c1", "Community", "Cur", "th", songCount = 12)),
         )
 
-        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false) { "$it songs" }
+        val rows = ZemerResultMapper.homeRows(resp) { "$it songs" }
 
         val album = rows.albums.single()
         assertEquals("MPRE1", album.browseId)
@@ -526,28 +526,6 @@ class ZemerResultMapperTest {
     }
 
     @Test
-    fun `home rows honor hideExplicit on albums and videos`() {
-        val resp = ZemerHomeRowsResponse(
-            topAlbums = listOf(
-                ZemerAlbum(id = "clean", title = "C", artist = "A", explicit = false),
-                ZemerAlbum(id = "dirty", title = "D", artist = "A", explicit = true),
-            ),
-            topVideos = listOf(
-                ZemerTrack(videoId = "cv", title = "C", artist = "A", explicit = false),
-                ZemerTrack(videoId = "dv", title = "D", artist = "A", explicit = true),
-            ),
-        )
-
-        val hidden = ZemerResultMapper.homeRows(resp, hideExplicit = true)
-        assertEquals(listOf("clean"), hidden.albums.map { it.id })
-        assertEquals(listOf("cv"), hidden.videos.map { it.id })
-
-        val shown = ZemerResultMapper.homeRows(resp, hideExplicit = false)
-        assertEquals(listOf("clean", "dirty"), shown.albums.map { it.id })
-        assertEquals(listOf("cv", "dv"), shown.videos.map { it.id })
-    }
-
-    @Test
     fun `home rows drop blank and duplicate ids per row`() {
         val resp = ZemerHomeRowsResponse(
             topAlbums = listOf(
@@ -559,7 +537,7 @@ class ZemerResultMapperTest {
             topArtists = listOf(ZemerArtist("", "x"), ZemerArtist("UC", "y"), ZemerArtist("UC", "dup")),
         )
 
-        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        val rows = ZemerResultMapper.homeRows(resp)
         assertEquals(listOf("al"), rows.albums.map { it.id })
         assertEquals(listOf("v"), rows.videos.map { it.id })
         assertEquals(listOf("UC"), rows.artists.map { it.id })
@@ -580,7 +558,7 @@ class ZemerResultMapperTest {
             ),
         )
 
-        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        val rows = ZemerResultMapper.homeRows(resp)
         assertEquals(listOf("okAlbum"), rows.albums.map { it.id })
         assertEquals(listOf("okVideo"), rows.videos.map { it.id })
     }

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -498,10 +498,10 @@ class ZemerResultMapperTest {
             ),
             topVideos = listOf(ZemerTrack(videoId = "v1", title = "Vid", artist = "B", artistId = "UCb")),
             topArtists = listOf(ZemerArtist("UCc", "C", "art")),
-            topCommunity = listOf(ZemerPlaylist("c1", "Community", "Cur", "t")), // ignored — not wired yet
+            topCommunity = listOf(ZemerPlaylist("c1", "Community", "Cur", "th", songCount = 12)),
         )
 
-        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false)
+        val rows = ZemerResultMapper.homeRows(resp, hideExplicit = false) { "$it songs" }
 
         val album = rows.albums.single()
         assertEquals("MPRE1", album.browseId)
@@ -516,6 +516,13 @@ class ZemerResultMapperTest {
         val artist = rows.artists.single()
         assertEquals("UCc", artist.id)
         assertEquals("art", artist.thumbnail)
+
+        // topCommunity maps to the featured-playlists row (discovery-sourced community playlists).
+        val community = rows.community.single()
+        assertEquals("c1", community.id)
+        assertEquals("Community", community.title)
+        assertEquals("Cur", community.author?.name)
+        assertEquals("12 songs", community.songCountText)
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/tracking/PlaySourceResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/tracking/PlaySourceResolverTest.kt
@@ -23,6 +23,17 @@ class PlaySourceResolverTest {
     }
 
     @Test
+    fun `a community playlist queue tags its tracks community, distinct from artist playlists`() {
+        val r = PlaySourceResolver()
+        r.onQueueStarted(PlaySource.community("PL1"), listOf("v1", "v2"))
+
+        assertEquals("community:PL1", r.sourceFor("v1"))
+        assertEquals("community:PL1", r.sourceFor("v2"))
+        // Distinct from the artist-owned playlist source (the whole point of the split).
+        assertEquals("playlist:PL1", PlaySource.playlist("PL1"))
+    }
+
+    @Test
     fun `radio fill reports radio but never demotes a context item`() {
         val r = PlaySourceResolver()
         r.onQueueStarted(PlaySource.SEARCH, listOf("tapped"))

--- a/app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt
@@ -52,6 +52,15 @@ class ZemerCuratedPlaylistFilterTest {
     }
 
     @Test
+    fun `chips show only when the playlist has albums`() {
+        // No albums -> ALL == SONGS and ALBUMS is empty, so the chip row is hidden (plain track list).
+        assertFalse(curatedChipsVisible(albumCount = 0))
+        // Any albums -> the split is meaningful, show the chips.
+        assertTrue(curatedChipsVisible(albumCount = 1))
+        assertTrue(curatedChipsVisible(albumCount = 5))
+    }
+
+    @Test
     fun `empty-state gates on the SELECTED chip's content, never the raw ALL list`() {
         // ALBUMS chip renders album rows: empty albums -> empty state even with visible songs.
         assertTrue(isCuratedChipEmpty(LatestReleaseFilter.ALBUMS, albumCount = 0, visibleSongCount = 5))

--- a/docs/home_rows/README.md
+++ b/docs/home_rows/README.md
@@ -1,0 +1,91 @@
+# Home rows — telemetry-ranked, zero-InnerTube home tab
+
+Hand-authored docset for the **home tab**: how each row is sourced, why the tab makes no InnerTube
+call for content, and the rules that must not regress. Full app↔server design lives in the handoff
+thread `~/zemer-fix/handoff-docs/zemer-app-home-rows-request.md` + `home-rows-plan.md`.
+
+## TL;DR
+
+The old home tab scraped InnerTube on every load (`YouTube.artist().sections`, `getChartsPage()`,
+`YouTube.home()`/`explore()`), shuffled, and showed random YouTube-shaped content — most of which
+either rendered nothing (charts/home/explore carry ~no whitelisted artists) or was arbitrary. It now
+serves **what the Zemer audience actually plays**, and touches InnerTube for **zero** content:
+
+1. **Featured Albums / Videos / Artists / Playlists** come from the Zemer `GET /home-rows` endpoint —
+   ranked by real distinct-device listening (albums/videos/artists) and YouTube view count (community
+   playlists), 30-day live window, whitelist-pure + content-filtered server-side.
+2. **Quick Picks / Keep Listening / Forgotten Favorites** come from local Room. A brand-new user's empty
+   Quick Picks seeds from the Zemer `auto-top-50` curated playlist, not YouTube.
+3. **Latest Releases** comes from the flipphoneguy feed; **Zemer Playlists** from `/zemer-playlists`.
+4. The **mainstream Trending row is removed** (it filtered to empty and never displayed).
+
+The **only** remaining `YouTube.*` call in `HomeViewModel` is `accountInfo()` — a signed-in user's own
+name/avatar for the account card. There is **no InnerTube scrape fallback**: if `/home-rows` is
+unreachable, the featured rows just hide (local rows + Latest Releases still populate).
+
+## Direction — this is a template, not a one-off
+
+Progressively **replacing as much InnerTube as we can across the app** with Zemer-served, whitelist-pure
+data is a real, ongoing project goal. The home tab is the first surface fully migrated; other
+discovery surfaces (browse shelves, mood/genre, charts, related/recommendations) are candidates to move
+the same way — a Zemer endpoint (or a handoff request for one) rather than a YouTube feed. Streaming and
+playback are the exception: they need InnerTube + the cipher and stay (see `AGENTS.md` §The streaming
+pipeline). This doc is about content *discovery*, where YouTube's global feeds carry almost no kosher
+content to begin with.
+
+| Where | File |
+|---|---|
+| Home orchestration | `app/.../viewmodels/HomeViewModel.kt` (`load()`, `loadHomeRows()`, `seedQuickPicksFromZemer()`) |
+| Endpoint client | `app/.../search/ZemerSearchClient.kt` (`homeRows()`) → `GET https://search.zemer.io/home-rows` |
+| Repository | `app/.../search/ZemerSearchRepository.kt` (`homeRows()`) |
+| Wire → native items | `app/.../search/ZemerResultMapper.kt` (`homeRows()` → `HomeRows`) |
+| Wire models | `app/.../search/ZemerSearchModels.kt` (`ZemerHomeRowsResponse`, `ZemerAlbum/Track.artistId`) |
+| Render | `app/.../ui/screens/HomeScreen.kt` |
+| "See all" | `app/.../ui/screens/HomeSeeAllScreen.kt`, `app/.../viewmodels/HomeSeeAllStore.kt` |
+
+## The `/home-rows` contract
+
+```
+GET https://search.zemer.io/home-rows?allowFemale=0&blockVideos=1&kidZone=0
+→ { topAlbums:[ZemerAlbum+artistId+explicit], topVideos:[ZemerTrack+artistId],
+    topArtists:[ZemerArtist], topCommunity:[ZemerPlaylist] }
+```
+
+- All three content flags sent explicitly every request (server is default-OPEN; `kidZone` always `0`
+  from home — home is never reachable from the KidZone tab).
+- Cards carry the **artist channel id** (`artistId` / `ZemerArtist.id`). This is load-bearing: the home
+  one-per-artist `rotateByArtist` dedup and the female/israeli defence-in-depth both key on it and **no-op
+  when it is null**.
+- `topCommunity` = discovery-sourced community playlists, ranked by each playlist's own YouTube view
+  count (no telemetry tagging, no cold-start). Backs the **Featured Playlists** row.
+
+## Rules that must not regress
+
+- **No InnerTube for content.** The featured rows have no scrape fallback; `loadHomeRows()` null → rows
+  hide. `seedQuickPicksFromZemer` is the cold-start seed. The only `YouTube.*` in `HomeViewModel` is
+  `accountInfo()`. Never reintroduce `loadFeaturedContent` / `loadFeaturedPlaylists` / `YouTube.home()` /
+  `getChartsPage()` on this tab.
+- **Ranked content gate ≠ home gate.** `isAllowedRanked` applies female/israeli/blocked-ids ONLY, NOT the
+  famous/american quality proxy in `isBlockedArtist`. Real listening reach supersedes the proxy; applying
+  it cut the rows to near-empty (measured: albums 40→7, videos 19→2). See handoff REPLY 3.
+- **Server routing on tap.** Zemer-sourced albums/playlists open via `onlineAlbumRoute` /
+  `onlinePlaylistRoute` (`?zemer=true`), gated on `featuredAlbumsAreZemer` / `featuredPlaylistsAreZemer`,
+  so the opened screen is whitelist-scoped and bot-gate-proof. Telemetry artist cards have no radio
+  endpoint → excluded from the lucky-shuffle pool (`radioEndpoint != null`).
+- **"See all" reads the published snapshot.** `HomeSeeAllStore` holds the FULL (un-rotated) filtered pool
+  `HomeViewModel` publishes each load; the see-all pages render straight from it (no re-fetch, no
+  re-filter), so they can never disagree with the row. Featured grids are 2-column.
+- **Row sizing.** Featured rows `rotateByArtist(maxPerArtist=1, target=20)`; Featured Playlists `target=8`.
+  Community playlists have no curator id, so the dedup is a pass-through (server already applies the
+  female-owner hide + member survival + blocked-ids).
+
+## Why the removed subsystems produced nothing
+
+- `YouTube.getChartsPage()` browses `FEmusic_charts` (mainstream YT Music) — ~no whitelisted artists, so
+  the Trending row filtered to empty and never rendered.
+- `YouTube.home()`/`explore()` results (`homePage`/`explorePage`) were stored in UI state but **never
+  drawn**; `home()` only seeded cold-start Quick Picks (now Zemer), `explore()` only fed a dedup set.
+- The InnerTube featured scrape (`loadFeaturedContent`, `YouTube.artist()`) only ever ran as a thin-row /
+  outage fallback; live data showed a healthy server never returns a row under the old `MIN_ROW=4`
+  (albums 20 / videos 14 / artists 20 / community 8), so it only covered the outage case — dropped in
+  favour of hiding the row (a Kosher home shows no YouTube-shaped content even during a Zemer outage).

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (447)
+## `app` Kotlin files (449)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -139,11 +139,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 | `com.jtech.zemer.recognition.shazam` | no | 2 | 137 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 | `com.jtech.zemer.repositories` | no | 22 | 18 | android.content, androidx.media3, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 39 | `com.jtech.zemer.search` | no | 1 | 3 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 297 | `com.jtech.zemer.search` | no | 16 | 34 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 233 | `com.jtech.zemer.search` | no | 14 | 26 | io.ktor, java.io, javax.inject, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 214 | `com.jtech.zemer.search` | no | 2 | 83 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 340 | `com.jtech.zemer.search` | no | 16 | 40 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 254 | `com.jtech.zemer.search` | no | 14 | 28 | io.ktor, java.io, javax.inject, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 241 | `com.jtech.zemer.search` | no | 2 | 91 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 191 | `com.jtech.zemer.search` | no | 19 | 38 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 205 | `com.jtech.zemer.search` | no | 19 | 39 | android.content, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 346 | `com.jtech.zemer.sync` | no | 17 | 42 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 708 | `com.jtech.zemer.sync` | no | 38 | 103 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -238,14 +238,15 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/BrowseScreen.kt` | 143 | `com.jtech.zemer.ui.screens` | yes | 37 | 7 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt` | 307 | `com.jtech.zemer.ui.screens` | yes | 74 | 16 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 517 | `com.jtech.zemer.ui.screens` | yes | 75 | 31 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, java.time |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1042 | `com.jtech.zemer.ui.screens` | yes | 110 | 68 | android.net, androidx.compose, androidx.hilt, androidx.navigation, kotlin.math, kotlin.random, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 978 | `com.jtech.zemer.ui.screens` | yes | 109 | 67 | android.net, androidx.compose, androidx.hilt, androidx.navigation, kotlin.math, kotlin.random, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 272 | `com.jtech.zemer.ui.screens` | yes | 58 | 26 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 336 | `com.jtech.zemer.ui.screens` | yes | 63 | 19 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 122 | `com.jtech.zemer.ui.screens` | yes | 37 | 10 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginCapture.kt` | 39 | `com.jtech.zemer.ui.screens` | no | 0 | 7 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt` | 253 | `com.jtech.zemer.ui.screens` | yes | 53 | 23 | android.widget, androidx.compose, androidx.navigation, io.ktor, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt` | 254 | `com.jtech.zemer.ui.screens` | yes | 41 | 20 | android.annotation, android.content, android.webkit, android.widget, androidx.activity, androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/MoodAndGenresScreen.kt` | 171 | `com.jtech.zemer.ui.screens` | yes | 40 | 8 | android.content, androidx.compose, androidx.hilt, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt` | 395 | `com.jtech.zemer.ui.screens` | no | 45 | 4 | androidx.compose, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt` | 406 | `com.jtech.zemer.ui.screens` | no | 47 | 5 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt` | 254 | `com.jtech.zemer.ui.screens` | yes | 45 | 12 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt` | 2074 | `com.jtech.zemer.ui.screens` | yes | 113 | 113 | android.Manifest, android.annotation, android.content, android.graphics, android.net, android.os, android.provider, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, com.airbnb, com.google, dagger.hilt, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 53 | `com.jtech.zemer.ui.screens` | no | 4 | 11 | androidx.annotation, androidx.compose |
@@ -276,7 +277,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistDetailShared.kt` | 120 | `com.jtech.zemer.ui.screens.playlist` | yes | 29 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistHeaderCover.kt` | 16 | `com.jtech.zemer.ui.screens.playlist` | no | 0 | 0 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 | `com.jtech.zemer.ui.screens.playlist` | yes | 96 | 27 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt` | 470 | `com.jtech.zemer.ui.screens.playlist` | yes | 84 | 21 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, coil3.request |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt` | 485 | `com.jtech.zemer.ui.screens.playlist` | yes | 84 | 24 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 | `com.jtech.zemer.ui.screens.recognition` | yes | 51 | 6 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 | `com.jtech.zemer.ui.screens.recognition` | yes | 65 | 19 | android.content, android.os, androidx.activity, androidx.compose, androidx.core, androidx.hilt, coil3.compose, dagger.hilt |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 506 | `com.jtech.zemer.ui.screens.search` | yes | 88 | 35 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
@@ -373,7 +374,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 24 | `com.jtech.zemer.viewmodels` | no | 8 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 | `com.jtech.zemer.viewmodels` | no | 20 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 1515 | `com.jtech.zemer.viewmodels` | no | 58 | 309 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 65 | `com.jtech.zemer.viewmodels` | no | 11 | 18 | androidx.annotation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 975 | `com.jtech.zemer.viewmodels` | no | 55 | 211 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 17 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -424,7 +426,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ChartMovementTest.kt` | 78 | `com.jtech.zemer.search` | no | 3 | 4 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 55 | `com.jtech.zemer.search` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 184 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 488 | `com.jtech.zemer.search` | no | 15 | 60 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 587 | `com.jtech.zemer.search` | no | 15 | 73 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 | `com.jtech.zemer.search` | no | 2 | 4 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
@@ -439,7 +441,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 | `com.jtech.zemer.ui.player` | no | 4 | 3 | androidx.compose, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/screens/LoginCaptureTest.kt` | 61 | `com.jtech.zemer.ui.screens` | no | 5 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistHeaderCoverTest.kt` | 23 | `com.jtech.zemer.ui.screens.playlist` | no | 3 | 1 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt` | 64 | `com.jtech.zemer.ui.screens.playlist` | no | 7 | 4 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt` | 73 | `com.jtech.zemer.ui.screens.playlist` | no | 7 | 4 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 | `com.jtech.zemer.ui.utils` | no | 3 | 2 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 | `com.jtech.zemer.ui.utils` | no | 2 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 62 | `com.jtech.zemer.utils` | no | 5 | 6 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 328 lines | text `.md` |
+| `AGENTS.md` | 379 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `931`
+- Files counted: `933`
 - By extension:
-  - `.kt`: `546`
+  - `.kt`: `548`
   - `.xml`: `155`
   - `.mjs`: `72`
   - `.md`: `61`
@@ -114,7 +114,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 328 lines | `.md` |
+| `AGENTS.md` | 379 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -297,11 +297,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/recognition/shazam/ShazamModels.kt` | 316 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/repositories/CachedSongsRepository.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/SearchProvider.kt` | 39 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 297 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 233 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 214 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 340 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 254 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 241 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 191 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 205 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 346 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 708 lines | `.kt` |
@@ -396,14 +396,15 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/BrowseScreen.kt` | 143 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 517 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1042 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 978 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 272 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 336 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 122 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginCapture.kt` | 39 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateScreen.kt` | 253 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt` | 254 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/MoodAndGenresScreen.kt` | 171 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt` | 395 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt` | 406 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt` | 254 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt` | 2074 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 53 lines | `.kt` |
@@ -434,7 +435,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistDetailShared.kt` | 120 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistHeaderCover.kt` | 16 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt` | 560 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt` | 470 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt` | 485 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt` | 191 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt` | 336 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt` | 506 lines | `.kt` |
@@ -531,7 +532,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 24 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 1515 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 65 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 975 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 lines | `.kt` |
@@ -751,7 +753,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ChartMovementTest.kt` | 78 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/SearchProviderTest.kt` | 55 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 184 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 488 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 587 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
@@ -766,7 +768,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/ui/player/PlayerBackgroundTest.kt` | 53 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/screens/LoginCaptureTest.kt` | 61 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/PlaylistHeaderCoverTest.kt` | 23 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt` | 64 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistFilterTest.kt` | 73 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 62 lines | `.kt` |
@@ -821,7 +823,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 569 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 571 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 338 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -832,7 +834,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1040 lines | `.md` |
+| `docs/repository-map.md` | 1042 lines | `.md` |
 | `docs/tracking/README.md` | 338 lines | `.md` |
 | `docs/ui/README.md` | 317 lines | `.md` |
 | `docs/ui/standards.md` | 290 lines | `.md` |


### PR DESCRIPTION
Reworks the home tab to serve **what the Zemer audience actually plays** instead of scraping InnerTube, and takes the tab to **zero InnerTube calls for content**. Backed by the new `search.zemer.io/home-rows` endpoint (full app↔server design in `~/zemer-fix/handoff-docs/`).

## What changed

- **Featured Albums / Videos / Artists / Playlists** now come from `GET /home-rows` — ranked by real distinct-device listening (albums/videos/artists) and engagement-gated view count (community playlists → the "Community playlists" row), 30-day live window, whitelist-pure + content-filtered server-side. No InnerTube scrape.
- **Removed the dead mainstream Trending row** (`getChartsPage()` charts carry ~no whitelisted artists — it filtered to empty and never displayed). The telemetry `auto-trending` / `auto-top-50` Zemer playlists are the real trending/top surface.
- **Every content row now has a "See all"** → one generic `HomeSeeAllScreen` reading a process-wide `HomeSeeAllStore` snapshot the VM publishes each load (so See-all can never disagree with the row). Featured grids are 2-column.
- **New-user cold-start Quick Picks seeds from Zemer** (`auto-top-50`), not YouTube's home feed.
- **Removed the InnerTube scrape fallback and the render-nothing `YouTube.home()`/`explore()` subsystem** (~660 lines). If `/home-rows` is unreachable the featured rows just hide. The only remaining `YouTube.*` call in `HomeViewModel` is the account-card identity lookup (`accountInfo()`), unchanged.
- **Curated-playlist detail:** the All/Albums/Songs chip row now hides when a playlist has no albums (an all-songs playlist showed two duplicate chips + a dead-end empty Albums).

## Design decisions worth knowing

- **Ranked content gate ≠ home gate.** Ranked rows apply female/israeli/blocked-ids only, NOT the famous/american quality proxy — real listening reach supersedes it (applying it cut rows to near-empty). Cards carry the artist channel id so the one-per-artist dedup + female/israeli check work.
- **Zemer-sourced albums/playlists open via the server route** (`?zemer=true`) so the opened screen is whitelist-scoped and bot-gate-proof; telemetry artist cards (no radio endpoint) are kept out of the lucky-shuffle pool.
- **No fallback by choice:** live data shows a healthy server never returns a row under the old MIN_ROW=4 (albums 20 / videos 14 / artists 20 / community 8); the fallback only ever covered a Zemer outage, and we chose to hide the row instead (a Kosher home shows no YouTube-shaped content even during an outage).

## Project direction

Documented in `AGENTS.md` + `docs/home_rows/README.md`: progressively replacing as much InnerTube as we can across the app with Zemer-served, whitelist-pure data is an explicit ongoing goal. The home tab is the first fully-migrated surface and the template for other discovery surfaces. Streaming/playback (InnerTube + cipher) is the irreducible core and out of scope.

## Testing

- Unit tests added/extended on the pure seams: `ZemerResultMapper.homeRows()` (artistId propagation, hideExplicit, blank/dup drop, blocked-ids, community mapping) and `curatedChipsVisible`.
- `HomeViewModel`/Compose orchestration has no pure-JVM seam (Hilt VM, no Robolectric); verified via `:app:assembleDebug` + `:app:assembleRelease` (R8) and the UI-audit ratchet. Every commit builds green.