### PR TITLE
feat(radio): route single-song taps through Zemer /radio?kind=song

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleaseCard.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.R
-import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.playback.PlayerConnection
 import com.jtech.zemer.ui.component.AlbumBadges
@@ -47,7 +46,6 @@ fun LatestReleaseCard(
     release: LatestRelease,
     navController: NavController,
     playerConnection: PlayerConnection,
-    database: MusicDatabase,
     mediaMetadata: MediaMetadata?,
     isPlaying: Boolean,
     asGrid: Boolean,
@@ -59,7 +57,7 @@ fun LatestReleaseCard(
     val dateLabel = remember(release.browseId) { release.relativeDateLabel() }
     val subtitle = joinByBullet(release.artistName, dateLabel)
     val clickable = Modifier.combinedClickable(
-        onClick = { release.openOrPlay(navController, playerConnection, database) },
+        onClick = { release.openOrPlay(navController, playerConnection) },
         onLongClick = {
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
             menuState.show {

--- a/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlayback.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlayback.kt
@@ -1,12 +1,11 @@
 package com.jtech.zemer.latestreleases
 
 import androidx.navigation.NavController
-import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.playback.PlayerConnection
 import com.jtech.zemer.playback.queues.ListQueue
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 
 /**
@@ -57,11 +56,10 @@ fun LatestRelease.playableSingle(): MediaMetadata? =
 fun LatestRelease.openOrPlay(
     navController: NavController,
     playerConnection: PlayerConnection,
-    database: MusicDatabase,
 ) {
     val single = playableSingle()
     if (single != null) {
-        playerConnection.playQueue(YouTubeQueue.radio(single, database, PlaySource.NEW))
+        playerConnection.playQueue(ZemerRadioQueue.song(single, playerConnection.service, PlaySource.NEW))
     } else {
         navController.navigate("album/$browseId")
     }

--- a/app/src/main/kotlin/com/jtech/zemer/recognition/RecognitionHistoryPlayback.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/recognition/RecognitionHistoryPlayback.kt
@@ -1,0 +1,34 @@
+package com.jtech.zemer.recognition
+
+import com.jtech.zemer.db.entities.RecognitionHistoryEntity
+import com.jtech.zemer.models.MediaMetadata
+
+/**
+ * A history entry as the playable [MediaMetadata] seeding its radio replay. Two rules the hand-built
+ * inline version got wrong (and that persist through `MusicService.recoverSong`):
+ *
+ * - `duration` is the **-1 unknown sentinel**, never 0 — `recoverSong` treats 0 as a real length,
+ *   skips the playerResponse fetch, and the song shows "0:00" everywhere forever (its repair branch
+ *   only fires on -1).
+ * - Artists carry their real browse ids from [RecognitionHistoryEntity.artistIds] (stored precisely
+ *   for replay) so the persisted artist rows and the now-playing artist tap work. The display
+ *   string joins names with ", " and [RecognitionHistoryFilter.joinIds] drops null/blank
+ *   ids, so the two lists can disagree — ids are paired only when the counts line up (a lone name
+ *   takes the first id); on a mismatch the names keep null ids rather than mis-attribute a channel.
+ */
+fun RecognitionHistoryEntity.toMediaMetadata(): MediaMetadata {
+    val names = artist.split(", ").filter { it.isNotBlank() }
+    val ids = artistIds.split(RecognitionHistoryFilter.ID_SEPARATOR).filter { it.isNotBlank() }
+    val artists = when {
+        names.size == ids.size -> names.zip(ids) { name, id -> MediaMetadata.Artist(id = id, name = name) }
+        names.size == 1 && ids.isNotEmpty() -> listOf(MediaMetadata.Artist(id = ids.first(), name = names.single()))
+        else -> names.map { MediaMetadata.Artist(id = null, name = it) }
+    }
+    return MediaMetadata(
+        id = songId,
+        title = title,
+        artists = artists,
+        duration = -1,
+        thumbnailUrl = thumbnailUrl,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
@@ -53,14 +53,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.ListItemHeight
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.NavigationTitle
@@ -73,7 +72,6 @@ import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.ChartsViewModel
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -82,7 +80,6 @@ fun ChartsScreen(
     viewModel: ChartsViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isPlaying.collectAsState()
@@ -275,11 +272,7 @@ fun ChartsScreen(
                                                             playerConnection.playPause()
                                                         } else {
                                                             playerConnection.playQueue(
-                                                                YouTubeQueue(
-                                                                    endpoint = WatchEndpoint(videoId = song.id),
-                                                                    preloadItem = song.toMediaMetadata(),
-                                                                    database = database,
-                                                                ),
+                                                                ZemerRadioQueue.song(song.toMediaMetadata(), playerConnection.service),
                                                             )
                                                         }
                                                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
@@ -59,7 +58,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
@@ -83,7 +82,6 @@ fun HistoryScreen(
     viewModel: HistoryViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val database = LocalDatabase.current
     val menuState = LocalMenuState.current
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -262,7 +260,7 @@ fun HistoryScreen(
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(
-                                                YouTubeQueue.radio(song.toMediaMetadata(), database)
+                                                ZemerRadioQueue.song(song.toMediaMetadata(), playerConnection.service)
                                             )
                                         }
                                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -64,7 +64,7 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
 import com.jtech.zemer.search.onlinePlaylistRoute
@@ -101,7 +101,6 @@ import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.models.YTItem
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -216,7 +215,7 @@ fun HomeScreen(
                                 playerConnection.playPause()
                             } else {
                                 playerConnection.playQueue(
-                                    YouTubeQueue.radio(it.toMediaMetadata(), database),
+                                    ZemerRadioQueue.song(it.toMediaMetadata(), playerConnection.service),
                                 )
                             }
                         },
@@ -300,11 +299,7 @@ fun HomeScreen(
                     onClick = {
                         when (item) {
                             is SongItem -> playerConnection.playQueue(
-                                YouTubeQueue(
-                                    item.endpoint ?: WatchEndpoint(
-                                        videoId = item.id
-                                    ), item.toMediaMetadata(), database
-                                )
+                                ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service)
                             )
 
                             // Only the featured-albums row passes an AlbumItem through ytGridItem, so this
@@ -487,8 +482,8 @@ fun HomeScreen(
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(
-                                                        YouTubeQueue.radio(
-                                                            song!!.toMediaMetadata(), database
+                                                        ZemerRadioQueue.song(
+                                                            song!!.toMediaMetadata(), playerConnection.service
                                                         )
                                                     )
                                                 }
@@ -535,7 +530,6 @@ fun HomeScreen(
                                     release = release,
                                     navController = navController,
                                     playerConnection = playerConnection,
-                                    database = database,
                                     mediaMetadata = mediaMetadata,
                                     isPlaying = isPlaying,
                                     asGrid = true,
@@ -730,8 +724,8 @@ fun HomeScreen(
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(
-                                                        YouTubeQueue.radio(
-                                                            song!!.toMediaMetadata(), database
+                                                        ZemerRadioQueue.song(
+                                                            song!!.toMediaMetadata(), playerConnection.service
                                                         )
                                                     )
                                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -39,7 +39,7 @@ import com.jtech.zemer.db.entities.LocalItem
 import com.jtech.zemer.db.entities.Playlist
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
 import com.jtech.zemer.search.onlinePlaylistRoute
@@ -226,7 +226,7 @@ private fun SongList(songs: List<Song>, navController: NavController) {
                 modifier = Modifier.combinedClickable(
                     onClick = {
                         if (shown.id == mediaMetadata?.id) playerConnection.playPause()
-                        else playerConnection.playQueue(YouTubeQueue.radio(shown.toMediaMetadata(), database))
+                        else playerConnection.playQueue(ZemerRadioQueue.song(shown.toMediaMetadata(), playerConnection.service))
                     },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -242,7 +242,6 @@ private fun SongList(songs: List<Song>, navController: NavController) {
 @Composable
 private fun LocalItemList(items: List<LocalItem>, navController: NavController) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val haptic = LocalHapticFeedback.current
     val scope = rememberCoroutineScope()
@@ -264,7 +263,7 @@ private fun LocalItemList(items: List<LocalItem>, navController: NavController) 
                     modifier = Modifier.combinedClickable(
                         onClick = {
                             if (item.id == mediaMetadata?.id) playerConnection.playPause()
-                            else playerConnection.playQueue(YouTubeQueue.radio(item.toMediaMetadata(), database))
+                            else playerConnection.playQueue(ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service))
                         },
                         onLongClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
@@ -53,7 +52,6 @@ fun LatestReleasesScreen(
     viewModel: LatestReleasesViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
@@ -88,7 +86,6 @@ fun LatestReleasesScreen(
                     release = release,
                     navController = navController,
                     playerConnection = playerConnection,
-                    database = database,
                     mediaMetadata = mediaMetadata,
                     isPlaying = isPlaying,
                     asGrid = false,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
@@ -39,7 +38,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.ChoiceChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
@@ -55,7 +54,6 @@ import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.joinByBullet
 import com.jtech.zemer.utils.makeTimeString
 import com.jtech.zemer.viewmodels.StatsViewModel
-import com.metrolist.innertube.models.WatchEndpoint
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -66,7 +64,6 @@ fun StatsScreen(
     viewModel: StatsViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isPlaying.collectAsState()
@@ -262,11 +259,7 @@ fun StatsScreen(
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(
-                                                YouTubeQueue(
-                                                    endpoint = WatchEndpoint(song.id),
-                                                    preloadItem = mostPlayedSongs[index].toMediaMetadata(),
-                                                    database = database,
-                                                ),
+                                                ZemerRadioQueue.song(mostPlayedSongs[index].toMediaMetadata(), playerConnection.service),
                                             )
                                         }
                                     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/YouTubeBrowseScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/YouTubeBrowseScreen.kt
@@ -43,14 +43,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.ListItemHeight
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.NavigationTitle
@@ -78,7 +77,6 @@ fun YouTubeBrowseScreen(
     viewModel: YouTubeBrowseViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isPlaying.collectAsState()
@@ -181,9 +179,9 @@ fun YouTubeBrowseScreen(
                                                         playerConnection.playPause()
                                                     } else {
                                                         playerConnection.playQueue(
-                                                            YouTubeQueue.radio(
+                                                            ZemerRadioQueue.song(
                                                                 song.toMediaMetadata(),
-                                                                database
+                                                                playerConnection.service
                                                             )
                                                         )
                                                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -95,6 +95,7 @@ import com.jtech.zemer.search.SearchProvider
 import com.jtech.zemer.search.onlineAlbumRoute
 import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlbumGridItem
 import com.jtech.zemer.ui.component.HideOnScrollFAB
@@ -125,7 +126,6 @@ import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 import com.valentinilk.shimmer.shimmer
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
@@ -699,11 +699,10 @@ fun ArtistScreen(
                                                         playerConnection.playPause()
                                                     } else {
                                                         playerConnection.playQueue(
-                                                            YouTubeQueue(
-                                                                WatchEndpoint(videoId = song.id),
+                                                            ZemerRadioQueue.song(
                                                                 song.toMediaMetadata(),
-                                                                database,
-                                                                playSource = PlaySource.artist(viewModel.artistId)
+                                                                playerConnection.service,
+                                                                PlaySource.artist(viewModel.artistId)
                                                             ),
                                                         )
                                                     }
@@ -761,11 +760,10 @@ fun ArtistScreen(
                                                             when (item) {
                                                                 is SongItem -> {
                                                                     playerConnection.playQueue(
-                                                                        YouTubeQueue(
-                                                                            WatchEndpoint(videoId = item.id),
+                                                                        ZemerRadioQueue.song(
                                                                             item.toMediaMetadata(),
-                                                                            database,
-                                                                            playSource = PlaySource.artist(viewModel.artistId)
+                                                                            playerConnection.service,
+                                                                            PlaySource.artist(viewModel.artistId)
                                                                         ),
                                                                     )
                                                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
@@ -25,12 +25,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -40,7 +39,6 @@ import com.jtech.zemer.ui.screens.YtItemGrid
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.ArtistViewModel
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 
 /**
  * "See all" for one artist-page section. `/artist` returns each section's whole catalog, so this reads
@@ -112,7 +110,6 @@ private fun ArtistSongList(
     artistId: String,
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val haptic = LocalHapticFeedback.current
     val isPlaying by playerConnection.isPlaying.collectAsState()
@@ -137,11 +134,10 @@ private fun ArtistSongList(
                             playerConnection.playPause()
                         } else {
                             playerConnection.playQueue(
-                                YouTubeQueue(
-                                    WatchEndpoint(videoId = song.id),
+                                ZemerRadioQueue.song(
                                     song.toMediaMetadata(),
-                                    database,
-                                    playSource = PlaySource.artist(artistId),
+                                    playerConnection.service,
+                                    PlaySource.artist(artistId),
                                 ),
                             )
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt
@@ -27,21 +27,18 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.CONTENT_TYPE_HEADER
-import com.jtech.zemer.extensions.metadata
-import com.jtech.zemer.extensions.toMediaItem
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.viewmodels.LibraryVideosViewModel
-import com.metrolist.innertube.models.WatchEndpoint
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -53,7 +50,6 @@ fun LibraryVideosScreen(
     val menuState = LocalMenuState.current
     val haptic = LocalHapticFeedback.current
     val playerConnection = LocalPlayerConnection.current ?: return
-    val database = LocalDatabase.current
     val isPlaying = playerConnection.isPlaying.collectAsState().value
     val mediaMetadata = playerConnection.mediaMetadata.collectAsState().value
 
@@ -143,11 +139,7 @@ fun LibraryVideosScreen(
             onClick = {
                 videos.firstOrNull()?.let { first ->
                     playerConnection.playQueue(
-                        YouTubeQueue(
-                            WatchEndpoint(videoId = first.id),
-                            first.toMediaItem().metadata,
-                            database
-                        )
+                        ZemerRadioQueue.song(first.toMediaMetadata(), playerConnection.service)
                     )
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -42,7 +42,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.constants.ListThumbnailSize
 import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.RecognitionHistoryEntity
-import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.recognition.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.IconButton
@@ -104,18 +104,7 @@ fun RecognitionHistoryScreen(
                         entry = entry,
                         onPlay = {
                             playerConnection?.let { pc ->
-                                pc.playQueue(
-                                    ZemerRadioQueue.song(
-                                        MediaMetadata(
-                                            id = entry.songId,
-                                            title = entry.title,
-                                            artists = listOf(MediaMetadata.Artist(id = null, name = entry.artist)),
-                                            duration = 0,
-                                            thumbnailUrl = entry.thumbnailUrl,
-                                        ),
-                                        pc.service,
-                                    ),
-                                )
+                                pc.playQueue(ZemerRadioQueue.song(entry.toMediaMetadata(), pc.service))
                             }
                         },
                         onDelete = { viewModel.delete(entry) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -36,21 +36,20 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.ListThumbnailSize
 import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.RecognitionHistoryEntity
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.focusBorder
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.resize
 import com.jtech.zemer.viewmodels.RecognitionHistoryViewModel
-import com.metrolist.innertube.models.WatchEndpoint
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,7 +58,6 @@ fun RecognitionHistoryScreen(
     viewModel: RecognitionHistoryViewModel = hiltViewModel(),
 ) {
     val items by viewModel.history.collectAsState()
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current
     var showClearDialog by remember { mutableStateOf(false) }
 
@@ -105,9 +103,20 @@ fun RecognitionHistoryScreen(
                     RecognitionHistoryRow(
                         entry = entry,
                         onPlay = {
-                            playerConnection?.playQueue(
-                                YouTubeQueue(WatchEndpoint(videoId = entry.songId), database = database),
-                            )
+                            playerConnection?.let { pc ->
+                                pc.playQueue(
+                                    ZemerRadioQueue.song(
+                                        MediaMetadata(
+                                            id = entry.songId,
+                                            title = entry.title,
+                                            artists = listOf(MediaMetadata.Artist(id = null, name = entry.artist)),
+                                            duration = 0,
+                                            thumbnailUrl = entry.thumbnailUrl,
+                                        ),
+                                        pc.service,
+                                    ),
+                                )
+                            }
                         },
                         onDelete = { viewModel.delete(entry) },
                     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -43,13 +43,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.tracking.Tracker
 import com.jtech.zemer.tracking.TrackImpressionsByKey
@@ -83,7 +82,6 @@ import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
-import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.models.YTItem
 import com.jtech.zemer.ui.screens.videoRoute
 import kotlinx.coroutines.delay
@@ -96,7 +94,6 @@ fun OnlineSearchResult(
     viewModel: OnlineSearchViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
-    val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val haptic = LocalHapticFeedback.current
     val isPlaying by playerConnection.isPlaying.collectAsState()
@@ -190,12 +187,7 @@ fun OnlineSearchResult(
                         playerConnection.playPause()
                     } else {
                         playerConnection.playQueue(
-                            YouTubeQueue(
-                                WatchEndpoint(videoId = item.id),
-                                item.toMediaMetadata(),
-                                database,
-                                playSource = PlaySource.SEARCH,
-                            )
+                            ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service, PlaySource.SEARCH)
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -71,7 +71,7 @@ import com.jtech.zemer.search.onlinePlaylistRoute
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
-import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SearchBarIconOffsetX
 import com.jtech.zemer.ui.component.YouTubeListItem
@@ -278,7 +278,7 @@ fun OnlineSearchScreen(
                                         playerConnection.playPause()
                                     } else {
                                         playerConnection.playQueue(
-                                            YouTubeQueue.radio(item.toMediaMetadata(), database)
+                                            ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service)
                                         )
                                         onDismiss()
                                     }
@@ -352,7 +352,7 @@ fun OnlineSearchScreen(
                                         playerConnection.playPause()
                                     } else {
                                         playerConnection.playQueue(
-                                            YouTubeQueue.radio(item.toMediaMetadata(), database)
+                                            ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service)
                                         )
                                         onDismiss()
                                     }

--- a/app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionHistoryPlaybackTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/recognition/RecognitionHistoryPlaybackTest.kt
@@ -1,0 +1,64 @@
+package com.jtech.zemer.recognition
+
+import com.jtech.zemer.db.entities.RecognitionHistoryEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Guards the history-entry → MediaMetadata seed conversion the radio replay persists through
+ * `MusicService.recoverSong`: the -1 unknown-duration sentinel (0 would be stored as a real length
+ * and never repaired) and real artist browse ids from [RecognitionHistoryEntity.artistIds] (a null
+ * id persists a bogus local artist row and dead-presses the now-playing artist tap).
+ */
+class RecognitionHistoryPlaybackTest {
+
+    private fun entry(artist: String, artistIds: String) = RecognitionHistoryEntity(
+        songId = "vid1",
+        title = "Title",
+        artist = artist,
+        thumbnailUrl = "https://thumb",
+        artistIds = artistIds,
+    )
+
+    @Test
+    fun `duration is the -1 unknown sentinel so recoverSong fetches the real length`() {
+        assertEquals(-1, entry("A", "UC1").toMediaMetadata().duration)
+    }
+
+    @Test
+    fun `single artist carries its browse id`() {
+        val artists = entry("Abie Rotenberg", "UC1").toMediaMetadata().artists
+        assertEquals(listOf("Abie Rotenberg"), artists.map { it.name })
+        assertEquals(listOf("UC1"), artists.map { it.id })
+    }
+
+    @Test
+    fun `multiple artists pair names with ids in order`() {
+        val artists = entry("A, B", "UC1,UC2").toMediaMetadata().artists
+        assertEquals(listOf("A" to "UC1", "B" to "UC2"), artists.map { it.name to it.id })
+    }
+
+    @Test
+    fun `count mismatch keeps null ids rather than mis-attribute a channel`() {
+        // joinIds drops a null/blank id, so two names can sit next to one id — pairing would guess.
+        val artists = entry("A, B", "UC1").toMediaMetadata().artists
+        assertEquals(listOf("A", "B"), artists.map { it.name })
+        assertEquals(listOf(null, null), artists.map { it.id })
+    }
+
+    @Test
+    fun `no stored ids keeps the display artist with a null id`() {
+        val artists = entry("A", "").toMediaMetadata().artists
+        assertEquals(listOf("A"), artists.map { it.name })
+        assertNull(artists.single().id)
+    }
+
+    @Test
+    fun `id and thumbnail carry over`() {
+        val metadata = entry("A", "UC1").toMediaMetadata()
+        assertEquals("vid1", metadata.id)
+        assertEquals("Title", metadata.title)
+        assertEquals("https://thumb", metadata.thumbnailUrl)
+    }
+}


### PR DESCRIPTION
Routes every **single-song tap** off app-runtime `YouTube.next()` onto the corpus-native Zemer `/radio?kind=song` station. Follow-up to the artist/album swap + Zemer Radio work — this is the pervasive "tap a song → it plays, then autoplay-radio continues" path.

> **Stacked on #290** (`feat/artist-album-innertube-swap`) — it depends on `ZemerRadioQueue`, which lands there. Merge after #290.

## What changed
- **New `ZemerRadioQueue.song()` seed-first factory**: the tapped song plays immediately (preload) and heads the queue at index 0, deduped from the `/radio?kind=song` fill so it can't appear twice. `MusicService` splices the fill around the preloaded seed exactly as it did for `YouTubeQueue.radio`.
- **Converted every single-song-radio tap**:
  - The `YouTubeQueue.radio(song)` sites: Home, Home see-all, History, YouTube-browse, online search screen.
  - The equivalent bare-`WatchEndpoint(videoId)` `YouTubeQueue(...)` taps on corpus/local surfaces: the corpus-sourced artist page + per-section see-all, online search results, charts, stats, library videos, recognition history, and Home's featured-song grid.
- **Context queues unchanged**: album/playlist/artist-shuffle watch endpoints and deep links carrying a real `playlistId` stay on `YouTubeQueue` (they are chosen context, not radio).
- Dropped the now-dead `database`/`WatchEndpoint`/`YouTubeQueue` plumbing the conversions left behind (incl. threading `database` out of `LatestReleaseCard`/`openOrPlay`).

## Offline / downloaded music
Unaffected. The tapped downloaded song plays from the **preload** before the radio fetch runs; only the radio continuation needs the network — identical to the old `YouTube.next()` path, which also needed it. List playback (Downloaded / library) uses `ListQueue`, not radio, so it is fully offline.

## Not in this PR (tracked)
- Whole-screen **YouTube discovery** migrations — `NewReleaseScreen` (`FEmusic_new_releases`) and the legacy `ArtistItemsScreen` (`YouTube.artistItems`, superseded by the Zemer per-section see-all). Those are screen-level InnerTube-content removals, not the single-song-tap continuation.
- **YouTube search engine removal** — greenlit; its own branch.

## Testing
- Debug build green; full unit suite green; ui-audit + dead-resource + download-unification checks pass.
- No pure-JVM seam for the queue (Hilt + Media3, no Robolectric). Worth an on-device pass of the converted taps, including an **offline downloaded-song tap** to confirm it still plays.
