### PR TITLE
feat(artist,album,radio): corpus-native artist/album opens + Zemer Radio

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/di/ZemerSearchRepositoryEntryPoint.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/di/ZemerSearchRepositoryEntryPoint.kt
@@ -1,0 +1,17 @@
+package com.jtech.zemer.di
+
+import com.jtech.zemer.search.ZemerSearchRepository
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * Resolves the singleton [ZemerSearchRepository] from a plain application [android.content.Context], for
+ * the few non-injected constructors that need it — e.g. [com.jtech.zemer.playback.queues.LocalAlbumRadio],
+ * built inside leaf composables that have no ViewModel to inject it. Mirrors [LyricsHelperEntryPoint].
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ZemerSearchRepositoryEntryPoint {
+    fun zemerSearchRepository(): ZemerSearchRepository
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -121,6 +121,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.EmptyQueue
 import com.jtech.zemer.playback.queues.Queue
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.playback.queues.filterExplicit
 import com.jtech.zemer.tracking.Tracker
 import com.jtech.zemer.utils.CoilBitmapLoader
@@ -1029,10 +1030,10 @@ class MusicService :
         )
 
         startRadioJob = scope.launch(SilentHandler) {
-            val radioQueue = YouTubeQueue(
-                endpoint = WatchEndpoint(videoId = currentMediaMetadata.id),
-                preloadItem = null,
-                database = database
+            val radioQueue = ZemerRadioQueue(
+                kind = "song",
+                seed = currentMediaMetadata.id,
+                context = this@MusicService,
             )
             val initialStatus = try {
                 radioQueue.getInitialStatus()
@@ -1041,8 +1042,9 @@ class MusicService :
                 onStartRadioFailed()
                 return@launch
             }
-            // Item 0 is the seed (currently-playing) song; only the rest gets appended.
-            val radioItems = initialStatus.items.drop(1)
+            // Exclude the seed (currently-playing) song by id so it isn't queued twice — the Zemer radio
+            // may or may not lead with the seed, unlike the YouTube watch playlist that always did.
+            val radioItems = initialStatus.items.filterNot { it.mediaId == currentMediaMetadata.id }
             if (radioItems.isEmpty()) {
                 // Fetch came back empty (e.g. everything whitelist-filtered) — leave the
                 // existing queue alone instead of having wiped it for nothing.

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -122,6 +122,7 @@ import com.jtech.zemer.playback.queues.EmptyQueue
 import com.jtech.zemer.playback.queues.Queue
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.playback.queues.continuationItemsToAppend
 import com.jtech.zemer.playback.queues.filterExplicit
 import com.jtech.zemer.tracking.Tracker
 import com.jtech.zemer.utils.CoilBitmapLoader
@@ -139,6 +140,7 @@ import com.jtech.zemer.utils.get
 import com.jtech.zemer.utils.reportException
 import com.metrolist.innertube.utils.parseCookieString
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -950,6 +952,7 @@ class MusicService :
         queue: Queue,
         playWhenReady: Boolean = true,
     ) {
+        val previousQueue = currentQueue
         currentQueue = queue
         queueTitle = null
         player.shuffleModeEnabled = false
@@ -965,8 +968,22 @@ class MusicService :
         }
         scope.launch(SilentHandler) {
             val initialStatus =
-                withContext(Dispatchers.IO) {
-                    queue.getInitialStatus().filterExplicit(dataStore.get(HideExplicitKey, false))
+                try {
+                    withContext(Dispatchers.IO) {
+                        queue.getInitialStatus().filterExplicit(dataStore.get(HideExplicitKey, false))
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A failed fetch must not be a silent dead press: without a preload nothing ever
+                    // plays, so tell the user and hand auto-continuation back to the queue that was
+                    // playing (its player items are untouched — only the pointer was swapped).
+                    reportException(e)
+                    if (queue.preloadItem == null && currentQueue === queue) {
+                        currentQueue = previousQueue
+                        onStartRadioFailed()
+                    }
+                    return@launch
                 }
             // Tracking: initial items keep the queue's source when they are the chosen context
             // (album/playlist tracks); a radio queue's fill beyond the tapped song reports "radio".
@@ -1419,8 +1436,14 @@ class MusicService :
             !(dataStore.get(DisableLoadMoreWhenRepeatAllKey, false) && player.repeatMode == REPEAT_MODE_ALL)
         ) {
             scope.launch(SilentHandler) {
-                val mediaItems =
+                val page =
                     currentQueue.nextPage().filterExplicit(dataStore.get(HideExplicitKey, false))
+                // Append only what isn't queued yet: YouTube-style pages lead with the already-queued
+                // current item, Zemer /radio pages are pure fresh tracks — the old blanket drop(1)
+                // silently discarded the first (top-ranked) track of every Zemer page.
+                val queuedIds = (0 until player.mediaItemCount)
+                    .mapTo(mutableSetOf()) { player.getMediaItemAt(it).mediaId }
+                val mediaItems = continuationItemsToAppend(queuedIds, page)
                 // Tracking: a chosen playlist's later pages are still the chosen context (spec:
                 // tracks continuing from an originally-chosen context KEEP its source); only a
                 // radio queue's pages are autoplay.
@@ -1432,7 +1455,7 @@ class MusicService :
                     }
                 }
                 if (player.playbackState != STATE_IDLE) {
-                    player.addMediaItems(mediaItems.drop(1))
+                    player.addMediaItems(mediaItems)
                 }
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/LocalAlbumRadio.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/LocalAlbumRadio.kt
@@ -1,69 +1,59 @@
 package com.jtech.zemer.playback.queues
 
+import android.content.Context
 import androidx.media3.common.MediaItem
-import com.metrolist.innertube.YouTube
-import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
-import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.AlbumWithSongs
+import com.jtech.zemer.di.ZemerSearchRepositoryEntryPoint
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.tracking.PlaySource
-import com.jtech.zemer.utils.filterWhitelisted
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 
+/**
+ * Plays a local album's tracks, then continues with corpus-native radio seeded by that album — Zemer
+ * `/radio?kind=album` (whitelist-pure, opaque-token paging) instead of `YouTube.next()`. The album's own
+ * tracks are the chosen context; the continuation beyond them reports as "radio". Selection only — the
+ * audio stream stays InnerTube + cipher.
+ */
 class LocalAlbumRadio(
     private val albumWithSongs: AlbumWithSongs,
     private val startIndex: Int = 0,
-    private val database: MusicDatabase,
+    private val context: Context,
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
 
-    // The album's tracks are the chosen context; the radio continuation beyond them is "radio".
     override val playSource: String = PlaySource.album(albumWithSongs.album.id)
 
-    private lateinit var playlistId: String
-    private val endpoint: WatchEndpoint
-        get() = WatchEndpoint(
-            playlistId = playlistId,
-            params = "wAEB"
-        )
+    // Resolved from the application context — LocalAlbumRadio is built in leaf composables with no VM.
+    private val repository = EntryPointAccessors
+        .fromApplication(context.applicationContext, ZemerSearchRepositoryEntryPoint::class.java)
+        .zemerSearchRepository()
 
     private var continuation: String? = null
-    private var firstTimeLoaded: Boolean = false
+    private var firstTimeLoaded = false
 
     override suspend fun getInitialStatus(): Queue.Status = withContext(IO) {
         Queue.Status(
             title = albumWithSongs.album.title,
             items = albumWithSongs.songs.map { it.toMediaItem() },
-            mediaItemIndex = startIndex
+            mediaItemIndex = startIndex,
         )
     }
 
     override fun hasNextPage(): Boolean = !firstTimeLoaded || continuation != null
 
     override suspend fun nextPage(): List<MediaItem> = withContext(IO) {
-        if (!firstTimeLoaded) {
-            playlistId = YouTube.album(albumWithSongs.album.id).getOrThrow().album.playlistId
-            val nextResult = YouTube.next(endpoint, continuation).getOrThrow()
-            continuation = nextResult.continuation
+        val page = if (!firstTimeLoaded) {
             firstTimeLoaded = true
-
-            // Filter by whitelist before converting to MediaItems
-            val filteredItems = nextResult.items.subList(
-                albumWithSongs.songs.size,
-                nextResult.items.size
-            ).filterWhitelisted(database).filterIsInstance<SongItem>()
-
-            return@withContext filteredItems.map { it.toMediaItem() }
+            repository.radio("album", albumWithSongs.album.id, zemerSearchOptions(context))
+        } else {
+            val token = continuation ?: return@withContext emptyList()
+            repository.radioContinuation(token)
         }
-        val nextResult = YouTube.next(endpoint, continuation).getOrThrow()
-        continuation = nextResult.continuation
-
-        // Filter by whitelist before converting to MediaItems
-        val filteredItems = nextResult.items.filterWhitelisted(database).filterIsInstance<SongItem>()
-
-        filteredItems.map { it.toMediaItem() }
+        continuation = page.continuation
+        page.songs.map { it.toMediaItem() }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/LocalAlbumRadio.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/LocalAlbumRadio.kt
@@ -21,11 +21,15 @@ import kotlinx.coroutines.withContext
 class LocalAlbumRadio(
     private val albumWithSongs: AlbumWithSongs,
     private val startIndex: Int = 0,
-    private val context: Context,
+    context: Context,
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
 
     override val playSource: String = PlaySource.album(albumWithSongs.album.id)
+
+    // MusicService retains currentQueue for the whole playback session; callers hand in whatever
+    // Context they have (often the Activity), so only the application context may be held.
+    private val context = context.applicationContext
 
     // Resolved from the application context — LocalAlbumRadio is built in leaf composables with no VM.
     private val repository = EntryPointAccessors
@@ -47,8 +51,10 @@ class LocalAlbumRadio(
 
     override suspend fun nextPage(): List<MediaItem> = withContext(IO) {
         val page = if (!firstTimeLoaded) {
-            firstTimeLoaded = true
+            // Flip only after the fetch succeeds: a transient /radio failure must leave
+            // hasNextPage() true so a later transition retries instead of ending the radio forever.
             repository.radio("album", albumWithSongs.album.id, zemerSearchOptions(context))
+                .also { firstTimeLoaded = true }
         } else {
             val token = continuation ?: return@withContext emptyList()
             repository.radioContinuation(token)

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/Queue.kt
@@ -60,3 +60,12 @@ fun List<MediaItem>.filterExplicit(enabled: Boolean = true) =
     } else {
         this
     }
+
+/**
+ * The continuation-page items safe to append to the player. YouTube-style continuations lead with
+ * the already-queued current item; Zemer `/radio` pages are pure fresh tracks. Deduping against the
+ * ids already in the player handles both — the old blanket `drop(1)` silently discarded the first
+ * (top-ranked) track of every Zemer page.
+ */
+fun continuationItemsToAppend(queuedIds: Set<String>, page: List<MediaItem>): List<MediaItem> =
+    page.filterNot { it.mediaId in queuedIds }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
@@ -2,11 +2,12 @@ package com.jtech.zemer.playback.queues
 
 import android.content.Context
 import androidx.media3.common.MediaItem
+import com.jtech.zemer.di.ZemerSearchRepositoryEntryPoint
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
-import com.jtech.zemer.search.ZemerSearchRepository
 import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.tracking.PlaySource
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 
@@ -18,17 +19,23 @@ import kotlinx.coroutines.withContext
  * The server's `continuation` is an opaque token (it encodes the seed + flags + position), so this queue
  * keeps no cursor state: [getInitialStatus] pulls the first page and stashes the token, [nextPage] echoes
  * it back for the next slice. Radio items are autoplay fill, so they report as "radio" (tracking §3.3).
+ *
+ * Built from just a [Context] (repository resolved via [ZemerSearchRepositoryEntryPoint]) so it works from
+ * ViewModels and leaf menu composables alike.
  */
 class ZemerRadioQueue(
     private val kind: String,
     private val seed: String?,
     private val context: Context,
-    private val repository: ZemerSearchRepository,
     override val playSource: String = PlaySource.OTHER,
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
     override val initialItemsAreContext: Boolean = false
     override val continuationIsContext: Boolean = false
+
+    private val repository = EntryPointAccessors
+        .fromApplication(context.applicationContext, ZemerSearchRepositoryEntryPoint::class.java)
+        .zemerSearchRepository()
 
     private var continuation: String? = null
     private var started = false

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
@@ -1,0 +1,55 @@
+package com.jtech.zemer.playback.queues
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import com.jtech.zemer.extensions.toMediaItem
+import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
+import com.jtech.zemer.tracking.PlaySource
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+
+/**
+ * Corpus-native radio (Zemer `/radio`): an endless, whitelist-pure continuation queue seeded by an
+ * artist / album / song, or `kind=shuffle` (no seed) for the Home "Radio mode". It replaces
+ * `YouTube.next()` for SELECTION only — the audio stream still comes from InnerTube + the cipher.
+ *
+ * The server's `continuation` is an opaque token (it encodes the seed + flags + position), so this queue
+ * keeps no cursor state: [getInitialStatus] pulls the first page and stashes the token, [nextPage] echoes
+ * it back for the next slice. Radio items are autoplay fill, so they report as "radio" (tracking §3.3).
+ */
+class ZemerRadioQueue(
+    private val kind: String,
+    private val seed: String?,
+    private val context: Context,
+    private val repository: ZemerSearchRepository,
+    override val playSource: String = PlaySource.OTHER,
+) : Queue {
+    override val preloadItem: MediaMetadata? = null
+    override val initialItemsAreContext: Boolean = false
+    override val continuationIsContext: Boolean = false
+
+    private var continuation: String? = null
+    private var started = false
+
+    override suspend fun getInitialStatus(): Queue.Status = withContext(IO) {
+        val page = repository.radio(kind, seed, zemerSearchOptions(context))
+        continuation = page.continuation
+        started = true
+        Queue.Status(
+            title = null,
+            items = page.songs.map { it.toMediaItem() },
+            mediaItemIndex = 0,
+        )
+    }
+
+    override fun hasNextPage(): Boolean = !started || continuation != null
+
+    override suspend fun nextPage(): List<MediaItem> = withContext(IO) {
+        val token = continuation ?: return@withContext emptyList()
+        val page = repository.radioContinuation(token)
+        continuation = page.continuation
+        page.songs.map { it.toMediaItem() }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/ZemerRadioQueue.kt
@@ -26,12 +26,19 @@ import kotlinx.coroutines.withContext
 class ZemerRadioQueue(
     private val kind: String,
     private val seed: String?,
-    private val context: Context,
+    context: Context,
     override val playSource: String = PlaySource.OTHER,
+    // Single-song tap: the tapped song plays immediately (preload) and heads the queue, with the
+    // /radio?kind=song fill following it. Null for the endless artist/album/playlist/shuffle stations.
+    private val seedSong: MediaMetadata? = null,
 ) : Queue {
-    override val preloadItem: MediaMetadata? = null
+    override val preloadItem: MediaMetadata? = seedSong
     override val initialItemsAreContext: Boolean = false
     override val continuationIsContext: Boolean = false
+
+    // MusicService retains currentQueue for the whole playback session; callers hand in whatever
+    // Context they have (often the Activity), so only the application context may be held.
+    private val context = context.applicationContext
 
     private val repository = EntryPointAccessors
         .fromApplication(context.applicationContext, ZemerSearchRepositoryEntryPoint::class.java)
@@ -44,9 +51,18 @@ class ZemerRadioQueue(
         val page = repository.radio(kind, seed, zemerSearchOptions(context))
         continuation = page.continuation
         started = true
+        // Seed-first: the tapped song (already preloading) heads the queue at index 0 and the fill
+        // follows, deduped so the seed can't appear twice. MusicService splices the fill around the
+        // preloaded seed at [mediaItemIndex]. Stations (no seedSong) are pure fill.
+        val items = if (seedSong != null) {
+            listOf(seedSong.toMediaItem()) +
+                page.songs.filterNot { it.id == seedSong.id }.map { it.toMediaItem() }
+        } else {
+            page.songs.map { it.toMediaItem() }
+        }
         Queue.Status(
             title = null,
-            items = page.songs.map { it.toMediaItem() },
+            items = items,
             mediaItemIndex = 0,
         )
     }
@@ -58,5 +74,18 @@ class ZemerRadioQueue(
         val page = repository.radioContinuation(token)
         continuation = page.continuation
         page.songs.map { it.toMediaItem() }
+    }
+
+    companion object {
+        /**
+         * Seed-first song radio for a single-song tap: the tapped [song] plays immediately and the
+         * queue continues with `/radio?kind=song` seeded by it. Corpus-native replacement for
+         * `YouTubeQueue.radio(song)`; the tapped song is the chosen play, the fill reports as radio.
+         */
+        fun song(
+            song: MediaMetadata,
+            context: Context,
+            playSource: String = PlaySource.OTHER,
+        ) = ZemerRadioQueue("song", song.id, context, playSource, seedSong = song)
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -202,6 +202,16 @@ object ZemerResultMapper {
         songItems(tracks, hideExplicit)
 
     /**
+     * A `/radio` page's tracks as playable [SongItem]s with the same defense-in-depth every other
+     * Zemer surface gets — sparse-row drop, de-dup, and the surgical id-overrides ([dropBlocked]):
+     * a Firestore-blocked id must not play even when the server's override sync lags the app's.
+     * Explicit filtering is centrally applied by MusicService over every queue page, so
+     * `hideExplicit` is not re-run here.
+     */
+    fun ZemerRadioResponse.toSongItems(): List<SongItem> =
+        songItems(tracks, hideExplicit = false)
+
+    /**
      * The curated albums as browsable [AlbumItem] rows (the detail screen's Albums chip), with the
      * same defense-in-depth every other Zemer collection gets: sparse-row drop, de-dup, and the
      * surgical id-overrides ([dropBlocked]) — a Firestore-blocked album must not render as a row
@@ -221,8 +231,10 @@ object ZemerResultMapper {
     fun ZemerAlbumResponse.toAlbumPage(playlistId: String?): AlbumPage {
         val albumItem = AlbumItem(
             browseId = album.id,
-            // Opener-threaded id first, then the server's own album playlistId, then the browseId fallback.
-            playlistId = playlistId ?: album.playlistId ?: album.id,
+            // Opener-threaded id first — but only when it's a real OP id: [toAlbumItem] falls cards'
+            // playlistId back to the browseId, and persisting that MPRE would dead-press album radio
+            // and mis-id share links. Then the server's own playlistId, then the browseId fallback.
+            playlistId = playlistId?.takeIf { it != album.id } ?: album.playlistId ?: album.id,
             title = album.title,
             artists = if (album.artist.isBlank()) null else listOf(Artist(name = album.artist, id = null)),
             year = album.year,

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -10,6 +10,8 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.pages.AlbumPage
+import com.metrolist.innertube.pages.ArtistPage
+import com.metrolist.innertube.pages.ArtistSection
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummary
 import com.metrolist.innertube.pages.SearchSummaryPage
@@ -55,10 +57,14 @@ object ZemerResultMapper {
             // real channel id — required for the home one-per-artist dedup + female/israeli check.
             artists = listOf(Artist(name = artist, id = artistId)),
             title = title,
-            album = null,
+            // The album link, when the server sends it (/artist tracks) — enables the song menu's
+            // "View album". Absent elsewhere / for standalone singles + videos.
+            album = album?.takeIf { it.id.isNotBlank() }?.let { Album(name = it.name, id = it.id) },
             // Present on /album and /zemer-playlists tracks; the search categories send none.
             duration = durationSec,
-            thumbnail = thumbnailFor(videoId),
+            // Prefer the server's square album art; fall back to the (letterboxed) video frame until the
+            // track carries one — see the /artist per-track thumbnail request.
+            thumbnail = thumbnail?.takeIf { it.isNotBlank() } ?: thumbnailFor(videoId),
             explicit = explicit,
         )
 
@@ -215,7 +221,8 @@ object ZemerResultMapper {
     fun ZemerAlbumResponse.toAlbumPage(playlistId: String?): AlbumPage {
         val albumItem = AlbumItem(
             browseId = album.id,
-            playlistId = playlistId ?: album.id,
+            // Opener-threaded id first, then the server's own album playlistId, then the browseId fallback.
+            playlistId = playlistId ?: album.playlistId ?: album.id,
             title = album.title,
             artists = if (album.artist.isBlank()) null else listOf(Artist(name = album.artist, id = null)),
             year = album.year,
@@ -235,6 +242,36 @@ object ZemerResultMapper {
             .distinctBy { it.id }
             .dropBlocked()
         return AlbumPage(album = albumItem, songs = songs)
+    }
+
+    /**
+     * A Zemer `/artist` response as the [ArtistPage] the artist screen already consumes: the flat
+     * songs / videos / albums / singles / playlists arrays become the screen's sections, in that order.
+     * Tracks are whitelist-scoped server-side, so only hide-explicit + the surgical id-overrides
+     * ([dropBlocked]) run here. Section titles reuse the same English constants as the summary view. The
+     * header carries no play/shuffle/radio endpoint (the corpus has none): the screen plays Shuffle from
+     * these tracks locally, and the Radio button waits for Zemer Radio.
+     */
+    fun ZemerArtistResponse.toArtistPage(
+        hideExplicit: Boolean,
+        formatSongCount: (Int) -> String? = { null },
+    ): ArtistPage {
+        fun albumSection(list: List<ZemerAlbum>): List<AlbumItem> =
+            list.filter { it.id.isNotBlank() }.map { it.toAlbumItem() }.distinctBy { it.id }.dropBlocked()
+        // Section order mirrors the InnerTube artist page: Songs, Albums, Singles, Videos, Playlists.
+        val sections = buildList {
+            songItems(songs, hideExplicit).takeIf { it.isNotEmpty() }
+                ?.let { add(ArtistSection(TITLE_SONGS, it, null)) }
+            albumSection(albums).takeIf { it.isNotEmpty() }
+                ?.let { add(ArtistSection(TITLE_ALBUMS, it, null)) }
+            albumSection(singles).takeIf { it.isNotEmpty() }
+                ?.let { add(ArtistSection(TITLE_SINGLES, it, null)) }
+            songItems(videos, hideExplicit).takeIf { it.isNotEmpty() }
+                ?.let { add(ArtistSection(TITLE_VIDEOS, it, null)) }
+            playlistItems(playlists, formatSongCount).takeIf { it.isNotEmpty() }
+                ?.let { add(ArtistSection(TITLE_PLAYLISTS, it, null)) }
+        }
+        return ArtistPage(artist = artist.toArtistItem(), sections = sections, description = null)
     }
 
     /**
@@ -330,7 +367,9 @@ object ZemerResultMapper {
     // Verbatim match of the YouTube summary section titles/order (YouTube.searchSummary hardcodes
     // these English literals too), so the summary looks identical whichever engine is selected.
     private const val TITLE_ALBUMS = "Albums"
+    private const val TITLE_SINGLES = "Singles"
     private const val TITLE_SONGS = "Songs"
+    private const val TITLE_VIDEOS = "Videos"
     private const val TITLE_ARTISTS = "Artists"
     private const val TITLE_PLAYLISTS = "Playlists"
 }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -199,6 +199,46 @@ class ZemerSearchClient @Inject constructor() {
     }
 
     /**
+     * Corpus-native radio: the first page of a whitelist-pure continuation seeded by [kind] (`artist` /
+     * `album` / `song`, with [seed] the channelId/browseId/videoId) or `shuffle` (no seed) for Radio mode.
+     * Content flags are sent explicitly (kidZone included), same as the other endpoints.
+     */
+    suspend fun radio(
+        kind: String,
+        seed: String?,
+        allowFemale: Boolean,
+        blockVideos: Boolean,
+    ): ZemerRadioResponse {
+        val response: HttpResponse = client.get("$BASE_URL/radio") {
+            parameter("kind", kind)
+            seed?.let { parameter("seed", it) }
+            zemerContentFlagParameters(allowFemale, blockVideos, includeKidZone = true).forEach { (name, value) ->
+                parameter(name, value)
+            }
+            timeout { requestTimeoutMillis = LARGE_REQUEST_TIMEOUT_MS }
+        }
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer radio returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerRadioResponse.serializer(), response.bodyAsText())
+    }
+
+    /**
+     * The next radio page: the opaque [continuation] token from a prior [radio]/[radioContinuation] carries
+     * the seed + flags + position, so nothing else is sent. The queue is endless (token rarely null).
+     */
+    suspend fun radioContinuation(continuation: String): ZemerRadioResponse {
+        val response: HttpResponse = client.get("$BASE_URL/radio") {
+            parameter("continuation", continuation)
+            timeout { requestTimeoutMillis = LARGE_REQUEST_TIMEOUT_MS }
+        }
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer radio returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerRadioResponse.serializer(), response.bodyAsText())
+    }
+
+    /**
      * The hand-curated "Zemer Playlists" list, ready to render: order, counts, covers and runtimes are
      * all server-computed for the flags sent (see [zemerCuratedPlaylistsParameters]). An empty list is
      * normal — nothing curated yet.

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -173,6 +173,32 @@ class ZemerSearchClient @Inject constructor() {
     }
 
     /**
+     * Fetch an artist's whole catalog, already whitelist-scoped + content-filtered by the server for the
+     * flags sent (same fail-closed, default-OPEN contract as [search]/[album]). `kidZone` is included so a
+     * KidZone-opened artist stays scoped. Returns null on `404` — the artist is filtered out entirely or
+     * absent from the corpus — so the caller can fall back to the InnerTube artist path for it. The server
+     * reads the corpus (no upstream fetch), but the open is user-initiated so it gets the larger ceiling.
+     */
+    suspend fun artist(
+        id: String,
+        allowFemale: Boolean,
+        blockVideos: Boolean,
+    ): ZemerArtistResponse? {
+        val response: HttpResponse = client.get("$BASE_URL/artist") {
+            parameter("id", id)
+            zemerContentFlagParameters(allowFemale, blockVideos, includeKidZone = true).forEach { (name, value) ->
+                parameter(name, value)
+            }
+            timeout { requestTimeoutMillis = LARGE_REQUEST_TIMEOUT_MS }
+        }
+        if (response.status == HttpStatusCode.NotFound) return null
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer artist returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerArtistResponse.serializer(), response.bodyAsText())
+    }
+
+    /**
      * The hand-curated "Zemer Playlists" list, ready to render: order, counts, covers and runtimes are
      * all server-computed for the flags sent (see [zemerCuratedPlaylistsParameters]). An empty list is
      * normal — nothing curated yet.

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -152,13 +152,15 @@ class ZemerSearchClient @Inject constructor() {
      * blocked album is a 404). The flags are sent explicitly (same fail-closed contract as [search] —
      * the server is default-OPEN); `kidZone` is always off because the album screen is only reachable
      * from search, never from inside KidZone. The server fetches the album upstream on a cold cache,
-     * so this user-initiated one-shot open gets the larger request ceiling.
+     * so this user-initiated one-shot open gets the larger request ceiling. Returns null on `404` —
+     * the album is gone from the whitelist/corpus — a typed signal the caller uses to delete a stale
+     * local copy (an [IOException] message-match would silently rot).
      */
     suspend fun album(
         id: String,
         allowFemale: Boolean,
         blockVideos: Boolean,
-    ): ZemerAlbumResponse {
+    ): ZemerAlbumResponse? {
         val response: HttpResponse = client.get("$BASE_URL/album") {
             parameter("id", id)
             zemerContentFlagParameters(allowFemale, blockVideos, includeKidZone = true).forEach { (name, value) ->
@@ -166,6 +168,7 @@ class ZemerSearchClient @Inject constructor() {
             }
             timeout { requestTimeoutMillis = LARGE_REQUEST_TIMEOUT_MS }
         }
+        if (response.status == HttpStatusCode.NotFound) return null
         if (!response.status.isSuccess()) {
             throw IOException("Zemer album returned HTTP ${response.status.value}")
         }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -40,6 +40,13 @@ data class ZemerArtist(
     val thumbnail: String? = null,
 )
 
+/** A track's album link ({id = album browseId, name}) — powers the song menu's "View album". */
+@Serializable
+data class ZemerTrackAlbum(
+    val id: String = "",
+    val name: String = "",
+)
+
 /** Both songs and videos share this shape (videos differ only by which category they arrive in). */
 @Serializable
 data class ZemerTrack(
@@ -50,6 +57,13 @@ data class ZemerTrack(
     // dedup + female/israeli defence-in-depth can run); absent (null) on the search categories, where
     // the artist arrives as a name only. Maps to `Artist.id` — null there keeps the prior behaviour.
     val artistId: String? = null,
+    // Square album-art URL, when the server sends one on the track (so a song list shows real album art
+    // instead of the letterboxed video frame). Absent on surfaces that don't provide it yet;
+    // [ZemerResultMapper.toSongItem] then falls back to the videoId-derived thumbnail.
+    val thumbnail: String? = null,
+    // The track's album {id (browseId), name}, when the server links it — powers the song menu's
+    // "View album". Null for standalone singles / videos (no album in the corpus).
+    val album: ZemerTrackAlbum? = null,
     val explicit: Boolean = false,
     // `/album` tracks only; absent (null) on the search categories.
     val durationSec: Int? = null,
@@ -231,8 +245,29 @@ data class ZemerCuratedPlaylistResponse(
 @Serializable
 data class ZemerAlbumHeader(
     val id: String = "",
+    // The album's own playlist id (OLAK…), when the server sends it — used for the album's radio/automix
+    // when the opener didn't thread one. Absent on older builds; [toAlbumPage] then falls back to the id.
+    val playlistId: String? = null,
     val title: String = "",
     val artist: String = "",
     val year: Int? = null,
     val thumbnail: String? = null,
+)
+
+/**
+ * Wire model for `GET /artist` (search.zemer.io) — an artist's whole catalog, already whitelist-scoped
+ * and content-filtered server-side for the flags sent. Returned as flat arrays; the app builds the
+ * `ArtistPage` sections from them (there is no pagination — the arrays are complete). A `404` means the
+ * artist is filtered out entirely or absent from the corpus; the caller then falls back to InnerTube.
+ * The `artist` header and `playlists` reuse [ZemerArtist]/[ZemerPlaylist]; `songs`/`videos` reuse
+ * [ZemerTrack]; `albums`/`singles` reuse [ZemerAlbum] (the server splits them on `type`).
+ */
+@Serializable
+data class ZemerArtistResponse(
+    val artist: ZemerArtist = ZemerArtist(),
+    val songs: List<ZemerTrack> = emptyList(),
+    val videos: List<ZemerTrack> = emptyList(),
+    val albums: List<ZemerAlbum> = emptyList(),
+    val singles: List<ZemerAlbum> = emptyList(),
+    val playlists: List<ZemerPlaylist> = emptyList(),
 )

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -271,3 +271,15 @@ data class ZemerArtistResponse(
     val singles: List<ZemerAlbum> = emptyList(),
     val playlists: List<ZemerPlaylist> = emptyList(),
 )
+
+/**
+ * Wire model for `GET /radio` (search.zemer.io) — the corpus-native, whitelist-pure radio continuation.
+ * [tracks] are the next tracks to enqueue; [continuation] is an opaque token echoed back to
+ * `GET /radio?continuation=` for the next page (null = end, realistically never for an endless radio).
+ * Replaces `YouTube.next()` for SELECTION only — the audio stream stays InnerTube + cipher.
+ */
+@Serializable
+data class ZemerRadioResponse(
+    val tracks: List<ZemerTrack> = emptyList(),
+    val continuation: String? = null,
+)

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -5,6 +5,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumItems
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumPage
 import com.jtech.zemer.search.ZemerResultMapper.toArtistPage
+import com.jtech.zemer.search.ZemerResultMapper.toSongItem
 import com.jtech.zemer.search.ZemerResultMapper.toSongItems
 import com.metrolist.innertube.YouTube.SearchFilter
 import com.metrolist.innertube.models.AlbumItem
@@ -24,6 +25,9 @@ import javax.inject.Singleton
 
 /** A Zemer `/playlist` open, mapped to the UI types the online-playlist screen already renders. */
 data class ZemerPlaylistPage(val playlist: PlaylistItem, val songs: List<SongItem>)
+
+/** A Zemer `/radio` page: the next whitelist-pure tracks + the opaque continuation token (null = end). */
+data class ZemerRadioPage(val songs: List<SongItem>, val continuation: String?)
 
 /**
  * A curated `/zemer-playlists?id=…` open: the server header plus playable, already-filtered tracks.
@@ -145,6 +149,24 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun artist(id: String, options: ZemerSearchOptions): ArtistPage? =
         client.artist(id, options.allowFemale, options.blockVideos)
             ?.toArtistPage(options.hideExplicit, formatSongCount)
+
+    /**
+     * Corpus-native radio (see [ZemerRadioResponse]): the first page seeded by [kind]/[seed] (`artist` /
+     * `album` / `song`, or `shuffle` with a null seed), mapped to playable [SongItem]s. Not cached — a
+     * live continuation; tracks are whitelist-pure + blocked-ids filtered server-side.
+     */
+    suspend fun radio(kind: String, seed: String?, options: ZemerSearchOptions): ZemerRadioPage =
+        client.radio(kind, seed, options.allowFemale, options.blockVideos).toRadioPage()
+
+    /** The next radio page for an opaque [continuation] token (the seed + flags ride inside the token). */
+    suspend fun radioContinuation(continuation: String): ZemerRadioPage =
+        client.radioContinuation(continuation).toRadioPage()
+
+    private fun ZemerRadioResponse.toRadioPage(): ZemerRadioPage =
+        ZemerRadioPage(
+            songs = tracks.filter { it.videoId.isNotBlank() }.map { it.toSongItem() }.distinctBy { it.id },
+            continuation = continuation,
+        )
 
     /**
      * The hand-curated "Zemer Playlists" section, in editorial order (rendered as received). Not

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -5,7 +5,6 @@ import com.jtech.zemer.R
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumItems
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumPage
 import com.jtech.zemer.search.ZemerResultMapper.toArtistPage
-import com.jtech.zemer.search.ZemerResultMapper.toSongItem
 import com.jtech.zemer.search.ZemerResultMapper.toSongItems
 import com.metrolist.innertube.YouTube.SearchFilter
 import com.metrolist.innertube.models.AlbumItem
@@ -121,10 +120,12 @@ class ZemerSearchRepository @Inject constructor(
      * server (immune to on-device bot-gating/rate limits) and comes back already whitelist-scoped +
      * content-filtered, mapped to the same [AlbumPage] the YouTube path yields so the album screen
      * and DB persist flow are reused unchanged. [playlistId] is the search card's OP playlist id —
-     * the server's album header doesn't return one. Not cached — each open is a single fetch.
+     * the server's album header doesn't return one. Null = 404 (the album is gone from the
+     * whitelist/corpus) — the caller deletes its stale local copy. Not cached — each open is a
+     * single fetch.
      */
-    suspend fun album(browseId: String, playlistId: String?, options: ZemerSearchOptions): AlbumPage =
-        client.album(browseId, options.allowFemale, options.blockVideos).toAlbumPage(playlistId)
+    suspend fun album(browseId: String, playlistId: String?, options: ZemerSearchOptions): AlbumPage? =
+        client.album(browseId, options.allowFemale, options.blockVideos)?.toAlbumPage(playlistId)
 
     /**
      * The telemetry-ranked home rows (albums / videos / artists), already whitelist-scoped and
@@ -162,9 +163,11 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun radioContinuation(continuation: String): ZemerRadioPage =
         client.radioContinuation(continuation).toRadioPage()
 
+    // Routed through the mapper so radio gets the same dropBlocked id-overrides pass as every other
+    // Zemer surface (the server filters too; this covers its ~10-min override-sync lag).
     private fun ZemerRadioResponse.toRadioPage(): ZemerRadioPage =
         ZemerRadioPage(
-            songs = tracks.filter { it.videoId.isNotBlank() }.map { it.toSongItem() }.distinctBy { it.id },
+            songs = toSongItems(),
             continuation = continuation,
         )
 

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.jtech.zemer.R
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumItems
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumPage
+import com.jtech.zemer.search.ZemerResultMapper.toArtistPage
 import com.jtech.zemer.search.ZemerResultMapper.toSongItems
 import com.metrolist.innertube.YouTube.SearchFilter
 import com.metrolist.innertube.models.AlbumItem
@@ -12,6 +13,7 @@ import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SearchSuggestions
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.pages.AlbumPage
+import com.metrolist.innertube.pages.ArtistPage
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -132,6 +134,17 @@ class ZemerSearchRepository @Inject constructor(
             client.homeRows(options.allowFemale, options.blockVideos),
             formatSongCount,
         )
+
+    /**
+     * Open an artist through the server's `/artist` endpoint (whitelist-scoped + content-filtered),
+     * mapped to the [AlbumPage]-sibling [ArtistPage] the artist screen already consumes. Null = 404
+     * (the artist is filtered out entirely, or is absent from the corpus) — the caller falls back to the
+     * InnerTube artist path. Not cached: a single user-initiated open, same freshness contract as
+     * [album]/[playlist].
+     */
+    suspend fun artist(id: String, options: ZemerSearchOptions): ArtistPage? =
+        client.artist(id, options.allowFemale, options.blockVideos)
+            ?.toArtistPage(options.hideExplicit, formatSongCount)
 
     /**
      * The hand-curated "Zemer Playlists" section, in editorial order (rendered as received). Not

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -597,6 +597,7 @@ fun AlbumGridItem(
     badges = badges,
     thumbnailContent = {
         val database = LocalDatabase.current
+        val context = LocalContext.current
         val playerConnection = LocalPlayerConnection.current ?: return@GridItem
         val scope = rememberCoroutineScope()
 
@@ -615,7 +616,7 @@ fun AlbumGridItem(
                         database.albumWithSongs(album.id).firstOrNull()
                     }
                     albumWithSongs?.let {
-                        playerConnection.playQueue(LocalAlbumRadio(it, database = database))
+                        playerConnection.playQueue(LocalAlbumRadio(it, context = context))
                     }
                 }
             }
@@ -955,6 +956,7 @@ fun YouTubeGridItem(
     badges = badges,
     thumbnailContent = {
         val database = LocalDatabase.current
+        val context = LocalContext.current
         val playerConnection = LocalPlayerConnection.current ?: return@GridItem
         val scope = rememberCoroutineScope()
 
@@ -986,7 +988,7 @@ fun YouTubeGridItem(
                     }
                     albumWithSongs?.let {
                         withContext(Dispatchers.Main) {
-                            playerConnection.playQueue(LocalAlbumRadio(it, database = database))
+                            playerConnection.playQueue(LocalAlbumRadio(it, context = context))
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -357,7 +357,9 @@ fun SongMenu(
                             title = { Text(stringResource(R.string.start_radio)) },
                             onClick = {
                                 onDismiss()
-                                playerConnection.playQueue(ZemerRadioQueue("song", song.id, context, PlaySource.RADIO))
+                                // Seed-first: the tapped song plays instantly (preload) and heads the
+                                // queue; the /radio fill follows — a failed fetch still plays the song.
+                                playerConnection.playQueue(ZemerRadioQueue.song(song.toMediaMetadata(), context, PlaySource.RADIO))
                             },
                         )
                     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -59,6 +59,8 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
 import com.jtech.zemer.ui.component.ArtistChoice
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
@@ -355,7 +357,7 @@ fun SongMenu(
                             title = { Text(stringResource(R.string.start_radio)) },
                             onClick = {
                                 onDismiss()
-                                playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata(), database))
+                                playerConnection.playQueue(ZemerRadioQueue("song", song.id, context, PlaySource.RADIO))
                             },
                         )
                     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeArtistMenu.kt
@@ -31,6 +31,8 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.ArtistEntity
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
 import com.jtech.zemer.ui.component.NewAction
@@ -83,25 +85,25 @@ fun YouTubeArtistMenu(
         item {
             NewActionGrid(
                 actions = buildList {
-                    artist.radioEndpoint?.let { watchEndpoint ->
-                        add(
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.radio),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                },
-                                text = stringResource(R.string.start_radio),
-                                onClick = {
-                                    playerConnection.playQueue(YouTubeQueue(watchEndpoint, preloadItem = null, database))
-                                    onDismiss()
-                                }
-                            )
+                    // Corpus-native Zemer radio (/radio?kind=artist), always available (no InnerTube
+                    // radioEndpoint needed).
+                    add(
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.radio),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            text = stringResource(R.string.start_radio),
+                            onClick = {
+                                playerConnection.playQueue(ZemerRadioQueue("artist", artist.id, context, PlaySource.artist(artist.id)))
+                                onDismiss()
+                            }
                         )
-                    }
+                    )
 
                     artist.shuffleEndpoint?.let { watchEndpoint ->
                         add(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -52,6 +52,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
 import com.jtech.zemer.ui.component.DefaultDialog
@@ -333,25 +334,26 @@ fun YouTubePlaylistMenu(
                             )
                         )
                     }
-                    playlist.radioEndpoint?.let { radioEndpoint ->
-                        add(
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.radio),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                },
-                                text = stringResource(R.string.start_radio),
-                                onClick = {
-                                    playerConnection.playQueue(YouTubeQueue(radioEndpoint, preloadItem = null, database, playSource = PlaySource.RADIO))
-                                    onDismiss()
-                                }
-                            )
+                    // Corpus-native Zemer radio (/radio?kind=playlist), always available (seeds from the
+                    // playlist's member tracks; no InnerTube radioEndpoint needed). This menu only ever
+                    // opens for real YouTube/community playlists, so playlist.id is always a valid seed.
+                    add(
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.radio),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                            },
+                            text = stringResource(R.string.start_radio),
+                            onClick = {
+                                playerConnection.playQueue(ZemerRadioQueue("playlist", playlist.id, context, PlaySource.RADIO))
+                                onDismiss()
+                            }
                         )
-                    }
+                    )
                 },
                 modifier = Modifier.padding(horizontal = 4.dp, vertical = 16.dp)
             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -305,7 +305,9 @@ fun YouTubeSongMenu(
                             icon = { Icon(painterResource(R.drawable.radio), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.start_radio)) },
                             onClick = {
-                                playerConnection.playQueue(ZemerRadioQueue("song", song.id, context, PlaySource.RADIO))
+                                // Seed-first: the tapped song plays instantly (preload) and heads the
+                                // queue; the /radio fill follows — a failed fetch still plays the song.
+                                playerConnection.playQueue(ZemerRadioQueue.song(song.toMediaMetadata(), context, PlaySource.RADIO))
                                 onDismiss()
                             },
                         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -57,6 +57,8 @@ import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
 import com.jtech.zemer.playback.MediaStoreDownloadManager
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.ArtistChoice
 import com.jtech.zemer.utils.VideoLinkBuilder
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
@@ -303,7 +305,7 @@ fun YouTubeSongMenu(
                             icon = { Icon(painterResource(R.drawable.radio), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.start_radio)) },
                             onClick = {
-                                playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata(), database))
+                                playerConnection.playQueue(ZemerRadioQueue("song", song.id, context, PlaySource.RADIO))
                                 onDismiss()
                             },
                         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import com.jtech.zemer.ui.component.EmptyPlaceholder
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -119,6 +120,7 @@ fun AlbumScreen(
 
     val playlistId by viewModel.playlistId.collectAsState()
     val albumWithSongs by viewModel.albumWithSongs.collectAsState()
+    val albumNotFound by viewModel.notFound.collectAsState()
     val hideExplicit by rememberPreference(key = HideExplicitKey, defaultValue = false)
 
     val wrappedSongs = remember(albumWithSongs, hideExplicit) {
@@ -483,6 +485,16 @@ fun AlbumScreen(
                         )
                     }
                 }
+            }
+        } else if (albumNotFound) {
+            // The album isn't in the corpus (404 / no tracks) and nothing is stored locally — a neutral
+            // state rather than an endless loading shimmer.
+            item(key = "album_unavailable") {
+                EmptyPlaceholder(
+                    icon = R.drawable.album,
+                    text = stringResource(R.string.album_not_available),
+                    modifier = Modifier.fillParentMaxSize(),
+                )
             }
         } else {
             item(key = "loading_shimmer") {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -368,7 +368,7 @@ fun AlbumScreen(
                             onClick = {
                                 playerConnection.service.getAutomix(playlistId)
                                 playerConnection.playQueue(
-                                    LocalAlbumRadio(albumWithSongs, database = database),
+                                    LocalAlbumRadio(albumWithSongs, context = context),
                                 )
                             },
                             contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
@@ -389,7 +389,7 @@ fun AlbumScreen(
                             onClick = {
                                 playerConnection.service.getAutomix(playlistId)
                                 playerConnection.playQueue(
-                                    LocalAlbumRadio(albumWithSongs.copy(songs = albumWithSongs.songs.shuffled()), database = database),
+                                    LocalAlbumRadio(albumWithSongs.copy(songs = albumWithSongs.songs.shuffled()), context = context),
                                 )
                             },
                             contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
@@ -464,7 +464,7 @@ fun AlbumScreen(
                                             } else {
                                                 playerConnection.service.getAutomix(playlistId)
                                                 playerConnection.playQueue(
-                                                    LocalAlbumRadio(albumWithSongs, startIndex = index, database = database),
+                                                    LocalAlbumRadio(albumWithSongs, startIndex = index, context = context),
                                                 )
                                             }
                                         } else {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -64,8 +64,6 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.LocalAlbumRadio
-import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
@@ -108,7 +106,6 @@ import com.metrolist.innertube.models.YTItem
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.min
-import kotlin.random.Random
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -152,27 +149,6 @@ fun HomeScreen(
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
     homeUiState.isNewUser
 
-    val allLocalItems =
-        remember(quickPicks, forgottenFavorites, keepListening) {
-            (quickPicks + forgottenFavorites + keepListening).filter { it is Song || it is Album }
-        }
-    val allYtItems =
-        remember(featuredVideos, featuredAlbums, featuredArtists, blockVideos) {
-            buildList {
-                if (!blockVideos) {
-                    addAll(featuredVideos)
-                }
-                // A featured (Zemer) album is lucky-playable only with a real OLAK playlist id: when
-                // /home-rows sends none, toAlbumItem falls playlistId back to the MPRE browseId, which
-                // YouTubeAlbumRadio's InnerTube lookup can't resolve — a lucky pick on it would dead-press.
-                // Keep only albums with a distinct (resolvable) playlist id, same guard as the artists below.
-                addAll(featuredAlbums.filter { it.playlistId != it.id })
-                // Telemetry-ranked (Zemer) artist cards carry no InnerTube radio endpoint, so the lucky
-                // shuffle can't start radio from them — keep only artists that can actually play (the
-                // scrape-fallback ones) in the pool, so a lucky pick never dead-presses.
-                addAll(featuredArtists.filter { it.radioEndpoint != null })
-            }
-        }
 
     // Memoized distinct lists to avoid creating new lists on every recomposition
     val uniqueQuickPicks = remember(quickPicks) { quickPicks.distinctBy { it.id } }
@@ -216,43 +192,9 @@ fun HomeScreen(
     }
 
     fun performShuffle() {
-        if (allLocalItems.isEmpty() && allYtItems.isEmpty()) {
-            android.widget.Toast.makeText(context, R.string.radio_empty_message, android.widget.Toast.LENGTH_SHORT).show()
-            return
-        }
-        val local = when {
-            allLocalItems.isNotEmpty() && allYtItems.isNotEmpty() -> Random.nextFloat() < 0.5
-            allLocalItems.isNotEmpty() -> true
-            else -> false
-        }
-        if (local) {
-            when (val luckyItem = allLocalItems.random()) {
-                is Song -> playerConnection.playQueue(YouTubeQueue.radio(luckyItem.toMediaMetadata(), database))
-                is Album -> {
-                    scope.launch {
-                        val albumWithSongs = database.albumWithSongs(luckyItem.id).first()
-                        albumWithSongs?.let {
-                            playerConnection.playQueue(LocalAlbumRadio(it, database = database))
-                        }
-                    }
-                }
-
-                is Artist -> {}
-                is Playlist -> {}
-            }
-        } else {
-            when (val luckyItem = allYtItems.random()) {
-                is SongItem -> playerConnection.playQueue(YouTubeQueue.radio(luckyItem.toMediaMetadata(), database))
-                is AlbumItem -> playerConnection.playQueue(YouTubeAlbumRadio(luckyItem.playlistId, database))
-                is ArtistItem -> luckyItem.radioEndpoint?.let {
-                    playerConnection.playQueue(YouTubeQueue(it, preloadItem = null, database))
-                }
-
-                is PlaylistItem -> luckyItem.playEndpoint?.let {
-                    playerConnection.playQueue(YouTubeQueue(it, preloadItem = null, database))
-                }
-            }
-        }
+        // "Radio mode": a corpus-native, whitelist-pure station over the whole catalog
+        // (Zemer /radio?kind=shuffle), replacing the old InnerTube lucky-item radio.
+        playerConnection.playQueue(viewModel.shuffleRadioQueue())
     }
 
     LaunchedEffect(shuffleNow?.value) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -128,11 +128,14 @@ fun HomeSeeAllScreen(
 
 /** Online Featured rows (albums / artists / videos) as a grid, click + long-press mirroring Home. */
 @Composable
-private fun <T : YTItem> YtItemGrid(
+internal fun <T : YTItem> YtItemGrid(
     items: List<T>,
     navController: NavController,
     zemerAlbums: Boolean = false,
     zemerPlaylists: Boolean = false,
+    // Zemer playlists tag their plays community:<id> by default (the Home community row); the artist
+    // page's own playlists are artist-owned, so it passes false to keep them plain playlist:<id>.
+    communityPlaylists: Boolean = true,
 ) {
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -171,7 +174,7 @@ private fun <T : YTItem> YtItemGrid(
                             // Community playlists are Zemer-sourced: open via the server /playlist route and
                             // tag plays `community:<id>` (the discovery-sourced community row).
                             is PlaylistItem ->
-                                if (zemerPlaylists) navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id, community = true))
+                                if (zemerPlaylists) navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id, community = communityPlaylists))
                                 else navController.navigate("online_playlist/${item.id}")
                         }
                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -16,6 +16,7 @@ import com.jtech.zemer.BuildConfig
 import com.jtech.zemer.ui.screens.artist.ArtistAlbumsScreen
 import com.jtech.zemer.ui.screens.artist.ArtistItemsScreen
 import com.jtech.zemer.ui.screens.artist.ArtistScreen
+import com.jtech.zemer.ui.screens.artist.ArtistSectionScreen
 import com.jtech.zemer.ui.screens.artist.ArtistSongsScreen
 import com.jtech.zemer.ui.screens.library.LibraryScreen
 import com.jtech.zemer.ui.screens.player.VideoPlayerScreen
@@ -103,6 +104,18 @@ fun NavGraphBuilder.navigationBuilder(
         val row = HomeSeeAllRow.fromSlug(it.arguments?.getString("row"))
         if (row == null) LaunchedEffect(Unit) { navController.navigateUp() }
         else HomeSeeAllScreen(navController, scrollBehavior, row)
+    }
+    composable(
+        route = "artist_section/{artistId}?title={title}",
+        arguments = listOf(
+            navArgument("artistId") { type = NavType.StringType },
+            navArgument("title") {
+                type = NavType.StringType
+                defaultValue = ""
+            },
+        ),
+    ) {
+        ArtistSectionScreen(navController, scrollBehavior, it.arguments?.getString("title").orEmpty())
     }
     composable("charts_screen") {
        ChartsScreen(navController)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -91,6 +91,9 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.search.SearchProvider
+import com.jtech.zemer.search.onlineAlbumRoute
+import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlbumGridItem
@@ -99,6 +102,7 @@ import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.SongListItem
+import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.YouTubeGridItem
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.shimmer.ButtonPlaceholder
@@ -186,7 +190,7 @@ fun ArtistScreen(
             state = lazyListState,
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
         ) {
-            if ((artistPage == null || isLoadingArtist) && !showLocal) {
+            if (isLoadingArtist && !showLocal) {
                 item(key = "shimmer") {
                     ShimmerHost (
                         modifier = Modifier
@@ -263,6 +267,16 @@ fun ArtistScreen(
                             }
                         }
                     }
+                }
+            } else if (artistPage == null && !showLocal) {
+                // Loaded but the corpus has nothing for this artist (404, a just-added artist before the
+                // next harvest, or a track-less whitelisted artist) — a neutral state, never a dead screen.
+                item(key = "artist_unavailable") {
+                    EmptyPlaceholder(
+                        icon = R.drawable.artist,
+                        text = stringResource(R.string.artist_not_available),
+                        modifier = Modifier.fillParentMaxSize(),
+                    )
                 }
             } else {
                 item(key = "header") {
@@ -399,41 +413,55 @@ fun ArtistScreen(
                                             }
                                         }
 
-                                        // Shuffle Button
-                                        if (!showLocal) {
-                                            artistPage?.artist?.shuffleEndpoint?.let { shuffleEndpoint ->
-                                                IconButton(
-                                                    onClick = {
-                                                        playerConnection.playQueue(YouTubeQueue(shuffleEndpoint, preloadItem = null, database, playSource = PlaySource.artist(viewModel.artistId)))
-                                                    },
-                                                    modifier = Modifier
-                                                        .size(48.dp)
-                                                        .background(
-                                                            MaterialTheme.colorScheme.primary,
-                                                            RoundedCornerShape(24.dp)
-                                                        )
-                                                ) {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.shuffle),
-                                                        contentDescription = stringResource(R.string.shuffle),
-                                                        tint = MaterialTheme.colorScheme.onPrimary,
-                                                        modifier = Modifier.size(20.dp)
-                                                    )
-                                                }
-                                            }
-                                        } else if (librarySongs.isNotEmpty()) {
+                                        // Shuffle Button: an InnerTube artist page uses its shuffleEndpoint;
+                                        // otherwise shuffle a local ListQueue — of the library songs, or of a
+                                        // Zemer-sourced page's own (whitelist-pure) tracks, which carry no
+                                        // shuffleEndpoint. So Shuffle survives the corpus swap; Radio waits for
+                                        // Zemer Radio (its endpoint is absent, so the Radio button above hides).
+                                        val shuffleEndpoint = artistPage?.artist?.shuffleEndpoint?.takeIf { !showLocal }
+                                        val shuffleSongs = if (showLocal) {
+                                            librarySongs.map { it.toMediaItem() }
+                                        } else {
+                                            artistPage?.sections
+                                                ?.flatMap { it.items }
+                                                ?.filterIsInstance<SongItem>()
+                                                ?.map { it.toMediaItem() }
+                                                .orEmpty()
+                                        }
+                                        val shuffleTitle = if (showLocal) {
+                                            libraryArtist?.artist?.name ?: unknownArtistTitle
+                                        } else {
+                                            artistPage?.artist?.title ?: unknownArtistTitle
+                                        }
+                                        if (shuffleEndpoint != null) {
                                             IconButton(
                                                 onClick = {
-                                                    val shuffledSongs = librarySongs.shuffled()
-                                                    if (shuffledSongs.isNotEmpty()) {
-                                                        playerConnection.playQueue(
-                                                            ListQueue(
-                                                                title = libraryArtist?.artist?.name ?: unknownArtistTitle,
-                                                                items = shuffledSongs.map { it.toMediaItem() },
-                                                                playSource = PlaySource.artist(viewModel.artistId)
-                                                            )
+                                                    playerConnection.playQueue(YouTubeQueue(shuffleEndpoint, preloadItem = null, database, playSource = PlaySource.artist(viewModel.artistId)))
+                                                },
+                                                modifier = Modifier
+                                                    .size(48.dp)
+                                                    .background(
+                                                        MaterialTheme.colorScheme.primary,
+                                                        RoundedCornerShape(24.dp)
+                                                    )
+                                            ) {
+                                                Icon(
+                                                    painter = painterResource(R.drawable.shuffle),
+                                                    contentDescription = stringResource(R.string.shuffle),
+                                                    tint = MaterialTheme.colorScheme.onPrimary,
+                                                    modifier = Modifier.size(20.dp)
+                                                )
+                                            }
+                                        } else if (shuffleSongs.isNotEmpty()) {
+                                            IconButton(
+                                                onClick = {
+                                                    playerConnection.playQueue(
+                                                        ListQueue(
+                                                            title = shuffleTitle,
+                                                            items = shuffleSongs.shuffled(),
+                                                            playSource = PlaySource.artist(viewModel.artistId)
                                                         )
-                                                    }
+                                                    )
                                                 },
                                                 modifier = Modifier
                                                     .size(48.dp)
@@ -599,8 +627,17 @@ fun ArtistScreen(
                             return@fastForEach
                         }
 
+                        // The top-songs shelf is a capped PREVIEW (its "more" arrow opens the full list) —
+                        // InnerTube returned only ~5, but /artist returns the whole catalog, so cap the inline
+                        // song list here to match instead of listing every song. Carousels + videos keep their
+                        // own limits; Play/Shuffle still use the full section, not this preview.
+                        val isSongList = distinctItems.firstOrNull() is SongItem && !isVideoSection
                         val visibleCount = visibleCounts.getOrPut(section.title) {
-                            if (isVideoSection) minOf(8, distinctItems.size) else distinctItems.size
+                            when {
+                                isVideoSection -> minOf(8, distinctItems.size)
+                                isSongList -> minOf(5, distinctItems.size)
+                                else -> distinctItems.size
+                            }
                         }
                         val displayItems = distinctItems.take(visibleCount)
 
@@ -638,7 +675,12 @@ fun ArtistScreen(
                             }
                         }
 
-                        if ((section.items.firstOrNull() as? SongItem)?.album != null) {
+                        // A non-video SongItem shelf (the "Songs"/top-songs list) renders as a vertical
+                        // LIST; videos/albums/singles/playlists render as the horizontal GRID. This keyed on
+                        // SongItem.album != null before — always set on the InnerTube path but absent on the
+                        // Zemer /artist songs — so key on item type + section instead. Same result for the
+                        // InnerTube path (its song shelf is non-video and album-tagged), fixes the Zemer path.
+                        if (section.items.firstOrNull() is SongItem && !isVideoSection) {
                             items(
                                 items = displayItems,
                                 key = { "youtube_song_${it.id}" },
@@ -746,9 +788,11 @@ fun ArtistScreen(
                                                                         ),
                                                                     )
                                                                 }
-                                                                is AlbumItem -> navController.navigate("album/${item.id}")
+                                                                // The artist page is corpus-sourced, so its albums/
+                                                                // playlists open via the server route (fast, bot-gate-proof).
+                                                                is AlbumItem -> navController.navigate(SearchProvider.ZEMER.onlineAlbumRoute(item))
                                                                 is ArtistItem -> navController.navigate("artist/${item.id}")
-                                                                is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
+                                                                is PlaylistItem -> navController.navigate(SearchProvider.ZEMER.onlinePlaylistRoute(item.id))
                                                             }
                                                         }
                                                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -643,33 +643,16 @@ fun ArtistScreen(
 
                         if (section.items.isNotEmpty()) {
                             item(key = "section_${section.title}") {
-                                val artistName = artistPage.artist.title
                                 NavigationTitle(
                                     title = section.title,
                                     modifier = Modifier.animateItem(),
-                                    // "Albums" is deliberately NOT routed to search. YouTube removed the
-                                    // album facet from search for independent (non-Official-Artist-Channel)
-                                    // artists: the search chip cloud no longer offers an "Albums" filter and
-                                    // search?filter=albums returns "No results" for them, even though the
-                                    // artist's page still lists every album. So route "Albums" through the
-                                    // section's own moreEndpoint (the artist album grid via YouTube.artistItems),
-                                    // like every other section, sourcing albums from where they now live.
-                                    // ("Songs" search still works, so it stays.) See tests/search/README.md.
-                                    onClick = when (section.title) {
-                                        "Songs" -> {
-                                            {
-                                                navController.navigate(
-                                                    "search/${java.net.URLEncoder.encode(artistName, "UTF-8")}?filter=songs"
-                                                )
-                                            }
-                                        }
-                                        else -> section.moreEndpoint?.let {
-                                            {
-                                                navController.navigate(
-                                                    "artist/${viewModel.artistId}/items?browseId=${it.browseId}?params=${it.params}",
-                                                )
-                                            }
-                                        }
+                                    // /artist returns each section's whole catalog, so every row gets the same
+                                    // "See all" arrow → a per-section view-all page (a Zemer-native list/grid,
+                                    // not the InnerTube moreEndpoint or a name search).
+                                    onClick = {
+                                        navController.navigate(
+                                            "artist_section/${viewModel.artistId}?title=${java.net.URLEncoder.encode(section.title, "UTF-8")}",
+                                        )
                                     },
                                 )
                             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -390,34 +390,32 @@ fun ArtistScreen(
                                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                                         verticalAlignment = Alignment.CenterVertically
                                     ) {
-                                        // Radio Button
-                                        if (!showLocal) {
-                                            artistPage?.artist?.radioEndpoint?.let { radioEndpoint ->
-                                                OutlinedButton(
-                                                    onClick = {
-                                                        playerConnection.playQueue(YouTubeQueue(radioEndpoint, preloadItem = null, database, playSource = PlaySource.artist(viewModel.artistId)))
-                                                    },
-                                                    shape = RoundedCornerShape(50),
-                                                    modifier = Modifier.height(40.dp)
-                                                ) {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.radio),
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(20.dp)
-                                                    )
-                                                    Spacer(modifier = Modifier.width(8.dp))
-                                                    Text(
-                                                        text = stringResource(R.string.radio)
-                                                    )
-                                                }
+                                        // Radio Button — corpus-native Zemer radio (`/radio?kind=artist`),
+                                        // whitelist-pure and InnerTube-free. Shown once the artist page loads.
+                                        if (!showLocal && artistPage != null) {
+                                            OutlinedButton(
+                                                onClick = {
+                                                    playerConnection.playQueue(viewModel.radioQueue())
+                                                },
+                                                shape = RoundedCornerShape(50),
+                                                modifier = Modifier.height(40.dp)
+                                            ) {
+                                                Icon(
+                                                    painter = painterResource(R.drawable.radio),
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(20.dp)
+                                                )
+                                                Spacer(modifier = Modifier.width(8.dp))
+                                                Text(
+                                                    text = stringResource(R.string.radio)
+                                                )
                                             }
                                         }
 
                                         // Shuffle Button: an InnerTube artist page uses its shuffleEndpoint;
                                         // otherwise shuffle a local ListQueue — of the library songs, or of a
                                         // Zemer-sourced page's own (whitelist-pure) tracks, which carry no
-                                        // shuffleEndpoint. So Shuffle survives the corpus swap; Radio waits for
-                                        // Zemer Radio (its endpoint is absent, so the Radio button above hides).
+                                        // shuffleEndpoint. (Radio, above, is the endless Zemer /radio queue.)
                                         val shuffleEndpoint = artistPage?.artist?.shuffleEndpoint?.takeIf { !showLocal }
                                         val shuffleSongs = if (showLocal) {
                                             librarySongs.map { it.toMediaItem() }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
@@ -1,0 +1,157 @@
+package com.jtech.zemer.ui.screens.artist
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.jtech.zemer.LocalDatabase
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.LocalPlayerConnection
+import com.jtech.zemer.R
+import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.tracking.PlaySource
+import com.jtech.zemer.ui.component.EmptyPlaceholder
+import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.screens.YtItemGrid
+import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.viewmodels.ArtistViewModel
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.WatchEndpoint
+
+/**
+ * "See all" for one artist-page section. `/artist` returns each section's whole catalog, so this reads
+ * the same [ArtistViewModel] (keyed by the route's `artistId`), finds the section by its title, and shows
+ * the full list — a vertical song list for the top-songs shelf, the shared [YtItemGrid] for videos /
+ * albums / singles / playlists (Zemer-routed, so opens go through the server, not InnerTube).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtistSectionScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    sectionTitle: String,
+    viewModel: ArtistViewModel = hiltViewModel(),
+) {
+    val artistPage = viewModel.artistPage
+    val isLoading = viewModel.isLoading
+    val section = artistPage?.sections?.firstOrNull { it.title == sectionTitle }
+    val items = section?.items?.distinctBy { it.id }.orEmpty()
+    val isVideoSection = sectionTitle.contains("video", ignoreCase = true) ||
+        sectionTitle.contains("short", ignoreCase = true)
+    val isSongList = items.firstOrNull() is SongItem && !isVideoSection
+
+    Box(Modifier.fillMaxSize()) {
+        when {
+            isSongList ->
+                ArtistSongList(items.filterIsInstance<SongItem>(), navController, viewModel.artistId)
+            items.isNotEmpty() ->
+                YtItemGrid(
+                    items = items,
+                    navController = navController,
+                    zemerAlbums = true,
+                    zemerPlaylists = true,
+                    communityPlaylists = false,
+                )
+            isLoading ->
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            else ->
+                EmptyPlaceholder(
+                    icon = R.drawable.music_note,
+                    text = stringResource(R.string.home_see_all_empty),
+                    modifier = Modifier.windowInsetsPadding(LocalPlayerAwareWindowInsets.current),
+                )
+        }
+    }
+
+    TopAppBar(
+        title = { Text(sectionTitle) },
+        navigationIcon = {
+            // The app's IconButton (long-press = back to Home), matching the other See-all screens.
+            com.jtech.zemer.ui.component.IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}
+
+/** The full top-songs list: tap plays the song under the artist play-source, matching the artist page. */
+@Composable
+private fun ArtistSongList(
+    songs: List<SongItem>,
+    navController: NavController,
+    artistId: String,
+) {
+    val menuState = LocalMenuState.current
+    val database = LocalDatabase.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val haptic = LocalHapticFeedback.current
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+
+    LazyColumn(contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()) {
+        items(items = songs, key = { it.id }) { song ->
+            YouTubeListItem(
+                item = song,
+                isActive = mediaMetadata?.id == song.id,
+                isPlaying = isPlaying,
+                trailingContent = {
+                    IconButton(onClick = {
+                        menuState.show { YouTubeSongMenu(song = song, navController = navController, onDismiss = menuState::dismiss) }
+                    }) {
+                        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
+                    }
+                },
+                modifier = Modifier.combinedClickable(
+                    onClick = {
+                        if (song.id == mediaMetadata?.id) {
+                            playerConnection.playPause()
+                        } else {
+                            playerConnection.playQueue(
+                                YouTubeQueue(
+                                    WatchEndpoint(videoId = song.id),
+                                    song.toMediaMetadata(),
+                                    database,
+                                    playSource = PlaySource.artist(artistId),
+                                ),
+                            )
+                        }
+                    },
+                    onLongClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        menuState.show { YouTubeSongMenu(song = song, navController = navController, onDismiss = menuState::dismiss) }
+                    },
+                ),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt
@@ -49,25 +49,31 @@ constructor(
         viewModelScope.launch {
             val album = database.album(albumId).first()
             runCatching { zemerRepository.album(albumId, zemerPlaylistId, zemerSearchOptions(context)) }
-                .onSuccess {
-                    playlistId.value = it.album.playlistId
-                    notFound.value = it.songs.isEmpty()
+                .onSuccess { page ->
+                    if (page == null) {
+                        // 404: the album is gone from the whitelist/corpus — surface not-found and
+                        // delete the stale local copy so it stops lingering in the library.
+                        notFound.value = true
+                        database.query {
+                            album?.album?.let(::delete)
+                        }
+                        return@onSuccess
+                    }
+                    playlistId.value = page.album.playlistId
+                    notFound.value = page.songs.isEmpty()
                     database.transaction {
                         if (album == null) {
-                            insert(it)
+                            insert(page)
                         } else {
-                            update(album.album, it, album.artists)
+                            update(album.album, page, album.artists)
                         }
                     }
                 }.onFailure {
                     if (it is java.util.concurrent.CancellationException) throw it
+                    // Transient failure (network / server): show not-found but keep the local copy —
+                    // only a definitive 404 above deletes it.
                     notFound.value = true
                     reportException(it)
-                    if (it.message?.contains("NOT_FOUND") == true) {
-                        database.query {
-                            album?.album?.let(::delete)
-                        }
-                    }
                 }
         }
     }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.metrolist.innertube.YouTube
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.search.ZemerSearchRepository
 import com.jtech.zemer.search.zemerSearchOptions
@@ -31,14 +30,16 @@ constructor(
         "albumId is required but was not provided in navigation arguments"
     }
 
-    // A Zemer-search album loads through the server's `/album` endpoint (already whitelist-scoped,
-    // fetched by a server immune to on-device InnerTube bot-gating) instead of `YouTube.album()`.
-    // Both paths yield the same AlbumPage, so everything downstream is shared. The search card's
-    // playlistId rides along because the server's album header doesn't return one.
-    private val isZemer = savedStateHandle.get<Boolean>("zemer") == true
+    // Albums load purely through the server's `/album` endpoint (whitelist-scoped, immune to on-device
+    // InnerTube bot-gating) — no InnerTube fallback (north-star: no app-runtime InnerTube; a non-corpus
+    // album is non-whitelisted and shouldn't open). The opener's playlistId rides along when it threaded
+    // one (a search/artist card); otherwise the server's own `album.playlistId` is used.
     private val zemerPlaylistId = savedStateHandle.get<String>("playlistId")
 
     val playlistId = MutableStateFlow("")
+    // True once the `/album` fetch 404s / fails (or returns no tracks) and there's nothing local to show —
+    // the screen renders a "not available" state instead of an endless loading shimmer.
+    val notFound = MutableStateFlow(false)
     val albumWithSongs =
         database
             .albumWithSongs(albumId)
@@ -47,15 +48,10 @@ constructor(
     init {
         viewModelScope.launch {
             val album = database.album(albumId).first()
-            val result =
-                if (isZemer) {
-                    runCatching { zemerRepository.album(albumId, zemerPlaylistId, zemerSearchOptions(context)) }
-                } else {
-                    YouTube.album(albumId)
-                }
-            result
+            runCatching { zemerRepository.album(albumId, zemerPlaylistId, zemerSearchOptions(context)) }
                 .onSuccess {
                     playlistId.value = it.album.playlistId
+                    notFound.value = it.songs.isEmpty()
                     database.transaction {
                         if (album == null) {
                             insert(it)
@@ -64,6 +60,8 @@ constructor(
                         }
                     }
                 }.onFailure {
+                    if (it is java.util.concurrent.CancellationException) throw it
+                    notFound.value = true
                     reportException(it)
                     if (it.message?.contains("NOT_FOUND") == true) {
                         database.query {

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
@@ -102,7 +102,6 @@ class ArtistViewModel @Inject constructor(
             kind = "artist",
             seed = artistId,
             context = context,
-            repository = zemerRepository,
             playSource = PlaySource.artist(artistId),
         )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
@@ -8,8 +8,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.metrolist.innertube.pages.ArtistPage
 import com.jtech.zemer.db.MusicDatabase
+import com.jtech.zemer.playback.queues.Queue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.search.ZemerSearchRepository
 import com.jtech.zemer.search.zemerSearchOptions
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -92,4 +95,14 @@ class ArtistViewModel @Inject constructor(
             isLoading = false
         }
     }
+
+    /** A corpus-native artist-seeded radio queue for the Radio button (Zemer `/radio`, no InnerTube). */
+    fun radioQueue(): Queue =
+        ZemerRadioQueue(
+            kind = "artist",
+            seed = artistId,
+            context = context,
+            repository = zemerRepository,
+            playSource = PlaySource.artist(artistId),
+        )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt
@@ -6,10 +6,10 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.metrolist.innertube.YouTube
-import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.pages.ArtistPage
 import com.jtech.zemer.db.MusicDatabase
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,8 +22,6 @@ import com.jtech.zemer.constants.HideExplicitKey
 import com.jtech.zemer.extensions.filterExplicit
 import com.jtech.zemer.extensions.filterExplicitAlbums
 import com.jtech.zemer.utils.dataStore
-import com.jtech.zemer.utils.getSuspend
-import com.jtech.zemer.utils.filterWhitelisted
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -35,6 +33,7 @@ import kotlinx.coroutines.flow.map
 class ArtistViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val database: MusicDatabase,
+    private val zemerRepository: ZemerSearchRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     val artistId = requireNotNull(savedStateHandle.get<String>("artistId")) {
@@ -80,55 +79,17 @@ class ArtistViewModel @Inject constructor(
     fun fetchArtistsFromYTM() {
         viewModelScope.launch {
             isLoading = true
-            val hideExplicit = context.dataStore.getSuspend(HideExplicitKey, false)
-            YouTube.artist(artistId)
-                .onSuccess { page ->
-                    timber.log.Timber.d("ArtistViewModel: Fetched YouTube page with ${page.sections.size} sections")
-                    page.sections.forEach { section ->
-                        timber.log.Timber.d("ArtistViewModel: Section '${section.title}' has ${section.items.size} items")
-                    }
-
-                    val filteredSections = mutableListOf<com.metrolist.innertube.pages.ArtistSection>()
-                    page.sections
-                        .filterNot { section ->
-                            // Filter "Fans might also like" / similar artist sections
-                            val browseId = section.moreEndpoint?.browseId ?: ""
-                            val hasSimilarBrowseId = browseId.startsWith("MPLAUC") ||
-                                                    browseId.startsWith("MPLART") ||
-                                                    browseId.startsWith("MPLREL")
-
-                            // Check for title keywords
-                            val hasSimilarTitle = section.title.contains("fans", ignoreCase = true) ||
-                                                 section.title.contains("similar", ignoreCase = true) ||
-                                                 section.title.contains("also like", ignoreCase = true) ||
-                                                 section.title.contains("you might", ignoreCase = true) ||
-                                                 section.title.contains("from your library", ignoreCase = true)
-
-                            // Check if section contains only artist recommendations
-                            val isOnlyArtists = section.items.isNotEmpty() &&
-                                               section.items.all { it is com.metrolist.innertube.models.ArtistItem }
-
-                            // Filter if it matches browseId OR (has similar title AND is only artists)
-                            hasSimilarBrowseId || (hasSimilarTitle && isOnlyArtists)
-                        }
-                        .forEach { section ->
-                            val originalCount = section.items.size
-                            val explicitFiltered = section.items.filterExplicit(hideExplicit)
-                            val whitelistFiltered = explicitFiltered.filterWhitelisted(
-                                database,
-                                requireAllArtists = false,
-                                fallbackArtistId = artistId,
-                            )
-                            timber.log.Timber.d("ArtistViewModel: Section '${section.title}': ${originalCount} items -> ${whitelistFiltered.size} after filtering")
-                            filteredSections.add(section.copy(items = whitelistFiltered))
-                        }
-
-                    artistPage = page.copy(sections = filteredSections)
-                    isLoading = false
-                }.onFailure {
+            // Served purely from the Zemer `/artist` corpus (whitelist-pure, already content-filtered,
+            // InnerTube-free). A 404 / failure leaves artistPage null — the screen then shows the local
+            // library content (showLocal) or nothing. No InnerTube fallback by design: the north-star is
+            // zero app-runtime InnerTube, and a non-corpus artist is non-whitelisted (shouldn't render).
+            artistPage = runCatching { zemerRepository.artist(artistId, zemerSearchOptions(context)) }
+                .onFailure {
+                    if (it is java.util.concurrent.CancellationException) throw it
                     reportException(it)
-                    isLoading = false
                 }
+                .getOrNull()
+            isLoading = false
         }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -19,6 +19,8 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toEnum
 import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.queues.Queue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.utils.ContentWhitelistDoc
 import com.jtech.zemer.utils.IsraeliArtistRegistry
 import com.jtech.zemer.utils.ZemerContentClient
@@ -856,6 +858,18 @@ class HomeViewModel @Inject constructor(
             uiState.update { it.copy(isLoading = false) }
         }
     }
+
+    /**
+     * "Radio mode": a corpus-native, whitelist-pure shuffle station over the whole catalog (Zemer
+     * `/radio?kind=shuffle`), replacing the old InnerTube lucky-item radio. Endless via the queue's token.
+     */
+    fun shuffleRadioQueue(): Queue =
+        ZemerRadioQueue(
+            kind = "shuffle",
+            seed = null,
+            context = context,
+            repository = zemerSearchRepository,
+        )
 
     fun refresh() {
         if (uiState.value.isRefreshing) return

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -868,7 +868,6 @@ class HomeViewModel @Inject constructor(
             kind = "shuffle",
             seed = null,
             context = context,
-            repository = zemerSearchRepository,
         )
 
     fun refresh() {

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -9,6 +9,8 @@
     <!-- Home rows -->
     <string name="featured_playlists">Community playlists</string>
     <string name="home_see_all_empty">Nothing here yet</string>
+    <string name="artist_not_available">This artist isn\'t available yet</string>
+    <string name="album_not_available">This album isn\'t available</string>
 
     <string name="local_history">Local</string>
     <string name="remote_history">Remote</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,7 +405,6 @@
     <string name="ok">OK</string>
     <string name="refresh_artists">Refresh artists</string>
     <string name="version_short">v%1$s</string>
-    <string name="radio_empty_message">Nothing to play yet. Try adding or playing something first.</string>
     <string name="splash_syncing_progress">Syncing %1$d/%2$d artists</string>
     <string name="splash_preparing_app">Warming up your experience…</string>
     <string name="splash_continue">Let\'s go</string>

--- a/app/src/test/kotlin/com/jtech/zemer/playback/QueueContinuationTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/QueueContinuationTest.kt
@@ -1,0 +1,42 @@
+package com.jtech.zemer.playback
+
+import androidx.media3.common.MediaItem
+import com.jtech.zemer.playback.queues.continuationItemsToAppend
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Guards the auto-load-more append rule: YouTube-style continuation pages lead with the
+ * already-queued current item, Zemer `/radio` pages are pure fresh tracks. Deduping against the
+ * queued ids handles both — the old blanket `drop(1)` silently discarded the first (top-ranked)
+ * track of every Zemer page (and a 1-track page appended nothing at all).
+ */
+class QueueContinuationTest {
+
+    private fun item(id: String): MediaItem = MediaItem.Builder().setMediaId(id).build()
+
+    @Test
+    fun `youtube-style page leading with the queued current item appends only the fresh tail`() {
+        val page = listOf(item("current"), item("n1"), item("n2"))
+
+        val appended = continuationItemsToAppend(setOf("prev", "current"), page)
+
+        assertEquals(listOf("n1", "n2"), appended.map { it.mediaId })
+    }
+
+    @Test
+    fun `zemer page of pure fresh tracks is appended whole - first track is not dropped`() {
+        val page = listOf(item("z1"), item("z2"), item("z3"))
+
+        val appended = continuationItemsToAppend(setOf("prev", "current"), page)
+
+        assertEquals(listOf("z1", "z2", "z3"), appended.map { it.mediaId })
+    }
+
+    @Test
+    fun `single fresh-track page survives - the old drop(1) appended nothing`() {
+        val appended = continuationItemsToAppend(setOf("current"), listOf(item("z1")))
+
+        assertEquals(listOf("z1"), appended.map { it.mediaId })
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -562,4 +562,66 @@ class ZemerResultMapperTest {
         assertEquals(listOf("okAlbum"), rows.albums.map { it.id })
         assertEquals(listOf("okVideo"), rows.videos.map { it.id })
     }
+
+    // --- /album playlistId threading (persisted to AlbumEntity.playlistId) ---
+
+    @Test
+    fun `album opener playlistId equal to the browseId never shadows the server's real one`() {
+        // toAlbumItem falls a card's playlistId back to the browseId, so an artist/search open can
+        // thread the MPRE itself; persisting it would dead-press album radio and mis-id share links.
+        val resp = ZemerAlbumResponse(
+            album = ZemerAlbumHeader(id = "MPRE1", playlistId = "OLAK9", title = "T", artist = "A"),
+            tracks = listOf(ZemerTrack("a", "A", "X")),
+        )
+
+        // Opener echoing the browseId -> the server's OLAK id wins.
+        assertEquals("OLAK9", resp.toAlbumPage(playlistId = "MPRE1").album.playlistId)
+        // A real opener OP id still wins over the server's.
+        assertEquals("OLAK1", resp.toAlbumPage(playlistId = "OLAK1").album.playlistId)
+        // Opener echoing the browseId with no server id -> browseId fallback (disabled automix only).
+        val bare = resp.copy(album = resp.album.copy(playlistId = null))
+        assertEquals("MPRE1", bare.toAlbumPage(playlistId = "MPRE1").album.playlistId)
+    }
+
+    // --- /radio page mapping (ZemerRadioResponse.toSongItems) ---
+
+    @Test
+    fun `radio tracks get the blocked-id overrides plus sparse-row drop and dedup`() {
+        BlockedIdsCache.updateAll(mapOf("blockedTrack" to "global"))
+        ContentFilterState.current = ContentFilterConfig(filtersEnabled = true)
+        val resp = ZemerRadioResponse(
+            tracks = listOf(
+                ZemerTrack("ok", "OK", "A"),
+                ZemerTrack("blockedTrack", "Blocked", "A"),
+                ZemerTrack("", "No id", "A"),
+                ZemerTrack("ok", "Dup", "A"),
+            ),
+            continuation = "tok",
+        )
+
+        assertEquals(listOf("ok"), resp.toSongItems().map { it.id })
+    }
+
+    @Test
+    fun `radio female-reason overrides follow the live content-filter config`() {
+        BlockedIdsCache.updateAll(mapOf("femaleTrack" to "female"))
+        val resp = ZemerRadioResponse(
+            tracks = listOf(ZemerTrack("ok", "OK", "A"), ZemerTrack("femaleTrack", "F", "B")),
+        )
+
+        ContentFilterState.current = ContentFilterConfig(filtersEnabled = true, allowFemaleSingers = false)
+        assertEquals(listOf("ok"), resp.toSongItems().map { it.id })
+
+        ContentFilterState.current = ContentFilterConfig(filtersEnabled = true, allowFemaleSingers = true)
+        assertEquals(listOf("ok", "femaleTrack"), resp.toSongItems().map { it.id })
+    }
+
+    @Test
+    fun `radio mapping keeps explicit tracks - explicit filtering is central in MusicService`() {
+        val resp = ZemerRadioResponse(
+            tracks = listOf(ZemerTrack("a", "Clean", "A"), ZemerTrack("b", "Dirty", "A", explicit = true)),
+        )
+
+        assertEquals(listOf("a", "b"), resp.toSongItems().map { it.id })
+    }
 }


### PR DESCRIPTION
Moves the artist/album **open** (browse) surfaces off app-runtime InnerTube onto the Zemer search server, and makes the Radio feature corpus-native, per the artist/album/playlist swap + Zemer Radio handoff. Streaming/playback stays InnerTube + the cipher (irreducible, out of scope).

## Artist opens → `/artist` (pure Zemer)
- New `/artist` integration: `ZemerArtistResponse` + `ZemerSearchClient.artist()` (404 → null) + `ZemerResultMapper.toArtistPage()` (sections built from the flat arrays, InnerTube order, 5-song preview cap) + `ZemerSearchRepository.artist()`.
- `ArtistViewModel` serves purely from `/artist` (no InnerTube fallback); a 404/empty shows local library content (`showLocal`) or a neutral "not available" state.
- Square album-art thumbnails + "View album" via the server's per-track `thumbnail` + `album{id,name}`.
- Per-section **"See all"** pages (`ArtistSectionScreen`), Zemer-native; sub-opens Zemer-routed. Local Shuffle of the page's tracks.

## Album opens → `/album` (pure Zemer)
- `AlbumViewModel` serves purely from `/album` (no InnerTube fallback); wires the server's `album.playlistId`; graceful 404/empty instead of an endless shimmer.

## Zemer Radio (all explicit radio surfaces, corpus-native)
- New `/radio` integration: `ZemerRadioResponse` + client/repo + `ZemerRadioQueue` (endless, opaque-token paging; repo resolved via a Hilt EntryPoint so it builds from just a `Context`). Reports plays as "radio".
- Wired: artist **Radio button** (`kind=artist`), Home **"Radio mode"** (`kind=shuffle`), album continuation `LocalAlbumRadio` (`kind=album`, retiring `YouTube.next()`), song + artist long-press **"Start radio"** (`kind=song` / `kind=artist`), and the now-playing seamless **"Start radio"** (`kind=song`).

## Not in this PR (tracked)
- **YouTube search engine removal** — greenlit; its own branch.
- The pervasive **single-song-tap default continuation** (`YouTubeQueue.radio`) — the core play path, its own pass over a seed-first queue on `/radio?kind=song`.
- **Playlist "Start radio"** — pending a server `/radio?kind=playlist` (asked in the handoff doc); already hidden for Zemer playlists.

## Testing
- Debug + release (R8) builds green throughout.
- No pure-JVM seam for the ViewModels/queues (Hilt + Media3, no Robolectric); verified via builds + the existing unit suite. `/artist`, `/album`, and `/radio` are live server-side — worth an on-device pass of the radio surfaces plus a non-corpus artist/album to confirm the graceful state.
