### PR TITLE
feat(offline): on-device search backup for brief Zemer-server outages

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -84,6 +84,9 @@ class App : Application(), SingletonImageLoader.Factory {
     @Inject
     lateinit var syncUtils: SyncUtils
 
+    @Inject
+    lateinit var offlineSubsetSyncer: com.jtech.zemer.offline.OfflineSubsetSyncer
+
     // Lazy so app start never pays for opening the DB before something else needs it.
     @Inject
     lateinit var databaseLazy: dagger.Lazy<MusicDatabase>
@@ -119,6 +122,14 @@ class App : Application(), SingletonImageLoader.Factory {
         registerActivityLifecycleCallbacks(TrackingLifecycle())
         PlayHistoryBackfill.maybeStart(this) { databaseLazy.get() }
         LibraryActionBackfill.maybeStart(this) { databaseLazy.get() }
+
+        // On-device offline-search snapshot: refresh it in the background if the user enabled offline
+        // search and it's due (daily), respecting the WiFi-only gate. Delayed + best-effort so it never
+        // competes with startup; a no-op when offline search is off. (docs: the outage-fallback subset.)
+        applicationScope.launch(Dispatchers.IO) {
+            delay(5000)
+            runCatching { offlineSubsetSyncer.maybeSync() }
+        }
 
         // Initialize cipher library for WEB_REMIX streaming
         ZemerCipher.initialize(

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -124,7 +124,7 @@ class App : Application(), SingletonImageLoader.Factory {
         LibraryActionBackfill.maybeStart(this) { databaseLazy.get() }
 
         // On-device offline-search snapshot: refresh it in the background if the user enabled offline
-        // search and it's due (daily), respecting the WiFi-only gate. Delayed + best-effort so it never
+        // search and it's due (daily, any connection). Delayed + best-effort so it never
         // competes with startup; a no-op when offline search is off. (docs: the outage-fallback subset.)
         applicationScope.launch(Dispatchers.IO) {
             delay(5000)

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -165,11 +165,12 @@ val DebugLoggingEnabledKey = booleanPreferencesKey("debugLoggingEnabled")
 val SearchProviderKey = stringPreferencesKey("searchProvider")
 
 // On-device outage-fallback subset: user opt-in to download the corpus snapshot for offline
-// search/browse (default off), whether to restrict downloads to unmetered networks (default on),
-// and the epoch-millis of the last successful sync (0 = never).
+// search/browse (default off; enabled = auto-updates on ANY connection — a product decision, the
+// diffs are small), the epoch-millis of the last successful sync (0 = never), and whether the user
+// dismissed the one-time search-screen promo (also set by declining the onboarding step).
 val OfflineSubsetEnabledKey = booleanPreferencesKey("offlineSubsetEnabled")
-val OfflineSubsetWifiOnlyKey = booleanPreferencesKey("offlineSubsetWifiOnly")
 val OfflineSubsetLastSyncedAtKey = longPreferencesKey("offlineSubsetLastSyncedAt")
+val OfflineSubsetPromoDismissedKey = booleanPreferencesKey("offlineSubsetPromoDismissed")
 
 val ContentFiltersAutoRestoredKey = booleanPreferencesKey("content_filters_auto_restored")
 val ContentFiltersRestoredEmailKey = stringPreferencesKey("content_filters_restored_email")

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -164,6 +164,13 @@ val DebugLoggingEnabledKey = booleanPreferencesKey("debugLoggingEnabled")
 // Online search engine: SearchProvider.name (ZEMER default, or YOUTUBE)
 val SearchProviderKey = stringPreferencesKey("searchProvider")
 
+// On-device outage-fallback subset: user opt-in to download the corpus snapshot for offline
+// search/browse (default off), whether to restrict downloads to unmetered networks (default on),
+// and the epoch-millis of the last successful sync (0 = never).
+val OfflineSubsetEnabledKey = booleanPreferencesKey("offlineSubsetEnabled")
+val OfflineSubsetWifiOnlyKey = booleanPreferencesKey("offlineSubsetWifiOnly")
+val OfflineSubsetLastSyncedAtKey = longPreferencesKey("offlineSubsetLastSyncedAt")
+
 val ContentFiltersAutoRestoredKey = booleanPreferencesKey("content_filters_auto_restored")
 val ContentFiltersRestoredEmailKey = stringPreferencesKey("content_filters_restored_email")
 val ContentFiltersLockedKey = booleanPreferencesKey("content_filters_locked")

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
@@ -3,6 +3,7 @@ package com.jtech.zemer.offline
 import android.content.Context
 import com.jtech.zemer.constants.OfflineSubsetLastSyncedAtKey
 import com.jtech.zemer.search.ZemerAlbumResponse
+import com.jtech.zemer.search.ZemerArtistResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylistResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
 import com.jtech.zemer.search.ZemerHomeRowsResponse
@@ -78,6 +79,11 @@ class OfflineReadProvider @Inject constructor(
     suspend fun album(id: String, allowFemale: Boolean, blockVideos: Boolean): ZemerAlbumResponse? =
         withContext(Dispatchers.IO) {
             snapshot()?.let { offlineAlbum(it.corpus, it.female, id, allowFemale, blockVideos, kidZone = false) }
+        }
+
+    suspend fun artist(id: String, allowFemale: Boolean, blockVideos: Boolean): ZemerArtistResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineArtist(it.corpus, it.female, id, allowFemale, blockVideos, kidZone = false) }
         }
 
     suspend fun homeRows(allowFemale: Boolean, blockVideos: Boolean): ZemerHomeRowsResponse? =

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
@@ -1,0 +1,73 @@
+package com.jtech.zemer.offline
+
+import android.content.Context
+import com.jtech.zemer.search.ZemerAlbumResponse
+import com.jtech.zemer.search.ZemerCuratedPlaylistResponse
+import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
+import com.jtech.zemer.search.ZemerHomeRowsResponse
+import com.jtech.zemer.search.ZemerSearchResponse
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.lang.ref.SoftReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Serves the reproducible Zemer read endpoints from the on-device snapshot ([SubsetCorpus]) so the app
+ * keeps working when `search.zemer.io` is unreachable. It returns the SAME response models the live
+ * [com.jtech.zemer.search.ZemerSearchClient] returns, so [com.jtech.zemer.search.ZemerSearchRepository]
+ * routes to it transparently (server-first, offline on network failure).
+ *
+ * The decoded corpus is cached behind a [SoftReference] — warm across repeated offline reads, but never
+ * pinning heap the app needs elsewhere (the snapshot is tens of MB in memory). It is reloaded when the
+ * on-disk manifest version changes (a sync landed) or the GC reclaimed it. All flags mirror the client:
+ * `kidZone` is always false (the client sends `kidZone=0` for these surfaces) and `hideExplicit` is
+ * applied by the shared mapper afterwards, not here.
+ *
+ * The endpoints that are NOT reproducible offline — `/playlist` (live YouTube) and `/radio` (needs the
+ * co-occurrence graph, not shipped) — have no method here; the repository leaves those server-only.
+ */
+@Singleton
+class OfflineReadProvider @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val store = SubsetStore(context)
+
+    private class Loaded(val version: Int, val corpus: SubsetCorpus, val female: FemaleMatcher)
+
+    private val lock = Any()
+    private var cache: SoftReference<Loaded>? = null
+
+    private fun snapshot(): Loaded? = synchronized(lock) {
+        val manifest = store.localManifest() ?: run { cache = null; return null }
+        cache?.get()?.let { if (it.version == manifest.v) return it }
+        val corpus = SubsetDecoder.loadCorpus(store) ?: run { cache = null; return null }
+        Loaded(manifest.v, corpus, buildFemaleMatcher(corpus.artists)).also { cache = SoftReference(it) }
+    }
+
+    suspend fun search(query: String, k: Int, allowFemale: Boolean, blockVideos: Boolean): ZemerSearchResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineSearch(it.corpus, it.female, query, k, allowFemale, blockVideos, kidZone = false) }
+        }
+
+    suspend fun album(id: String, allowFemale: Boolean, blockVideos: Boolean): ZemerAlbumResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineAlbum(it.corpus, it.female, id, allowFemale, blockVideos, kidZone = false) }
+        }
+
+    suspend fun homeRows(allowFemale: Boolean, blockVideos: Boolean): ZemerHomeRowsResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineHomeRows(it.corpus, it.female, allowFemale, blockVideos, kidZone = false) }
+        }
+
+    suspend fun curatedPlaylists(allowFemale: Boolean, blockVideos: Boolean): ZemerCuratedPlaylistsResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineCuratedPlaylists(it.corpus, it.female, allowFemale, blockVideos, kidZone = false) }
+        }
+
+    suspend fun curatedPlaylist(id: String, allowFemale: Boolean, blockVideos: Boolean): ZemerCuratedPlaylistResponse? =
+        withContext(Dispatchers.IO) {
+            snapshot()?.let { offlineCuratedPlaylist(it.corpus, it.female, id, allowFemale, blockVideos, kidZone = false) }
+        }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt
@@ -1,13 +1,17 @@
 package com.jtech.zemer.offline
 
 import android.content.Context
+import com.jtech.zemer.constants.OfflineSubsetLastSyncedAtKey
 import com.jtech.zemer.search.ZemerAlbumResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylistResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
 import com.jtech.zemer.search.ZemerHomeRowsResponse
 import com.jtech.zemer.search.ZemerSearchResponse
+import com.jtech.zemer.utils.WhitelistCache
+import com.jtech.zemer.utils.dataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.lang.ref.SoftReference
 import javax.inject.Inject
@@ -30,20 +34,40 @@ import javax.inject.Singleton
  */
 @Singleton
 class OfflineReadProvider @Inject constructor(
-    @ApplicationContext context: Context,
+    @ApplicationContext private val context: Context,
 ) {
     private val store = SubsetStore(context)
 
-    private class Loaded(val version: Int, val corpus: SubsetCorpus, val female: FemaleMatcher)
+    private class Loaded(
+        val version: Int,
+        val whitelistFingerprint: Long,
+        val corpus: SubsetCorpus,
+        val female: FemaleMatcher,
+    )
 
     private val lock = Any()
     private var cache: SoftReference<Loaded>? = null
 
-    private fun snapshot(): Loaded? = synchronized(lock) {
-        val manifest = store.localManifest() ?: run { cache = null; return null }
-        cache?.get()?.let { if (it.version == manifest.v) return it }
-        val corpus = SubsetDecoder.loadCorpus(store) ?: run { cache = null; return null }
-        Loaded(manifest.v, corpus, buildFemaleMatcher(corpus.artists)).also { cache = SoftReference(it) }
+    /**
+     * The decoded snapshot, gated on freshness ([subsetSnapshotIsFresh] — an unsyncable device must
+     * not serve an ever-aging copy) and overlaid with the live Firestore-synced whitelist
+     * ([SubsetCorpus.withLiveWhitelist] — a de-whitelisted or since-female-flagged artist is dropped
+     * the moment the app's whitelist sync lands, not on the next snapshot download). The cache is
+     * keyed on both the manifest version and the whitelist fingerprint so either changing rebuilds.
+     */
+    private suspend fun snapshot(): Loaded? {
+        val lastSyncedAt = context.dataStore.data.first()[OfflineSubsetLastSyncedAtKey] ?: 0L
+        if (!subsetSnapshotIsFresh(lastSyncedAt, System.currentTimeMillis())) return null
+        val live = WhitelistCache.snapshot().associate { it.artistId to it.isFemale }
+        return synchronized(lock) {
+            val manifest = store.localManifest() ?: run { cache = null; return null }
+            val fingerprint = liveWhitelistFingerprint(live)
+            cache?.get()?.let { if (it.version == manifest.v && it.whitelistFingerprint == fingerprint) return it }
+            val corpus = SubsetDecoder.loadCorpus(store)?.withLiveWhitelist(live)
+                ?: run { cache = null; return null }
+            Loaded(manifest.v, fingerprint, corpus, buildFemaleMatcher(corpus.artists))
+                .also { cache = SoftReference(it) }
+        }
     }
 
     suspend fun search(query: String, k: Int, allowFemale: Boolean, blockVideos: Boolean): ZemerSearchResponse? =

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
@@ -135,6 +135,19 @@ class OfflineSubsetSyncer @Inject constructor(
         }
     }
 
+    /**
+     * App-start auto-update: sync only when offline search is enabled and the last successful sync is
+     * older than [AUTO_UPDATE_INTERVAL_MS] (or never). A cheap no-op otherwise; [sync] still applies the
+     * enabled + WiFi-only gates, so an enabled-but-metered device simply defers to the next start.
+     */
+    suspend fun maybeSync() {
+        val prefs = context.dataStore.data.first()
+        if (prefs[OfflineSubsetEnabledKey] != true) return
+        val last = prefs[OfflineSubsetLastSyncedAtKey] ?: 0L
+        if (System.currentTimeMillis() - last < AUTO_UPDATE_INTERVAL_MS) return
+        sync()
+    }
+
     /** Wipes the downloaded snapshot (called when the user turns offline search off). */
     suspend fun clear() = mutex.withLock {
         store.clear()
@@ -147,5 +160,9 @@ class OfflineSubsetSyncer @Inject constructor(
             ?: return true
         val caps = cm.activeNetwork?.let(cm::getNetworkCapabilities) ?: return true
         return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+    }
+
+    companion object {
+        private const val AUTO_UPDATE_INTERVAL_MS = 24L * 60 * 60 * 1000 // daily
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
@@ -82,9 +82,6 @@ class OfflineSubsetSyncer @Inject constructor(
         }
     }
 
-    /** True when a usable snapshot is on disk (a committed manifest with its shards). */
-    fun hasSnapshot(): Boolean = store.localManifest() != null
-
     /**
      * Brings the local snapshot up to the server manifest. [force] runs even when the opt-in is off
      * (used by the "download now" settings action, which enables + forces the first sync).

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
@@ -1,15 +1,15 @@
 package com.jtech.zemer.offline
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import com.jtech.zemer.constants.OfflineSubsetEnabledKey
 import com.jtech.zemer.constants.OfflineSubsetLastSyncedAtKey
-import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
 import com.jtech.zemer.utils.dataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -29,9 +29,6 @@ enum class SubsetSyncOutcome {
     /** Offline search is off and the caller did not force — nothing done. */
     DISABLED,
 
-    /** WiFi-only is set and the active network is metered/absent — deferred, not an error. */
-    SKIPPED_METERED,
-
     /** Local snapshot already matches the server manifest. */
     UP_TO_DATE,
 
@@ -50,12 +47,6 @@ data class SubsetSyncStatus(
     val sizeOnDisk: Long = 0L,
     val lastSyncedAt: Long = 0L,
     val lastError: String? = null,
-    /**
-     * The last attempt was skipped by the WiFi-only gate (not an error). Rendered by the settings
-     * screen — without it an explicit "Download now" on cellular was a silent no-op that left the
-     * user believing a backup exists.
-     */
-    val waitingForWifi: Boolean = false,
 )
 
 /**
@@ -74,6 +65,9 @@ class OfflineSubsetSyncer @Inject constructor(
 ) {
     private val store = SubsetStore(context)
     private val mutex = Mutex()
+
+    // Singleton-owned scope for requestSync: outlives any screen/ViewModel that triggers a sync.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val _status = MutableStateFlow(SubsetSyncStatus())
     val status: StateFlow<SubsetSyncStatus> = _status.asStateFlow()
@@ -104,15 +98,11 @@ class OfflineSubsetSyncer @Inject constructor(
             val prefs = context.dataStore.data.first()
             val enabled = prefs[OfflineSubsetEnabledKey] ?: false
             if (!enabled && !force) return@withContext SubsetSyncOutcome.DISABLED
-            val wifiOnly = prefs[OfflineSubsetWifiOnlyKey] ?: true
-            if (wifiOnly && isMeteredOrOffline()) {
-                // Deferred, not an error — but it MUST be visible: the settings screen renders
-                // waitingForWifi so an explicit "Download now" on cellular isn't a silent dead press.
-                _status.update { it.copy(waitingForWifi = true) }
-                return@withContext SubsetSyncOutcome.SKIPPED_METERED
-            }
+            // No metered gate: enabled means the snapshot stays fresh on ANY connection (product
+            // decision — the old WiFi-only default deferred cellular-only devices forever and let
+            // the snapshot age to the staleness cap; incremental diffs are small).
 
-            _status.update { it.copy(running = true, lastError = null, waitingForWifi = false) }
+            _status.update { it.copy(running = true, lastError = null) }
             try {
                 val remote = client.fetchManifest()
                 if (remote.schema != SUPPORTED_SUBSET_SCHEMA) {
@@ -163,8 +153,8 @@ class OfflineSubsetSyncer @Inject constructor(
 
     /**
      * App-start auto-update: sync only when offline search is enabled and the last successful sync is
-     * older than [AUTO_UPDATE_INTERVAL_MS] (or never). A cheap no-op otherwise; [sync] still applies the
-     * enabled + WiFi-only gates, so an enabled-but-metered device simply defers to the next start.
+     * older than [AUTO_UPDATE_INTERVAL_MS] (or never). A cheap no-op otherwise. Enabled = MANDATORY
+     * freshness: it runs on whatever connection exists (no metered gate — see [sync]).
      */
     suspend fun maybeSync() {
         val prefs = context.dataStore.data.first()
@@ -174,6 +164,17 @@ class OfflineSubsetSyncer @Inject constructor(
         sync()
     }
 
+    /**
+     * Fire-and-forget [sync] on the syncer's own scope — for UI callers (settings, onboarding): a
+     * sync launched in a ViewModel scope dies with the screen, cancelling a first download midway
+     * the moment the user navigates on.
+     */
+    fun requestSync(force: Boolean = false) {
+        scope.launch {
+            runCatching { sync(force) } // sync() reports its own failures via status/log
+        }
+    }
+
     /** Wipes the downloaded snapshot (called when the user turns offline search off). */
     suspend fun clear() = mutex.withLock {
         withContext(Dispatchers.IO) {
@@ -181,13 +182,6 @@ class OfflineSubsetSyncer @Inject constructor(
             context.dataStore.edit { it.remove(OfflineSubsetLastSyncedAtKey) }
             _status.value = SubsetSyncStatus()
         }
-    }
-
-    private fun isMeteredOrOffline(): Boolean {
-        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-            ?: return true
-        val caps = cm.activeNetwork?.let(cm::getNetworkCapabilities) ?: return true
-        return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
@@ -9,6 +9,7 @@ import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
 import com.jtech.zemer.utils.dataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import androidx.datastore.preferences.core.edit
 import java.io.IOException
 import javax.inject.Inject
@@ -48,6 +50,12 @@ data class SubsetSyncStatus(
     val sizeOnDisk: Long = 0L,
     val lastSyncedAt: Long = 0L,
     val lastError: String? = null,
+    /**
+     * The last attempt was skipped by the WiFi-only gate (not an error). Rendered by the settings
+     * screen — without it an explicit "Download now" on cellular was a silent no-op that left the
+     * user believing a backup exists.
+     */
+    val waitingForWifi: Boolean = false,
 )
 
 /**
@@ -71,7 +79,7 @@ class OfflineSubsetSyncer @Inject constructor(
     val status: StateFlow<SubsetSyncStatus> = _status.asStateFlow()
 
     /** Repopulates [status] from what is currently on disk / in prefs (call before showing settings). */
-    suspend fun refresh() {
+    suspend fun refresh() = withContext(Dispatchers.IO) {
         val lastSyncedAt = context.dataStore.data.first()[OfflineSubsetLastSyncedAtKey] ?: 0L
         _status.update {
             it.copy(
@@ -85,50 +93,71 @@ class OfflineSubsetSyncer @Inject constructor(
     /**
      * Brings the local snapshot up to the server manifest. [force] runs even when the opt-in is off
      * (used by the "download now" settings action, which enables + forces the first sync).
+     *
+     * Runs on [Dispatchers.IO]: multi-MB SHA-256 hashing and blocking file writes must never execute
+     * on the caller's (often Main) dispatcher. Downloads are STAGED and promoted only after every
+     * shard verified — overwriting live shards one at a time left a silently mixed-version corpus
+     * whenever a later download failed.
      */
     suspend fun sync(force: Boolean = false): SubsetSyncOutcome = mutex.withLock {
-        val prefs = context.dataStore.data.first()
-        val enabled = prefs[OfflineSubsetEnabledKey] ?: false
-        if (!enabled && !force) return@withLock SubsetSyncOutcome.DISABLED
-        val wifiOnly = prefs[OfflineSubsetWifiOnlyKey] ?: true
-        if (wifiOnly && isMeteredOrOffline()) return@withLock SubsetSyncOutcome.SKIPPED_METERED
+        withContext(Dispatchers.IO) {
+            val prefs = context.dataStore.data.first()
+            val enabled = prefs[OfflineSubsetEnabledKey] ?: false
+            if (!enabled && !force) return@withContext SubsetSyncOutcome.DISABLED
+            val wifiOnly = prefs[OfflineSubsetWifiOnlyKey] ?: true
+            if (wifiOnly && isMeteredOrOffline()) {
+                // Deferred, not an error — but it MUST be visible: the settings screen renders
+                // waitingForWifi so an explicit "Download now" on cellular isn't a silent dead press.
+                _status.update { it.copy(waitingForWifi = true) }
+                return@withContext SubsetSyncOutcome.SKIPPED_METERED
+            }
 
-        _status.update { it.copy(running = true, lastError = null) }
-        try {
-            val remote = client.fetchManifest()
-            val plan = subsetSyncPlan(store.localManifest(), remote)
-
-            for (shard in plan.toDownload) {
-                val bytes = client.downloadShard(shard.name)
-                val actual = subsetShardHash(bytes)
-                if (actual != shard.hash) {
-                    throw IOException("shard ${shard.name} hash mismatch (expected ${shard.hash}, got $actual)")
+            _status.update { it.copy(running = true, lastError = null, waitingForWifi = false) }
+            try {
+                val remote = client.fetchManifest()
+                if (remote.schema != SUPPORTED_SUBSET_SCHEMA) {
+                    // Unknown wire-format generation (cipher-schemaVersion precedent): shard rows are
+                    // positional, so decoding them would silently mis-map — keep the last-good snapshot.
+                    throw IOException("unsupported subset schema ${remote.schema} (supported: $SUPPORTED_SUBSET_SCHEMA)")
                 }
-                store.writeShard(shard.name, bytes)
-            }
-            plan.toDelete.forEach(store::deleteShard)
-            store.pruneOrphans(remote.shards.mapTo(HashSet()) { it.name })
-            store.commitManifest(remote)
+                val plan = subsetSyncPlan(store.localManifest(), remote)
 
-            val now = System.currentTimeMillis()
-            context.dataStore.edit { it[OfflineSubsetLastSyncedAtKey] = now }
-            _status.update {
-                it.copy(
-                    running = false,
-                    localVersion = remote.v,
-                    sizeOnDisk = store.sizeOnDisk(),
-                    lastSyncedAt = now,
-                    lastError = null,
-                )
+                store.clearStaged()
+                for (shard in plan.toDownload) {
+                    val bytes = client.downloadShard(shard.name)
+                    val actual = subsetShardHash(bytes)
+                    if (actual != shard.hash) {
+                        throw IOException("shard ${shard.name} hash mismatch (expected ${shard.hash}, got $actual)")
+                    }
+                    store.stageShard(shard.name, bytes)
+                }
+                // Every download verified — only now touch the live set.
+                plan.toDownload.forEach { store.promoteStagedShard(it.name) }
+                plan.toDelete.forEach(store::deleteShard)
+                store.pruneOrphans(remote.shards.mapTo(HashSet()) { it.name })
+                store.commitManifest(remote)
+
+                val now = System.currentTimeMillis()
+                context.dataStore.edit { it[OfflineSubsetLastSyncedAtKey] = now }
+                _status.update {
+                    it.copy(
+                        running = false,
+                        localVersion = remote.v,
+                        sizeOnDisk = store.sizeOnDisk(),
+                        lastSyncedAt = now,
+                        lastError = null,
+                    )
+                }
+                if (plan.isNoOp) SubsetSyncOutcome.UP_TO_DATE else SubsetSyncOutcome.UPDATED
+            } catch (e: CancellationException) {
+                _status.update { it.copy(running = false) }
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Offline subset sync failed")
+                runCatching { store.clearStaged() }
+                _status.update { it.copy(running = false, lastError = e.message ?: e.javaClass.simpleName) }
+                SubsetSyncOutcome.FAILED
             }
-            if (plan.isNoOp) SubsetSyncOutcome.UP_TO_DATE else SubsetSyncOutcome.UPDATED
-        } catch (e: CancellationException) {
-            _status.update { it.copy(running = false) }
-            throw e
-        } catch (e: Exception) {
-            Timber.w(e, "Offline subset sync failed")
-            _status.update { it.copy(running = false, lastError = e.message ?: e.javaClass.simpleName) }
-            SubsetSyncOutcome.FAILED
         }
     }
 
@@ -147,9 +176,11 @@ class OfflineSubsetSyncer @Inject constructor(
 
     /** Wipes the downloaded snapshot (called when the user turns offline search off). */
     suspend fun clear() = mutex.withLock {
-        store.clear()
-        context.dataStore.edit { it.remove(OfflineSubsetLastSyncedAtKey) }
-        _status.value = SubsetSyncStatus()
+        withContext(Dispatchers.IO) {
+            store.clear()
+            context.dataStore.edit { it.remove(OfflineSubsetLastSyncedAtKey) }
+            _status.value = SubsetSyncStatus()
+        }
     }
 
     private fun isMeteredOrOffline(): Boolean {

--- a/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/OfflineSubsetSyncer.kt
@@ -1,0 +1,151 @@
+package com.jtech.zemer.offline
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.jtech.zemer.constants.OfflineSubsetEnabledKey
+import com.jtech.zemer.constants.OfflineSubsetLastSyncedAtKey
+import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
+import com.jtech.zemer.utils.dataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import androidx.datastore.preferences.core.edit
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/** What one [OfflineSubsetSyncer.sync] attempt did. */
+enum class SubsetSyncOutcome {
+    /** Offline search is off and the caller did not force — nothing done. */
+    DISABLED,
+
+    /** WiFi-only is set and the active network is metered/absent — deferred, not an error. */
+    SKIPPED_METERED,
+
+    /** Local snapshot already matches the server manifest. */
+    UP_TO_DATE,
+
+    /** Shards were downloaded/removed and the new manifest committed. */
+    UPDATED,
+
+    /** A network/verification error occurred; the previous snapshot (if any) is left intact. */
+    FAILED,
+}
+
+/** Observable snapshot state for settings UI. */
+data class SubsetSyncStatus(
+    val running: Boolean = false,
+    /** Version of the committed local manifest, or null when nothing is downloaded. */
+    val localVersion: Int? = null,
+    val sizeOnDisk: Long = 0L,
+    val lastSyncedAt: Long = 0L,
+    val lastError: String? = null,
+)
+
+/**
+ * Downloads and incrementally updates the on-device subset snapshot (see [SubsetManifest]).
+ *
+ * A single sync runs at a time ([mutex]). Each run diffs the local manifest against the server's,
+ * downloads only changed shards, **verifies every shard's content hash before writing it**, removes
+ * stale shards, and commits the new manifest last — so a failed or interrupted run never leaves a
+ * half-updated snapshot (the previous one keeps serving). Failure is expected when offline, so it is
+ * logged (not reported as a crash) and surfaces as [SubsetSyncOutcome.FAILED] / [SubsetSyncStatus.lastError].
+ */
+@Singleton
+class OfflineSubsetSyncer @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val client: SubsetSyncClient,
+) {
+    private val store = SubsetStore(context)
+    private val mutex = Mutex()
+
+    private val _status = MutableStateFlow(SubsetSyncStatus())
+    val status: StateFlow<SubsetSyncStatus> = _status.asStateFlow()
+
+    /** Repopulates [status] from what is currently on disk / in prefs (call before showing settings). */
+    suspend fun refresh() {
+        val lastSyncedAt = context.dataStore.data.first()[OfflineSubsetLastSyncedAtKey] ?: 0L
+        _status.update {
+            it.copy(
+                localVersion = store.localManifest()?.v,
+                sizeOnDisk = store.sizeOnDisk(),
+                lastSyncedAt = lastSyncedAt,
+            )
+        }
+    }
+
+    /** True when a usable snapshot is on disk (a committed manifest with its shards). */
+    fun hasSnapshot(): Boolean = store.localManifest() != null
+
+    /**
+     * Brings the local snapshot up to the server manifest. [force] runs even when the opt-in is off
+     * (used by the "download now" settings action, which enables + forces the first sync).
+     */
+    suspend fun sync(force: Boolean = false): SubsetSyncOutcome = mutex.withLock {
+        val prefs = context.dataStore.data.first()
+        val enabled = prefs[OfflineSubsetEnabledKey] ?: false
+        if (!enabled && !force) return@withLock SubsetSyncOutcome.DISABLED
+        val wifiOnly = prefs[OfflineSubsetWifiOnlyKey] ?: true
+        if (wifiOnly && isMeteredOrOffline()) return@withLock SubsetSyncOutcome.SKIPPED_METERED
+
+        _status.update { it.copy(running = true, lastError = null) }
+        try {
+            val remote = client.fetchManifest()
+            val plan = subsetSyncPlan(store.localManifest(), remote)
+
+            for (shard in plan.toDownload) {
+                val bytes = client.downloadShard(shard.name)
+                val actual = subsetShardHash(bytes)
+                if (actual != shard.hash) {
+                    throw IOException("shard ${shard.name} hash mismatch (expected ${shard.hash}, got $actual)")
+                }
+                store.writeShard(shard.name, bytes)
+            }
+            plan.toDelete.forEach(store::deleteShard)
+            store.pruneOrphans(remote.shards.mapTo(HashSet()) { it.name })
+            store.commitManifest(remote)
+
+            val now = System.currentTimeMillis()
+            context.dataStore.edit { it[OfflineSubsetLastSyncedAtKey] = now }
+            _status.update {
+                it.copy(
+                    running = false,
+                    localVersion = remote.v,
+                    sizeOnDisk = store.sizeOnDisk(),
+                    lastSyncedAt = now,
+                    lastError = null,
+                )
+            }
+            if (plan.isNoOp) SubsetSyncOutcome.UP_TO_DATE else SubsetSyncOutcome.UPDATED
+        } catch (e: CancellationException) {
+            _status.update { it.copy(running = false) }
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Offline subset sync failed")
+            _status.update { it.copy(running = false, lastError = e.message ?: e.javaClass.simpleName) }
+            SubsetSyncOutcome.FAILED
+        }
+    }
+
+    /** Wipes the downloaded snapshot (called when the user turns offline search off). */
+    suspend fun clear() = mutex.withLock {
+        store.clear()
+        context.dataStore.edit { it.remove(OfflineSubsetLastSyncedAtKey) }
+        _status.value = SubsetSyncStatus()
+    }
+
+    private fun isMeteredOrOffline(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return true
+        val caps = cm.activeNetwork?.let(cm::getNetworkCapabilities) ?: return true
+        return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
@@ -155,10 +155,10 @@ class BuiltCategories internal constructor(
         )
     }
 
-    // Content filters apply ONLY when explicitly requested (categories.mjs `allowed`). allowFemale=false
-    // drops female-involved; kidZone keeps only KidZone; blockVideos drops videos.
+    // Content filters apply ONLY when explicitly requested (categories.mjs `allowed`) — delegates to
+    // the shared [contentGatePasses] so the gate has ONE definition across the offline surfaces.
     private fun allowed(femaleInvolved: Boolean, isKidZone: Boolean, isVideo: Boolean, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): Boolean =
-        (if (!allowFemale) !femaleInvolved else true) && (if (kidZone) isKidZone else true) && (if (blockVideos) !isVideo else true)
+        contentGatePasses(femaleInvolved, isKidZone, isVideo, allowFemale, blockVideos, kidZone)
 
     // Server-curated id overrides (categories.mjs `blockedDoc`): `global` dropped always, `female` when
     // female is blocked. Matched against a result's videoId / id / playlistId.
@@ -201,7 +201,7 @@ class BuiltCategories internal constructor(
                 true // unknown member -> kept (fail-open)
             } else {
                 val female = m.female || femaleVideoIds.contains(m.videoId)
-                (allowFemale || !female) && (!kidZone || m.isKidZone) && (!blockVideos || !m.isVideo)
+                contentGatePasses(female, m.isKidZone, m.isVideo, allowFemale, blockVideos, kidZone)
             }
             if (keep) {
                 count++
@@ -215,9 +215,6 @@ class BuiltCategories internal constructor(
     }
 
     companion object {
-        private fun ytThumb(vid: String?): String? =
-            if (vid.isNullOrEmpty()) null else "https://i.ytimg.com/vi/$vid/mqdefault.jpg"
-
         /**
          * buildCategories over a [corpus] (categories.mjs `buildCategories`). Produces the seven indexes;
          * [female] is the shared matcher (build once via [buildFemaleMatcher]).
@@ -358,7 +355,7 @@ fun offlineSearch(
     blockVideos: Boolean,
     kidZone: Boolean,
 ): ZemerSearchResponse {
-    val query = q.replaceFirst(Regex("^\\s+"), "") // keep a TRAILING space
+    val query = q.trimStart() // keep a TRAILING space (it signals a completed last word)
     val kClamped = k.coerceIn(1, 200)
     if (query.isBlank()) return ZemerSearchResponse(q = query, count = 0, categories = ZemerCategories())
     val cats = categoriesFor(corpus, female)

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
@@ -65,9 +65,28 @@ internal class CatCommunityDoc(
     override val sortId get() = id
 }
 
-/** The seven built indexes for one corpus, plus the data the post-filter recompute needs. Build once. */
+/** One community member's filter-relevant snapshot, taken at build time (see [BuiltCategories]). */
+internal class CatCommunityMember(
+    val pos: Int,
+    val videoId: String,
+    /** No corpus track AND no discovery artist — kept fail-open by the recompute. */
+    val unknown: Boolean,
+    val female: Boolean,
+    val isKidZone: Boolean,
+    val isVideo: Boolean,
+)
+
+/**
+ * The seven built indexes for one corpus, plus the data the post-filter recompute needs. Build once.
+ *
+ * Deliberately holds NO [SubsetCorpus] reference: instances are cached in a `WeakHashMap` keyed by
+ * the corpus, and a value strongly referencing its own key can never be collected (WeakHashMap's
+ * documented trap) — each sync's corpus + indexes would be pinned forever. Everything the recompute
+ * needs is snapshotted into [communityMembers]/[blocked]/[femaleVideoIds] at build time instead.
+ */
 class BuiltCategories internal constructor(
-    private val corpus: SubsetCorpus,
+    private val blocked: SubBlocked,
+    private val communityMembers: Map<String, List<CatCommunityMember>>,
     private val artists: SubsetIndex<CatArtistDoc>,
     private val songs: SubsetIndex<CatTrackDoc>,
     private val videos: SubsetIndex<CatTrackDoc>,
@@ -79,7 +98,6 @@ class BuiltCategories internal constructor(
     // set (api.mjs setFemaleSet), used by the community post-filter kept-count recompute.
     private val femaleVideoIds: Set<String>,
 ) {
-    private val blocked = corpus.blocked
 
     fun search(q: String, k: Int, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): ZemerCategories {
         // pick = search n*4 -> filter allowed & !blocked -> slice n -> map (categories.mjs `pick`).
@@ -173,23 +191,17 @@ class BuiltCategories internal constructor(
     private class KeptCount(val count: Int, val cover: String?)
 
     // The api.mjs `communityKeptCounts` recompute: post-filter surviving-member count + first-surviving
-    // member's cover. Mirrors the SQL `keep` predicate over the corpus membership.
+    // member's cover, over the build-time member snapshots (no corpus reference — see the class KDoc).
     private fun communityKept(id: String, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): KeptCount {
-        val members = corpus.communityTracksByPlaylist[id].orEmpty()
         var count = 0
         var coverPos = Int.MAX_VALUE
         var coverVid: String? = null
-        for (m in members) {
-            val t = corpus.tracksById[m.videoId]
-            val a = t?.let { corpus.artistsById[it.artistId] }
-            val am = m.artistId?.let { corpus.artistsById[it] }
-            val keep = if (t == null && m.artistId == null) {
+        for (m in communityMembers[id].orEmpty()) {
+            val keep = if (m.unknown) {
                 true // unknown member -> kept (fail-open)
             } else {
-                val female = (a?.isFemale ?: am?.isFemale ?: false) || femaleVideoIds.contains(m.videoId)
-                val isKidZone = a?.isKidZone ?: am?.isKidZone ?: false
-                val isVideo = t?.isVideo ?: false
-                (allowFemale || !female) && (!kidZone || isKidZone) && (!blockVideos || !isVideo)
+                val female = m.female || femaleVideoIds.contains(m.videoId)
+                (allowFemale || !female) && (!kidZone || m.isKidZone) && (!blockVideos || !m.isVideo)
             }
             if (keep) {
                 count++
@@ -211,27 +223,23 @@ class BuiltCategories internal constructor(
          * [female] is the shared matcher (build once via [buildFemaleMatcher]).
          */
         fun build(corpus: SubsetCorpus, female: FemaleMatcher): BuiltCategories {
-            val femaleVideoIds = HashSet<String>()
-
-            // Enrich tracks: femaleInvolved = primary female OR a credited female (see SubsetFemale). Split
-            // songs / videos. Collect the female-involved videoId set.
+            // Enrich tracks: femaleInvolved = primary female OR a credited female — the shared
+            // [collectFemaleVideoIds] scan (SubsetFemale), the same one the read layer caches. Split
+            // songs / videos.
+            val involvedVideoIds = collectFemaleVideoIds(corpus, female)
             val trackDocs = ArrayList<CatTrackDoc>(corpus.tracks.size)
             for (t in corpus.tracks) {
                 val artist = corpus.artistsById[t.artistId]
-                val artistName = artist?.name ?: ""
-                val primaryFemale = artist?.isFemale ?: false
-                val fi = isFemaleInvolved(t.title, artistName, primaryFemale, female)
-                if (fi) femaleVideoIds.add(t.videoId)
                 trackDocs.add(
                     CatTrackDoc(
-                        videoId = t.videoId, title = t.title, artistName = artistName,
+                        videoId = t.videoId, title = t.title, artistName = artist?.name ?: "",
                         explicit = t.explicit, durationSec = t.durationSec, isVideo = t.isVideo,
-                        isKidZone = artist?.isKidZone ?: false, femaleInvolved = fi,
+                        isKidZone = artist?.isKidZone ?: false, femaleInvolved = t.videoId in involvedVideoIds,
                     ),
                 )
             }
             // `_female` = female-involved videoIds UNION the curated `female` blocked ids (api.mjs setFemaleSet).
-            femaleVideoIds.addAll(corpus.blocked.female)
+            val femaleVideoIds = HashSet(involvedVideoIds).apply { addAll(corpus.blocked.female) }
             val songDocs = trackDocs.filter { !it.isVideo }
             val videoDocs = trackDocs.filter { it.isVideo }
 
@@ -289,8 +297,27 @@ class BuiltCategories internal constructor(
                 )
             }
 
+            // Snapshot the per-community member facts the kept-count recompute needs, so the built
+            // value carries NO corpus reference (see the class KDoc — the WeakHashMap self-pin trap).
+            val communityMembers = corpus.community.associate { c ->
+                c.id to corpus.communityTracksByPlaylist[c.id].orEmpty().map { m ->
+                    val t = corpus.tracksById[m.videoId]
+                    val a = t?.let { corpus.artistsById[it.artistId] }
+                    val am = m.artistId?.let { corpus.artistsById[it] }
+                    CatCommunityMember(
+                        pos = m.pos,
+                        videoId = m.videoId,
+                        unknown = t == null && m.artistId == null,
+                        female = a?.isFemale ?: am?.isFemale ?: false,
+                        isKidZone = a?.isKidZone ?: am?.isKidZone ?: false,
+                        isVideo = t?.isVideo ?: false,
+                    )
+                }
+            }
+
             return BuiltCategories(
-                corpus = corpus,
+                blocked = corpus.blocked,
+                communityMembers = communityMembers,
                 artists = buildSubsetIndex(artistDocs),
                 songs = buildSubsetIndex(songDocs),
                 videos = buildSubsetIndex(videoDocs),

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCategories.kt
@@ -1,0 +1,342 @@
+package com.jtech.zemer.offline
+
+import com.jtech.zemer.search.ZemerAlbum
+import com.jtech.zemer.search.ZemerArtist
+import com.jtech.zemer.search.ZemerCategories
+import com.jtech.zemer.search.ZemerPlaylist
+import com.jtech.zemer.search.ZemerSearchResponse
+import com.jtech.zemer.search.ZemerTrack
+import java.util.WeakHashMap
+
+/**
+ * Grouped (categorized) offline search — the on-device port of `zemer-search/index/categories.mjs`
+ * plus the `/search` handler in `zemer-search/server/api.mjs`. Builds seven per-category indexes over a
+ * [SubsetCorpus] (artists / songs / albums / singles / videos / playlists / community, each doc carrying
+ * the content-filter flags) and returns top-k per category as [ZemerSearchResponse] — the SAME wire model
+ * the app decodes from the live server, so an offline result is consumed identically to a server one.
+ *
+ * The category split, the content filter, the community survival rule and the post-filter count/cover
+ * recompute are pinned to the JS source; residual, deliberately-reduced differences are called out inline.
+ */
+
+// --- category docs: each implements [SearchDoc] (title/artistName/sortId drive ranking) and carries the
+// content-filter fields (femaleInvolved / isKidZone / isVideo) + the id set blockedDoc() matches. --------
+
+internal class CatArtistDoc(
+    val id: String, val name: String, val thumbnail: String?,
+    val femaleInvolved: Boolean, val isKidZone: Boolean,
+) : SearchDoc {
+    override val title get() = name
+    override val artistName get() = ""
+    override val sortId get() = id
+}
+
+internal class CatTrackDoc(
+    val videoId: String, override val title: String, override val artistName: String,
+    val explicit: Boolean, val durationSec: Int?, val isVideo: Boolean,
+    val isKidZone: Boolean, val femaleInvolved: Boolean,
+) : SearchDoc {
+    override val sortId get() = videoId
+}
+
+internal class CatAlbumDoc(
+    val id: String, val playlistId: String?, override val title: String, override val artistName: String,
+    val type: String, val year: Int?, val thumbnail: String?,
+    val femaleInvolved: Boolean, val isKidZone: Boolean,
+) : SearchDoc {
+    override val sortId get() = id
+}
+
+internal class CatPlaylistDoc(
+    val id: String, override val title: String, override val artistName: String, val thumbnail: String?,
+    val femaleInvolved: Boolean, val isKidZone: Boolean,
+) : SearchDoc {
+    override val sortId get() = id
+}
+
+// Community playlists rank by TITLE only — artistName is "" on purpose (the "artist" is a random curator,
+// so matching/boosting on it would rank curator-name hits above title-begins-with hits). clsMask/fb mirror
+// store.mjs COMMUNITY_CONTENT_SQL; femaleOwned mirrors female-owned.mjs (author-name only offline).
+internal class CatCommunityDoc(
+    val id: String, override val title: String, val author: String, val thumbnail: String?,
+    val whitelisted: Int, val femaleOwned: Boolean, val clsMask: Int, val fb: Boolean,
+) : SearchDoc {
+    override val artistName get() = ""
+    override val sortId get() = id
+}
+
+/** The seven built indexes for one corpus, plus the data the post-filter recompute needs. Build once. */
+class BuiltCategories internal constructor(
+    private val corpus: SubsetCorpus,
+    private val artists: SubsetIndex<CatArtistDoc>,
+    private val songs: SubsetIndex<CatTrackDoc>,
+    private val videos: SubsetIndex<CatTrackDoc>,
+    private val albums: SubsetIndex<CatAlbumDoc>,
+    private val singles: SubsetIndex<CatAlbumDoc>,
+    private val playlists: SubsetIndex<CatPlaylistDoc>,
+    private val community: SubsetIndex<CatCommunityDoc>,
+    // female-involved videoIds (primary OR credited) UNION blocked.female — matches the server's `_female`
+    // set (api.mjs setFemaleSet), used by the community post-filter kept-count recompute.
+    private val femaleVideoIds: Set<String>,
+) {
+    private val blocked = corpus.blocked
+
+    fun search(q: String, k: Int, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): ZemerCategories {
+        // pick = search n*4 -> filter allowed & !blocked -> slice n -> map (categories.mjs `pick`).
+        fun <T : SearchDoc> pick(index: SubsetIndex<T>, n: Int, keep: (T) -> Boolean, blockIds: (T) -> List<String?>) =
+            searchIndex(index, q, n * 4).asSequence().map { it.doc }
+                .filter { keep(it) && !blockedDoc(blockIds(it), allowFemale) }
+                .take(n).toList()
+
+        val artistRows = pick(artists, k,
+            { allowed(it.femaleInvolved, it.isKidZone, isVideo = false, allowFemale, blockVideos, kidZone) },
+            { listOf(it.id) })
+            .map { ZemerArtist(id = it.id, name = it.name, thumbnail = it.thumbnail) }
+
+        fun trackRows(index: SubsetIndex<CatTrackDoc>) = pick(index, k,
+            { allowed(it.femaleInvolved, it.isKidZone, it.isVideo, allowFemale, blockVideos, kidZone) },
+            { listOf(it.videoId) })
+            .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = it.artistName, explicit = it.explicit, durationSec = it.durationSec) }
+
+        fun albumRows(index: SubsetIndex<CatAlbumDoc>) = pick(index, k,
+            { allowed(it.femaleInvolved, it.isKidZone, isVideo = false, allowFemale, blockVideos, kidZone) },
+            { listOf(it.id, it.playlistId) })
+            .map { ZemerAlbum(id = it.id, playlistId = it.playlistId, title = it.title, artist = it.artistName, year = it.year, thumbnail = it.thumbnail) }
+
+        val playlistRows = pick(playlists, k,
+            { allowed(it.femaleInvolved, it.isKidZone, isVideo = false, allowFemale, blockVideos, kidZone) },
+            { listOf(it.id) })
+            // Artist-owned playlists carry no `whitelisted` field on the wire => songCount null.
+            .map { ZemerPlaylist(id = it.id, title = it.title, artist = it.artistName, thumbnail = it.thumbnail, songCount = null) }
+
+        // Community: title-only ranking; communitySurvives() gate; then the api.mjs post-filter recompute of
+        // whitelisted count + cover (no-op when no filter is active).
+        val filterActive = !allowFemale || kidZone || blockVideos
+        val communityRows = searchIndex(community, q, k * 4).asSequence().map { it.doc }
+            .filter { communitySurvives(it, allowFemale, blockVideos, kidZone) && !blockedDoc(listOf(it.id), allowFemale) }
+            .take(k).toList()
+            .map { d ->
+                var songCount = d.whitelisted
+                var thumb = d.thumbnail
+                if (filterActive) {
+                    val kept = communityKept(d.id, allowFemale, blockVideos, kidZone)
+                    songCount = kept.count
+                    if (kept.cover != null) thumb = kept.cover
+                }
+                ZemerPlaylist(id = d.id, title = d.title, artist = d.author, thumbnail = thumb, songCount = songCount)
+            }
+
+        return ZemerCategories(
+            artists = artistRows,
+            songs = trackRows(songs),
+            albums = albumRows(albums),
+            singles = albumRows(singles),
+            videos = trackRows(videos),
+            playlists = playlistRows,
+            community = communityRows,
+        )
+    }
+
+    // Content filters apply ONLY when explicitly requested (categories.mjs `allowed`). allowFemale=false
+    // drops female-involved; kidZone keeps only KidZone; blockVideos drops videos.
+    private fun allowed(femaleInvolved: Boolean, isKidZone: Boolean, isVideo: Boolean, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): Boolean =
+        (if (!allowFemale) !femaleInvolved else true) && (if (kidZone) isKidZone else true) && (if (blockVideos) !isVideo else true)
+
+    // Server-curated id overrides (categories.mjs `blockedDoc`): `global` dropped always, `female` when
+    // female is blocked. Matched against a result's videoId / id / playlistId.
+    private fun blockedDoc(ids: List<String?>, allowFemale: Boolean): Boolean {
+        for (id in ids) {
+            if (id != null && (blocked.global.contains(id) || (!allowFemale && blocked.female.contains(id)))) return true
+        }
+        return false
+    }
+
+    // A community playlist survives iff >=1 whitelisted member survives the active filter (categories.mjs
+    // `communitySurvives`), using the packed [CatCommunityDoc.clsMask]. Fail-open on no class data.
+    private fun communitySurvives(p: CatCommunityDoc, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): Boolean {
+        if (allowFemale && !kidZone && !blockVideos) return true // no filter active
+        if (p.femaleOwned && !allowFemale) return false // a female artist's OWN playlist -> hide
+        if (p.fb) return true // has an unknown member -> always kept
+        val mask = p.clsMask
+        if (mask == 0) return true // no data -> don't hide
+        for (c in 0 until 8) {
+            if (mask and (1 shl c) == 0) continue
+            val female = (c shr 2) and 1
+            val video = (c shr 1) and 1
+            val kidzone = c and 1
+            val excluded = (female == 1 && !allowFemale) || (video == 1 && blockVideos) || (kidzone == 0 && kidZone)
+            if (!excluded) return true
+        }
+        return false
+    }
+
+    private class KeptCount(val count: Int, val cover: String?)
+
+    // The api.mjs `communityKeptCounts` recompute: post-filter surviving-member count + first-surviving
+    // member's cover. Mirrors the SQL `keep` predicate over the corpus membership.
+    private fun communityKept(id: String, allowFemale: Boolean, blockVideos: Boolean, kidZone: Boolean): KeptCount {
+        val members = corpus.communityTracksByPlaylist[id].orEmpty()
+        var count = 0
+        var coverPos = Int.MAX_VALUE
+        var coverVid: String? = null
+        for (m in members) {
+            val t = corpus.tracksById[m.videoId]
+            val a = t?.let { corpus.artistsById[it.artistId] }
+            val am = m.artistId?.let { corpus.artistsById[it] }
+            val keep = if (t == null && m.artistId == null) {
+                true // unknown member -> kept (fail-open)
+            } else {
+                val female = (a?.isFemale ?: am?.isFemale ?: false) || femaleVideoIds.contains(m.videoId)
+                val isKidZone = a?.isKidZone ?: am?.isKidZone ?: false
+                val isVideo = t?.isVideo ?: false
+                (allowFemale || !female) && (!kidZone || isKidZone) && (!blockVideos || !isVideo)
+            }
+            if (keep) {
+                count++
+                if (m.pos < coverPos) {
+                    coverPos = m.pos
+                    coverVid = m.videoId
+                }
+            }
+        }
+        return KeptCount(count, ytThumb(coverVid))
+    }
+
+    companion object {
+        private fun ytThumb(vid: String?): String? =
+            if (vid.isNullOrEmpty()) null else "https://i.ytimg.com/vi/$vid/mqdefault.jpg"
+
+        /**
+         * buildCategories over a [corpus] (categories.mjs `buildCategories`). Produces the seven indexes;
+         * [female] is the shared matcher (build once via [buildFemaleMatcher]).
+         */
+        fun build(corpus: SubsetCorpus, female: FemaleMatcher): BuiltCategories {
+            val femaleVideoIds = HashSet<String>()
+
+            // Enrich tracks: femaleInvolved = primary female OR a credited female (see SubsetFemale). Split
+            // songs / videos. Collect the female-involved videoId set.
+            val trackDocs = ArrayList<CatTrackDoc>(corpus.tracks.size)
+            for (t in corpus.tracks) {
+                val artist = corpus.artistsById[t.artistId]
+                val artistName = artist?.name ?: ""
+                val primaryFemale = artist?.isFemale ?: false
+                val fi = isFemaleInvolved(t.title, artistName, primaryFemale, female)
+                if (fi) femaleVideoIds.add(t.videoId)
+                trackDocs.add(
+                    CatTrackDoc(
+                        videoId = t.videoId, title = t.title, artistName = artistName,
+                        explicit = t.explicit, durationSec = t.durationSec, isVideo = t.isVideo,
+                        isKidZone = artist?.isKidZone ?: false, femaleInvolved = fi,
+                    ),
+                )
+            }
+            // `_female` = female-involved videoIds UNION the curated `female` blocked ids (api.mjs setFemaleSet).
+            femaleVideoIds.addAll(corpus.blocked.female)
+            val songDocs = trackDocs.filter { !it.isVideo }
+            val videoDocs = trackDocs.filter { it.isVideo }
+
+            val albumDocs = corpus.albums.map { a ->
+                val artist = corpus.artistsById[a.artistId]
+                val artistName = artist?.name ?: ""
+                val primaryFemale = artist?.isFemale ?: false
+                CatAlbumDoc(
+                    id = a.id, playlistId = a.playlistId, title = a.title, artistName = artistName,
+                    type = a.type, year = a.year, thumbnail = a.thumbnail,
+                    femaleInvolved = primaryFemale || isFemaleInvolved(a.title, artistName, primaryFemale, female),
+                    isKidZone = artist?.isKidZone ?: false,
+                )
+            }
+
+            val artistDocs = corpus.artists.map { a ->
+                CatArtistDoc(id = a.id, name = a.name, thumbnail = a.thumbnail, femaleInvolved = a.isFemale, isKidZone = a.isKidZone)
+            }
+
+            val playlistDocs = corpus.artistPlaylists.map { p ->
+                val artist = corpus.artistsById[p.artistId]
+                CatPlaylistDoc(
+                    id = p.id, title = p.title, artistName = artist?.name ?: "", thumbnail = p.thumbnail,
+                    femaleInvolved = artist?.isFemale ?: false, isKidZone = artist?.isKidZone ?: false,
+                )
+            }
+
+            // Community docs: clsMask/fb computed from members (store.mjs COMMUNITY_CONTENT_SQL); femaleOwned
+            // from the author name (SubsetFemale — the female-owned id set is not shipped on device).
+            val communityDocs = corpus.community.map { c ->
+                val members = corpus.communityTracksByPlaylist[c.id].orEmpty()
+                var clsMask = 0
+                var fb = false
+                var coverVid: String? = null
+                for (m in members) {
+                    if (coverVid == null) coverVid = m.videoId // members are pos-sorted -> first = cover
+                    val t = corpus.tracksById[m.videoId]
+                    val known = t != null || m.artistId != null
+                    if (!known) {
+                        fb = true
+                    } else {
+                        val a = t?.let { corpus.artistsById[it.artistId] }
+                        val am = m.artistId?.let { corpus.artistsById[it] }
+                        val female2 = (a?.isFemale ?: false) || (am?.isFemale ?: false) || femaleVideoIds.contains(m.videoId)
+                        val video = t?.isVideo ?: false
+                        val kidzone = (a?.isKidZone ?: false) || (am?.isKidZone ?: false)
+                        val cls = (if (female2) 4 else 0) + (if (video) 2 else 0) + (if (kidzone) 1 else 0)
+                        clsMask = clsMask or (1 shl cls)
+                    }
+                }
+                CatCommunityDoc(
+                    id = c.id, title = c.title, author = c.author ?: "", thumbnail = ytThumb(coverVid),
+                    whitelisted = c.whitelisted, femaleOwned = isCommunityFemaleOwned(c.author, female),
+                    clsMask = clsMask, fb = fb,
+                )
+            }
+
+            return BuiltCategories(
+                corpus = corpus,
+                artists = buildSubsetIndex(artistDocs),
+                songs = buildSubsetIndex(songDocs),
+                videos = buildSubsetIndex(videoDocs),
+                albums = buildSubsetIndex(albumDocs.filter { it.type != "single" }),
+                singles = buildSubsetIndex(albumDocs.filter { it.type == "single" }),
+                playlists = buildSubsetIndex(playlistDocs),
+                community = buildSubsetIndex(communityDocs),
+                femaleVideoIds = femaleVideoIds,
+            )
+        }
+    }
+}
+
+// Per-corpus cache of the built indexes so repeated offlineSearch calls don't rebuild (WeakHashMap so a
+// discarded corpus is collectable). Keyed on corpus identity; the matcher is derived deterministically
+// from the same corpus.
+private val categoriesCache = WeakHashMap<SubsetCorpus, BuiltCategories>()
+
+private fun categoriesFor(corpus: SubsetCorpus, female: FemaleMatcher): BuiltCategories =
+    synchronized(categoriesCache) { categoriesCache.getOrPut(corpus) { BuiltCategories.build(corpus, female) } }
+
+/**
+ * Top-level offline search entry point — the on-device equivalent of `GET /search`. Strips LEADING
+ * whitespace (a TRAILING space is kept — it signals a completed last word), clamps [k] to [1, 200] and
+ * returns the same [ZemerSearchResponse] the live server would for the same query + flags over the same
+ * corpus build. The category indexes are built once per corpus and cached.
+ *
+ * @param allowFemale false drops female-involved results (server default is true / open).
+ * @param blockVideos true drops the videos category and video tracks.
+ * @param kidZone true keeps only KidZone artists.
+ */
+fun offlineSearch(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    q: String,
+    k: Int,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerSearchResponse {
+    val query = q.replaceFirst(Regex("^\\s+"), "") // keep a TRAILING space
+    val kClamped = k.coerceIn(1, 200)
+    if (query.isBlank()) return ZemerSearchResponse(q = query, count = 0, categories = ZemerCategories())
+    val cats = categoriesFor(corpus, female)
+    val categories = cats.search(query, kClamped, allowFemale, blockVideos, kidZone)
+    val count = categories.artists.size + categories.songs.size + categories.albums.size +
+        categories.singles.size + categories.videos.size + categories.playlists.size + categories.community.size
+    return ZemerSearchResponse(q = query, count = count, categories = categories)
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCorpus.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetCorpus.kt
@@ -1,0 +1,134 @@
+package com.jtech.zemer.offline
+
+/**
+ * The decoded on-device corpus snapshot — the Kotlin mirror of the zemer-search SQLite tables the
+ * shards carry (see [SubsetDecoder] for the wire layout). Read endpoints ([OfflineReadLayer]) run over
+ * this in memory, exactly as the server runs them over SQLite, so an offline response matches the
+ * live one field-for-field for the reproducible endpoints.
+ *
+ * Raw tables are plain lists; the maps/groupings the reads need are built lazily on first use so a
+ * corpus that is loaded but never queried (e.g. app start with offline search off) costs only the parse.
+ */
+class SubsetCorpus(
+    val artists: List<SubArtist>,
+    val tracks: List<SubTrack>,
+    val albums: List<SubAlbum>,
+    val albumTracks: List<SubAlbumTrack>,
+    val artistPlaylists: List<SubArtistPlaylist>,
+    val community: List<SubCommunity>,
+    val communityTracks: List<SubCommunityTrack>,
+    val homeRank: List<SubHomeRank>,
+    val zemerPlaylists: List<SubZemerPlaylist>,
+    val zemerItems: List<SubZemerItem>,
+    val blocked: SubBlocked,
+) {
+    val artistsById: Map<String, SubArtist> by lazy { artists.associateBy { it.id } }
+    val tracksById: Map<String, SubTrack> by lazy { tracks.associateBy { it.videoId } }
+    val albumsById: Map<String, SubAlbum> by lazy { albums.associateBy { it.id } }
+    val communityById: Map<String, SubCommunity> by lazy { community.associateBy { it.id } }
+
+    /** Album members in stored order, grouped by album id. */
+    val albumTracksByAlbum: Map<String, List<SubAlbumTrack>> by lazy {
+        albumTracks.groupBy { it.albumId }.mapValues { (_, v) -> v.sortedBy { it.pos } }
+    }
+
+    /** Community members in stored order, grouped by community playlist id. */
+    val communityTracksByPlaylist: Map<String, List<SubCommunityTrack>> by lazy {
+        communityTracks.groupBy { it.playlistId }.mapValues { (_, v) -> v.sortedBy { it.pos } }
+    }
+
+    /**
+     * videoId → the album it belongs to with the smallest album id (matches the server's `trackAlbumInfo`
+     * MIN(album_id) tie-break), for the song "View album" link and per-song artwork.
+     */
+    val albumOfTrack: Map<String, SubAlbum> by lazy {
+        val byVideo = HashMap<String, SubAlbum>()
+        for (at in albumTracks) {
+            val album = albumsById[at.albumId] ?: continue
+            val cur = byVideo[at.videoId]
+            if (cur == null || album.id < cur.id) byVideo[at.videoId] = album
+        }
+        byVideo
+    }
+
+    val zemerItemsByPlaylist: Map<String, List<SubZemerItem>> by lazy {
+        zemerItems.groupBy { it.playlistId }.mapValues { (_, v) -> v.sortedBy { it.pos } }
+    }
+
+    val homeRankByRow: Map<String, List<SubHomeRank>> by lazy {
+        homeRank.groupBy { it.row }.mapValues { (_, v) -> v.sortedBy { it.pos } }
+    }
+}
+
+data class SubArtist(
+    val id: String,
+    val name: String,
+    val thumbnail: String?,
+    val isFemale: Boolean,
+    val isChasid: Boolean,
+    val isKidZone: Boolean,
+)
+
+data class SubTrack(
+    val videoId: String,
+    val title: String,
+    val artistId: String,
+    val isVideo: Boolean,
+    val explicit: Boolean,
+    val durationSec: Int?,
+    val playCount: Long?,
+    val uploadDate: String?,
+)
+
+data class SubAlbum(
+    val id: String,
+    val playlistId: String?,
+    val title: String,
+    val artistId: String,
+    /** "album" | "single" | "ep". */
+    val type: String,
+    val year: Int?,
+    val thumbnail: String?,
+    val uploadDate: String?,
+)
+
+data class SubAlbumTrack(val albumId: String, val videoId: String, val pos: Int)
+
+data class SubArtistPlaylist(val id: String, val title: String, val artistId: String, val thumbnail: String?)
+
+data class SubCommunity(
+    val id: String,
+    val title: String,
+    val author: String?,
+    /** The raw curator image; read endpoints override it with a whitelist-derived member cover. */
+    val thumbnail: String?,
+    val total: Int,
+    val whitelisted: Int,
+    val viewCount: Long?,
+)
+
+data class SubCommunityTrack(
+    val playlistId: String,
+    val videoId: String,
+    val pos: Int,
+    /** Discovery-resolved artist channel id for a member with no corpus track; may be null. */
+    val artistId: String?,
+)
+
+data class SubHomeRank(
+    /** "top-albums" | "top-videos" | "top-artists" | "top-community". */
+    val row: String,
+    /** "album" | "video" | "artist" | "community". */
+    val kind: String,
+    val refId: String,
+    val artistId: String?,
+    val pos: Int,
+    val score: Double?,
+)
+
+data class SubZemerPlaylist(val id: String, val title: String, val pos: Int, val year: Int?)
+
+/** kind = "track" | "album"; refId = videoId or album browseId. */
+data class SubZemerItem(val playlistId: String, val kind: String, val refId: String, val pos: Int)
+
+data class SubBlocked(val global: Set<String>, val female: Set<String>)

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
@@ -1,0 +1,184 @@
+package com.jtech.zemer.offline
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import timber.log.Timber
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+/**
+ * Decodes the gzipped subset shards into a [SubsetCorpus]. Each shard is a bare JSON array (positional
+ * rows) or object — no per-shard wrapper (the version lives only in the manifest). The positional
+ * layouts and packed-flag bits below are pinned to `zemer-search/index/build-subset.mjs`; a change
+ * there must be mirrored here (guarded by [SubsetDecoderTest] against real sample rows).
+ */
+object SubsetDecoder {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Loads the committed snapshot from [store] into a corpus, or null if none / incomplete / corrupt. */
+    fun loadCorpus(store: SubsetStore): SubsetCorpus? {
+        val manifest = store.localManifest() ?: return null
+        return try {
+            val artists = ArrayList<SubArtist>()
+            val tracks = ArrayList<SubTrack>()
+            val albums = ArrayList<SubAlbum>()
+            val albumTracks = ArrayList<SubAlbumTrack>()
+            val playlists = ArrayList<SubArtistPlaylist>()
+            val community = ArrayList<SubCommunity>()
+            val communityTracks = ArrayList<SubCommunityTrack>()
+            val homeRank = ArrayList<SubHomeRank>()
+            val zemerPlaylists = ArrayList<SubZemerPlaylist>()
+            val zemerItems = ArrayList<SubZemerItem>()
+            var blocked = SubBlocked(emptySet(), emptySet())
+
+            for (shard in manifest.shards) {
+                val text = gunzip(store.shardBytes(shard.name) ?: return null)
+                when {
+                    shard.name == "artists" -> artists += decodeArtists(text)
+                    shard.name.startsWith("albumtracks-") -> albumTracks += decodeAlbumTracks(text)
+                    shard.name.startsWith("tracks-") -> tracks += decodeTracks(text)
+                    shard.name.startsWith("albums-") -> albums += decodeAlbums(text)
+                    shard.name == "playlists" -> playlists += decodeArtistPlaylists(text)
+                    shard.name == "community" -> community += decodeCommunity(text)
+                    shard.name == "communitytracks" -> communityTracks += decodeCommunityTracks(text)
+                    shard.name == "homerank" -> homeRank += decodeHomeRank(text)
+                    shard.name == "zemer" -> decodeZemer(text).let { zemerPlaylists += it.first; zemerItems += it.second }
+                    shard.name == "blocked" -> blocked = decodeBlocked(text)
+                    // Unknown shard → ignored for forward compatibility.
+                }
+            }
+            SubsetCorpus(
+                artists, tracks, albums, albumTracks, playlists,
+                community, communityTracks, homeRank, zemerPlaylists, zemerItems, blocked,
+            )
+        } catch (e: Exception) {
+            Timber.w(e, "Subset decode failed")
+            null
+        }
+    }
+
+    // --- per-shard decoders (positions pinned to build-subset.mjs) ---
+
+    fun decodeArtists(text: String): List<SubArtist> = rows(text).map { r ->
+        val flags = r[3].asInt()
+        SubArtist(
+            id = r[0].asString(),
+            name = r[1].asString(),
+            thumbnail = r[2].asStringOrNull(),
+            isFemale = flags and 1 != 0,
+            isChasid = flags and 2 != 0,
+            isKidZone = flags and 4 != 0,
+        )
+    }
+
+    fun decodeTracks(text: String): List<SubTrack> = rows(text).map { r ->
+        val flags = r[3].asInt()
+        SubTrack(
+            videoId = r[0].asString(),
+            title = r[1].asString(),
+            artistId = r[2].asString(),
+            isVideo = flags and 1 != 0,
+            explicit = flags and 2 != 0,
+            durationSec = r[4].asIntOrNull(),
+            playCount = r[5].asLongOrNull(),
+            uploadDate = r[6].asStringOrNull(),
+        )
+    }
+
+    fun decodeAlbums(text: String): List<SubAlbum> = rows(text).map { r ->
+        SubAlbum(
+            id = r[0].asString(),
+            playlistId = r[1].asStringOrNull(),
+            title = r[2].asString(),
+            artistId = r[3].asString(),
+            type = r[4].asString(),
+            year = r[5].asIntOrNull(),
+            thumbnail = r[6].asStringOrNull(),
+            uploadDate = r[7].asStringOrNull(),
+        )
+    }
+
+    fun decodeAlbumTracks(text: String): List<SubAlbumTrack> = rows(text).map { r ->
+        SubAlbumTrack(albumId = r[0].asString(), videoId = r[1].asString(), pos = r[2].asInt())
+    }
+
+    fun decodeArtistPlaylists(text: String): List<SubArtistPlaylist> = rows(text).map { r ->
+        SubArtistPlaylist(id = r[0].asString(), title = r[1].asString(), artistId = r[2].asString(), thumbnail = r[3].asStringOrNull())
+    }
+
+    fun decodeCommunity(text: String): List<SubCommunity> = rows(text).map { r ->
+        SubCommunity(
+            id = r[0].asString(),
+            title = r[1].asString(),
+            author = r[2].asStringOrNull(),
+            thumbnail = r[3].asStringOrNull(),
+            total = r[4].asInt(),
+            whitelisted = r[5].asInt(),
+            viewCount = r[6].asLongOrNull(),
+        )
+    }
+
+    fun decodeCommunityTracks(text: String): List<SubCommunityTrack> = rows(text).map { r ->
+        SubCommunityTrack(playlistId = r[0].asString(), videoId = r[1].asString(), pos = r[2].asInt(), artistId = r[3].asStringOrNull())
+    }
+
+    fun decodeHomeRank(text: String): List<SubHomeRank> = json.parseToJsonElement(text).jsonArray.map { e ->
+        val o = e.jsonObject
+        SubHomeRank(
+            row = o["row"].asString(),
+            kind = o["kind"].asString(),
+            refId = o["refId"].asString(),
+            artistId = o["artistId"].asStringOrNull(),
+            pos = o["pos"].asInt(),
+            score = o["score"].asDoubleOrNull(),
+        )
+    }
+
+    fun decodeZemer(text: String): Pair<List<SubZemerPlaylist>, List<SubZemerItem>> {
+        val o = json.parseToJsonElement(text).jsonObject
+        val playlists = (o["playlists"] as? JsonArray).orEmpty().map { e ->
+            val p = e.jsonObject
+            SubZemerPlaylist(id = p["id"].asString(), title = p["title"].asString(), pos = p["pos"].asInt(), year = p["year"].asIntOrNull())
+        }
+        val items = (o["items"] as? JsonArray).orEmpty().map { e ->
+            val i = e.jsonObject
+            SubZemerItem(playlistId = i["playlistId"].asString(), kind = i["kind"].asString(), refId = i["refId"].asString(), pos = i["pos"].asInt())
+        }
+        return playlists to items
+    }
+
+    fun decodeBlocked(text: String): SubBlocked {
+        val o = json.parseToJsonElement(text).jsonObject
+        fun ids(key: String) = (o[key] as? JsonArray).orEmpty().mapTo(HashSet()) { it.asString() }
+        return SubBlocked(global = ids("global"), female = ids("female"))
+    }
+
+    // --- helpers ---
+
+    private fun rows(text: String): List<JsonArray> = json.parseToJsonElement(text).jsonArray.map { it.jsonArray }
+
+    private fun gunzip(bytes: ByteArray): String =
+        GZIPInputStream(ByteArrayInputStream(bytes)).bufferedReader(Charsets.UTF_8).use { it.readText() }
+
+    private fun JsonArray?.orEmpty(): List<JsonElement> = this ?: emptyList()
+
+    private fun JsonElement?.isNull(): Boolean = this == null || this is JsonNull
+    private fun JsonElement?.asString(): String = this!!.jsonPrimitive.content
+    private fun JsonElement?.asStringOrNull(): String? = if (isNull()) null else this!!.jsonPrimitive.contentOrNull
+    private fun JsonElement?.asInt(): Int = this!!.jsonPrimitive.int
+    private fun JsonElement?.asIntOrNull(): Int? = if (isNull()) null else this!!.jsonPrimitive.intOrNull
+    private fun JsonElement?.asLongOrNull(): Long? = if (isNull()) null else this!!.jsonPrimitive.longOrNull
+    private fun JsonElement?.asDoubleOrNull(): Double? = if (isNull()) null else this!!.jsonPrimitive.doubleOrNull
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
@@ -44,7 +44,15 @@ object SubsetDecoder {
             var blocked = SubBlocked(emptySet(), emptySet())
 
             for (shard in manifest.shards) {
-                val text = gunzip(store.shardBytes(shard.name) ?: return null)
+                val bytes = store.shardBytes(shard.name) ?: return null
+                // Belt-and-suspenders over the staged sync: a shard whose bytes don't match the
+                // committed manifest (an interrupted legacy sync, disk corruption) must read as
+                // "no snapshot", never decode as a silently mixed-version corpus.
+                if (subsetShardHash(bytes) != shard.hash) {
+                    Timber.w("Subset shard %s hash mismatch on read — snapshot unusable", shard.name)
+                    return null
+                }
+                val text = gunzip(bytes)
                 when {
                     shard.name == "artists" -> artists += decodeArtists(text)
                     shard.name.startsWith("albumtracks-") -> albumTracks += decodeAlbumTracks(text)

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetDecoder.kt
@@ -1,5 +1,6 @@
 package com.jtech.zemer.offline
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -71,7 +72,14 @@ object SubsetDecoder {
                 artists, tracks, albums, albumTracks, playlists,
                 community, communityTracks, homeRank, zemerPlaylists, zemerItems, blocked,
             )
-        } catch (e: Exception) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Throwable, not Exception: decoding materializes tens of MB (bytes + gunzipped text +
+            // JSON tree), so OutOfMemoryError is a REAL outcome on a low-RAM device — it must degrade
+            // to "no snapshot" (the caller rethrows the original network error), never crash the app
+            // on the path built to degrade gracefully. The half-built local lists are unreferenced
+            // after this frame, so the memory is immediately reclaimable.
             Timber.w(e, "Subset decode failed")
             null
         }

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
@@ -116,6 +116,21 @@ fun isFemaleInvolved(title: String, artistName: String, primaryIsFemale: Boolean
 }
 
 /**
+ * All female-involved videoIds (primary female OR a credited female) over the whole corpus — the
+ * `collectFemaleVideoIds` half of api.mjs `setFemaleSet` (the curated `blocked.female` union is the
+ * caller's concern). THE single implementation: both the categories build and the read layer's
+ * `_female` cache derive from this scan.
+ */
+fun collectFemaleVideoIds(corpus: SubsetCorpus, matcher: FemaleMatcher): Set<String> {
+    val out = HashSet<String>()
+    for (t in corpus.tracks) {
+        val artist = corpus.artistsById[t.artistId]
+        if (isFemaleInvolved(t.title, artist?.name ?: "", artist?.isFemale ?: false, matcher)) out.add(t.videoId)
+    }
+    return out
+}
+
+/**
  * "Female-owned" community playlist detection (female-owned.mjs `makeFemaleOwned`), reduced for the
  * on-device subset. The server also owns a set of playlist ids belonging to female artists, but that
  * id set is NOT shipped in the on-device subset — so offline it is EMPTY and the predicate reduces to

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
@@ -35,9 +35,12 @@ class FemaleMatcher internal constructor(
     internal fun isEmpty(): Boolean = names.isEmpty() && skels.isEmpty()
 }
 
-// `norm` / `skel` / `hasHeb` — the three helpers at the top of credits.mjs.
+// `norm` / `skel` / `hasHeb` — the three helpers at the top of credits.mjs. The whitespace regex is
+// hoisted: skel() runs per credited name for every track in the full-corpus female scans, so a
+// per-call Regex() compile is hundreds of thousands of Pattern.compile calls of pure overhead.
+private val WHITESPACE = Regex("\\s+")
 private fun norm(s: String?): String = SubsetNormalize.plainTokens(s).joinToString(" ")
-private fun skel(s: String?): String = SubsetNormalize.skeletonKey(s).replace(Regex("\\s+"), "")
+private fun skel(s: String?): String = SubsetNormalize.skeletonKey(s).replace(WHITESPACE, "")
 private val HEB_LETTER = Regex("[֐-׿]") // /[֐-׿]/
 private fun hasHeb(s: String?): Boolean = HEB_LETTER.containsMatchIn(s ?: "")
 

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetFemale.kt
@@ -1,0 +1,129 @@
+package com.jtech.zemer.offline
+
+/**
+ * Female-involvement detection — the offline port of `zemer-search/index/credits.mjs` plus the
+ * author-name half of `zemer-search/index/female-owned.mjs`. Deterministic, pure string ops.
+ *
+ * Two jobs, both reusing the same cross-script matcher built from the whitelist's female artists:
+ *  - [isFemaleInvolved] — a male-primary track still counts as female-involved when the credit is in
+ *    the TITLE (e.g. `"Shiru (feat. Franciska)"`) or in a secondary artist credit. Every credited name
+ *    is validated against the female whitelist, so an unknown name can never over-filter (only a
+ *    positively-known female triggers a drop).
+ *  - [isCommunityFemaleOwned] — a community playlist is female-owned when its curator name matches a
+ *    known female artist.
+ *
+ * Matching reuses [SubsetNormalize] (the same normalizer the rest of offline search uses): exact
+ * whole-token normalized names for same-script, plus a consonant skeleton tagged with the entry's
+ * SCRIPT for CROSS-SCRIPT alignment only (a Hebrew whitelist name vs a romanized credit, or vice
+ * versa — same-script skeletons collide badly, so same-script must hit the exact name). Skeletons
+ * gate at >=3 chars (a 2-char skeleton collides).
+ */
+
+/** Which scripts a female artist with a given skeleton writes her name in. */
+internal class ScriptFlags(var heb: Boolean = false, var lat: Boolean = false)
+
+/**
+ * A compiled matcher over the whitelist's female artists.
+ *  - [names]: exact normalized full names (`plainTokens(name).join(" ")`) — same-script matching, and
+ *    also the key set for [isCommunityFemaleOwned] (JS `femaleNameKey` == this `norm`).
+ *  - [skels]: consonant-skeleton -> the scripts a female with that skeleton uses — cross-script only.
+ */
+class FemaleMatcher internal constructor(
+    internal val names: Set<String>,
+    internal val skels: Map<String, ScriptFlags>,
+) {
+    internal fun isEmpty(): Boolean = names.isEmpty() && skels.isEmpty()
+}
+
+// `norm` / `skel` / `hasHeb` — the three helpers at the top of credits.mjs.
+private fun norm(s: String?): String = SubsetNormalize.plainTokens(s).joinToString(" ")
+private fun skel(s: String?): String = SubsetNormalize.skeletonKey(s).replace(Regex("\\s+"), "")
+private val HEB_LETTER = Regex("[֐-׿]") // /[֐-׿]/
+private fun hasHeb(s: String?): Boolean = HEB_LETTER.containsMatchIn(s ?: "")
+
+/**
+ * Build the matcher from the whitelist's female artists (credits.mjs `buildFemaleMatcher`). Exact
+ * normalized names, plus >=3-char skeletons tagged with the script(s) each female uses.
+ */
+fun buildFemaleMatcher(artists: List<SubArtist>): FemaleMatcher {
+    val names = LinkedHashSet<String>()
+    val skels = LinkedHashMap<String, ScriptFlags>()
+    for (a in artists) {
+        if (!a.isFemale || a.name.isEmpty()) continue
+        val n = norm(a.name)
+        if (n.isNotEmpty()) names.add(n)
+        val sk = skel(a.name)
+        if (sk.length >= 3) {
+            val e = skels.getOrPut(sk) { ScriptFlags() }
+            if (hasHeb(a.name)) e.heb = true else e.lat = true
+        }
+    }
+    return FemaleMatcher(names, skels)
+}
+
+// A candidate credit is female iff its normalized name is a known female (same-script), OR its
+// >=3-char skeleton matches a known female written in the OTHER script (cross-script only).
+private fun matchesFemale(name: String, m: FemaleMatcher): Boolean {
+    val n = norm(name)
+    if (n.isNotEmpty() && m.names.contains(n)) return true
+    val sk = skel(name)
+    if (sk.length < 3) return false
+    val e = m.skels[sk] ?: return false
+    return if (hasHeb(name)) e.lat else e.heb
+}
+
+// Credit separators, incl. Hebrew עם (credits.mjs SPLIT). Ported verbatim; case-insensitive.
+private val SPLIT = Regex(
+    "\\s*(?:,|&|\\+|·|/|\\bx\\b|\\bfeat\\.?\\b|\\bft\\.?\\b|\\bfeaturing\\b|\\bwith\\b|\\band\\b|\\bvs\\.?\\b|×|עם)\\s*",
+    RegexOption.IGNORE_CASE,
+)
+private fun splitNames(s: String): List<String> =
+    SPLIT.split(s).map { it.trim() }.filter { it.isNotEmpty() }
+
+// TITLE credits — ONLY text after an explicit credit marker (never scan the whole title). Inside a
+// parenthetical, "with"/"duet" also count; a non-parenthetical tail needs a STRONG marker.
+private val CREDIT_PAREN = Regex("(?:feat\\.?|ft\\.?|featuring|duet(?:\\s+with)?|with)\\s+(.+)", RegexOption.IGNORE_CASE)
+private val CREDIT_TAIL = Regex("(?:feat\\.?|ft\\.?|featuring)\\s+(.+)", RegexOption.IGNORE_CASE)
+private val PAREN_GROUP = Regex("[(\\[{]([^)\\]}]*)[)\\]}]")
+private val PAREN_STRIP = Regex("[(\\[{][^)\\]}]*[)\\]}]")
+
+private fun titleCredits(title: String): List<String> {
+    val out = ArrayList<String>()
+    for (mr in PAREN_GROUP.findAll(title)) {
+        val inner = mr.groupValues[1]
+        val c = CREDIT_PAREN.find(inner)
+        if (c != null) out += splitNames(c.groupValues[1])
+    }
+    val tail = CREDIT_TAIL.find(PAREN_STRIP.replace(title, " "))
+    if (tail != null) out += splitNames(tail.groupValues[1])
+    return out
+}
+
+// ARTIST-string credits — the primary is covered by its isFemale flag; this catches a female credited
+// as a SECONDARY artist in the artist field.
+private fun artistCredits(artistName: String): List<String> = splitNames(artistName)
+
+/**
+ * Is ANY credited artist female? (credits.mjs `isFemaleInvolved`.) The primary flag short-circuits;
+ * otherwise every title / artist-string credit is validated against the female whitelist.
+ */
+fun isFemaleInvolved(title: String, artistName: String, primaryIsFemale: Boolean, matcher: FemaleMatcher): Boolean {
+    if (primaryIsFemale) return true
+    if (matcher.isEmpty()) return false
+    for (c in titleCredits(title)) if (matchesFemale(c, matcher)) return true
+    for (c in artistCredits(artistName)) if (matchesFemale(c, matcher)) return true
+    return false
+}
+
+/**
+ * "Female-owned" community playlist detection (female-owned.mjs `makeFemaleOwned`), reduced for the
+ * on-device subset. The server also owns a set of playlist ids belonging to female artists, but that
+ * id set is NOT shipped in the on-device subset — so offline it is EMPTY and the predicate reduces to
+ * the author-name check: the curator name normalizes (`femaleNameKey` == this matcher's name key) to a
+ * known female artist. A null/blank author is never female-owned.
+ */
+fun isCommunityFemaleOwned(author: String?, matcher: FemaleMatcher): Boolean {
+    if (author.isNullOrEmpty()) return false
+    // female-owned id set is empty offline (see KDoc): id-membership branch is always false.
+    return matcher.names.contains(norm(author))
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetHash.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetHash.kt
@@ -1,0 +1,23 @@
+package com.jtech.zemer.offline
+
+import java.security.MessageDigest
+
+/**
+ * The content address the manifest uses for a shard: the first 16 hex characters (8 bytes) of
+ * sha256 over the **raw gzipped shard bytes** (as served by `GET /subset/<name>`, before
+ * decompression). A downloaded shard is only accepted when this matches its manifest [SubsetShard.hash],
+ * so a truncated or corrupted download can never be committed.
+ */
+fun subsetShardHash(gzippedBytes: ByteArray): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(gzippedBytes)
+    return buildString(HASH_HEX_LEN) {
+        for (i in 0 until HASH_HEX_LEN / 2) {
+            val b = digest[i].toInt() and 0xff
+            append(HEX[b ushr 4])
+            append(HEX[b and 0x0f])
+        }
+    }
+}
+
+private const val HASH_HEX_LEN = 16
+private val HEX = "0123456789abcdef".toCharArray()

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt
@@ -4,9 +4,9 @@ import java.util.concurrent.TimeUnit
 
 /**
  * The snapshot may serve for at most this long after its last successful sync. The auto-update is
- * daily, so a healthy device is always far inside the window; the cap exists for the device that
- * CAN'T sync (e.g. cellular-only with the WiFi-only default) — without it the snapshot ages
- * unboundedly and keeps serving content the whitelist has since dropped.
+ * daily on any connection, so a healthy device is always far inside the window; the cap exists for
+ * the device with no internet at all for weeks — without it the snapshot ages unboundedly and keeps
+ * serving content the whitelist has since dropped.
  */
 val SUBSET_MAX_SNAPSHOT_AGE_MS: Long = TimeUnit.DAYS.toMillis(14)
 

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt
@@ -1,0 +1,102 @@
+package com.jtech.zemer.offline
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * The snapshot may serve for at most this long after its last successful sync. The auto-update is
+ * daily, so a healthy device is always far inside the window; the cap exists for the device that
+ * CAN'T sync (e.g. cellular-only with the WiFi-only default) — without it the snapshot ages
+ * unboundedly and keeps serving content the whitelist has since dropped.
+ */
+val SUBSET_MAX_SNAPSHOT_AGE_MS: Long = TimeUnit.DAYS.toMillis(14)
+
+/** Pure freshness rule for the offline snapshot (unit-tested); 0/absent [lastSyncedAtMs] = never synced. */
+fun subsetSnapshotIsFresh(lastSyncedAtMs: Long, nowMs: Long): Boolean =
+    lastSyncedAtMs > 0 && nowMs - lastSyncedAtMs <= SUBSET_MAX_SNAPSHOT_AGE_MS
+
+/**
+ * Overlays the app's live, Firestore-synced artist whitelist onto a decoded snapshot. The shard flag
+ * bits are only as fresh as the last sync (up to [SUBSET_MAX_SNAPSHOT_AGE_MS] old); the live
+ * whitelist ([com.jtech.zemer.utils.WhitelistCache]) is minutes-fresh — so at corpus load:
+ *
+ * - an artist absent from [live] (de-whitelisted since the snapshot was built) is DROPPED, along
+ *   with every row that references it: its tracks, albums, album memberships, artist playlists,
+ *   community members resolved to it, home-rank rows and curated-playlist items;
+ * - `isFemale` is overridden by the live flag, so a since-flagged artist is hidden the moment the
+ *   app's whitelist sync lands, not on the next snapshot download.
+ *
+ * An EMPTY [live] map means the whitelist has not synced on this device yet — the overlay is a
+ * no-op (never wipe the snapshot on a fresh install where it may be the only whitelist knowledge).
+ * [live] maps artist channel id → the live `isFemale` flag.
+ */
+fun SubsetCorpus.withLiveWhitelist(live: Map<String, Boolean>): SubsetCorpus {
+    if (live.isEmpty()) return this
+    var changed = false
+    val overlaidArtists = ArrayList<SubArtist>(artists.size)
+    for (a in artists) {
+        val female = live[a.id]
+        if (female == null) {
+            changed = true // de-whitelisted → dropped
+            continue
+        }
+        if (female != a.isFemale) {
+            changed = true
+            overlaidArtists.add(a.copy(isFemale = female))
+        } else {
+            overlaidArtists.add(a)
+        }
+    }
+    if (!changed) return this
+
+    val keptArtists = overlaidArtists.mapTo(HashSet()) { it.id }
+    val keptTracks = tracks.filterTo(ArrayList()) { it.artistId in keptArtists }
+    val keptTrackIds = keptTracks.mapTo(HashSet()) { it.videoId }
+    val droppedTrackIds = tracks.mapTo(HashSet()) { it.videoId }.apply { removeAll(keptTrackIds) }
+    val keptAlbums = albums.filterTo(ArrayList()) { it.artistId in keptArtists }
+    val keptAlbumIds = keptAlbums.mapTo(HashSet()) { it.id }
+    val droppedAlbumIds = albums.mapTo(HashSet()) { it.id }.apply { removeAll(keptAlbumIds) }
+
+    return SubsetCorpus(
+        artists = overlaidArtists,
+        tracks = keptTracks,
+        albums = keptAlbums,
+        albumTracks = albumTracks.filter { it.albumId !in droppedAlbumIds && it.videoId !in droppedTrackIds },
+        artistPlaylists = artistPlaylists.filter { it.artistId in keptArtists },
+        community = community,
+        // A member is dropped when it POSITIVELY references dropped content: a corpus track of a
+        // dropped artist, or a discovery-resolved artist id the live whitelist no longer carries.
+        communityTracks = communityTracks.filter { ct ->
+            ct.videoId !in droppedTrackIds && (ct.artistId == null || ct.artistId in live)
+        },
+        homeRank = homeRank.filter { r ->
+            val refKept = when (r.kind) {
+                "album" -> r.refId !in droppedAlbumIds
+                "video" -> r.refId !in droppedTrackIds
+                "artist" -> r.refId in keptArtists
+                "community" -> true
+                else -> true
+            }
+            refKept && (r.artistId == null || r.artistId in live)
+        },
+        zemerPlaylists = zemerPlaylists,
+        zemerItems = zemerItems.filter {
+            when (it.kind) {
+                "track" -> it.refId !in droppedTrackIds
+                "album" -> it.refId !in droppedAlbumIds
+                else -> true
+            }
+        },
+        blocked = blocked,
+    )
+}
+
+/**
+ * Cheap order-independent fingerprint of the live overlay input, so [OfflineReadProvider] can keep
+ * its decoded-corpus cache while detecting a whitelist sync landing mid-process (membership or a
+ * female flag changing must rebuild the overlaid corpus).
+ */
+fun liveWhitelistFingerprint(live: Map<String, Boolean>): Long {
+    var fp = live.size.toLong()
+    for ((id, female) in live) fp += id.hashCode().toLong() * (if (female) 31L else 7L)
+    return fp
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt
@@ -13,6 +13,15 @@ import kotlinx.serialization.Serializable
  * shard absent from a newer manifest is **deleted** locally — so both content additions and removals
  * propagate without any server-side changelog. See [subsetSyncPlan].
  */
+/**
+ * The manifest/shard wire-format generation this build understands. Mirrors the cipher
+ * `schemaVersion` precedent: shard rows are positional, so a server-side column reorder would
+ * mis-decode silently — a breaking format change must bump the server's `schema` field, and a client
+ * seeing an unknown generation rejects the manifest wholesale and keeps its last-good snapshot.
+ * A manifest without the field (today's server) is generation 1.
+ */
+const val SUPPORTED_SUBSET_SCHEMA = 1
+
 @Serializable
 data class SubsetManifest(
     /** Manifest schema/version counter, bumped on every rebuild. Local == remote ⇒ in sync. */
@@ -20,6 +29,8 @@ data class SubsetManifest(
     /** ISO-8601 build timestamp (informational; the shard hashes are what drive the diff). */
     val builtAt: String,
     val shards: List<SubsetShard>,
+    /** Wire-format generation — see [SUPPORTED_SUBSET_SCHEMA]. Absent = 1. */
+    val schema: Int = SUPPORTED_SUBSET_SCHEMA,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt
@@ -1,0 +1,63 @@
+package com.jtech.zemer.offline
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The on-device outage-fallback snapshot ("subset") lets the app search and browse the whole Zemer
+ * corpus (everything except audio playback) with no InnerTube/YouTube when `search.zemer.io` is
+ * unreachable, and serve those reads locally even while online when the local copy is in sync.
+ *
+ * The `GET /subset/manifest` document is the authoritative set of content-addressed shards making up
+ * the current snapshot. Syncing is incremental and driven purely by this manifest: a shard whose
+ * [SubsetShard.hash] differs from the local copy is re-downloaded **wholesale** (never merged), and a
+ * shard absent from a newer manifest is **deleted** locally — so both content additions and removals
+ * propagate without any server-side changelog. See [subsetSyncPlan].
+ */
+@Serializable
+data class SubsetManifest(
+    /** Manifest schema/version counter, bumped on every rebuild. Local == remote ⇒ in sync. */
+    val v: Int,
+    /** ISO-8601 build timestamp (informational; the shard hashes are what drive the diff). */
+    val builtAt: String,
+    val shards: List<SubsetShard>,
+)
+
+@Serializable
+data class SubsetShard(
+    /** Shard id, also its filename stem; always matches [SHARD_NAME_REGEX]. */
+    val name: String,
+    /** The content address: first 16 hex chars of sha256(raw gzipped shard bytes). See [subsetShardHash]. */
+    val hash: String,
+    /** Gzipped size in bytes (informational, e.g. for a download-size estimate). */
+    val bytes: Long,
+)
+
+/** Shard names are used as filenames, so they are strictly validated to prevent path traversal. */
+val SHARD_NAME_REGEX = Regex("^[a-z0-9-]+$")
+
+fun isValidShardName(name: String): Boolean = SHARD_NAME_REGEX.matches(name)
+
+/**
+ * What a sync must do to bring the local shard set up to [remote]: which shards to (re)download and
+ * which stale local shards to delete.
+ */
+data class SubsetSyncPlan(
+    val toDownload: List<SubsetShard>,
+    val toDelete: List<String>,
+) {
+    val isNoOp: Boolean get() = toDownload.isEmpty() && toDelete.isEmpty()
+}
+
+/**
+ * Pure diff (unit-tested) of the [local] manifest (null when nothing is downloaded yet) against the
+ * [remote] one. A shard is downloaded when it is new or its content hash changed; a local shard that
+ * the remote manifest no longer lists is deleted. Shard identity is [SubsetShard.name]; [SubsetShard.hash]
+ * is the content address that decides staleness.
+ */
+fun subsetSyncPlan(local: SubsetManifest?, remote: SubsetManifest): SubsetSyncPlan {
+    val localByName = local?.shards?.associateBy { it.name }.orEmpty()
+    val remoteNames = remote.shards.mapTo(HashSet()) { it.name }
+    val toDownload = remote.shards.filter { localByName[it.name]?.hash != it.hash }
+    val toDelete = localByName.keys.filter { it !in remoteNames }
+    return SubsetSyncPlan(toDownload, toDelete)
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetNormalize.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetNormalize.kt
@@ -1,0 +1,115 @@
+package com.jtech.zemer.offline
+
+import java.text.Normalizer
+import kotlin.math.abs
+
+/**
+ * Hebrew-aware normalization / transliteration — the cross-script fuzzy layer, ported verbatim from
+ * `zemer-search/index/normalize.mjs` (pure string ops, deterministic, no ICU). Two token forms per
+ * string:
+ *  - **plain** — NFD-strip diacritics/niqqud, lowercase, fold to `[a-z0-9]` + Hebrew block, tokens.
+ *  - **skeleton** — a Hebrew-aware CONSONANT skeleton: romanize the strong consonants, DROP the matres
+ *    lectionis (א ה ו י ע) + latin vowels, fold ambiguous pairs (b/v, k/ch, p/f, s/sh, t/th, tz), so a
+ *    romanized query ("kevakarat", "dudi polak") aligns with the Hebrew title (כבקרת, דודי פולק).
+ *
+ * Must stay byte-for-byte equivalent to the JS (verified in [SubsetNormalizeTest] against real JS output).
+ */
+object SubsetNormalize {
+
+    private val COMBINING = Regex("\\p{Mn}+")
+    // In-word marks (ASCII/curly apostrophes, backtick, acute, double-quote, Hebrew geresh/gershayim) are
+    // REMOVED, not split — so "L'Chaim"/"LChaim"/"lchaim" and "ג'רופי"/"גרופי" tokenize identically.
+    private val JOINMARK = Regex("['’‘`´\"׳״]")
+    private val NON_TOKEN = Regex("[^a-z0-9֐-׿]+")
+
+    // Hebrew strong consonants → folded latin class. Matres lectionis (א ה ו י ע) intentionally absent → dropped.
+    private val HEB = mapOf(
+        'ב' to "b", 'ג' to "g", 'ד' to "d", 'ז' to "z", 'ח' to "k", 'ט' to "t",
+        'כ' to "k", 'ך' to "k", 'ל' to "l", 'מ' to "m", 'ם' to "m", 'נ' to "n", 'ן' to "n",
+        'ס' to "s", 'פ' to "p", 'ף' to "p", 'צ' to "c", 'ץ' to "c", 'ק' to "k", 'ר' to "r",
+        'ש' to "s", 'ת' to "t",
+    )
+
+    private fun romanizeHebrewToSkeleton(s: String): String {
+        val sb = StringBuilder(s.length)
+        for (ch in s) {
+            val mapped = HEB[ch]
+            when {
+                mapped != null -> sb.append(mapped)
+                ch in '֐'..'׿' -> Unit // matres lectionis / other Hebrew → dropped
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+
+    private val R_SH = Regex("sh|ş")
+    private val R_CH = Regex("ch|kh|ḥ|x")
+    private val R_TZ = Regex("tz|ts")
+    private val R_TH = Regex("th")
+    private val R_VOWEL = Regex("[aeiou]")
+    private val R_SEMI = Regex("[wyh']")
+    private val R_NONALNUM = Regex("[^a-z0-9]")
+
+    /** Fold a latin run to the same consonant alphabet as the Hebrew skeleton (order is load-bearing). */
+    private fun latinToSkeleton(s: String): String =
+        s.replace(R_SH, "s").replace(R_CH, "k").replace(R_TZ, "c").replace(R_TH, "t")
+            .replace(R_VOWEL, "").replace(R_SEMI, "")
+            .replace("v", "b").replace("f", "p").replace("q", "k").replace(R_NONALNUM, "")
+
+    fun plainTokens(str: String?): List<String> =
+        Normalizer.normalize(str ?: "", Normalizer.Form.NFD)
+            .replace(COMBINING, "")
+            .lowercase()
+            .replace(JOINMARK, "")
+            .replace(NON_TOKEN, " ")
+            .split(" ")
+            .filter { it.isNotEmpty() }
+
+    /**
+     * Word-ALIGNED skeleton key: one slot per plain token (a token skeletonizing to nothing keeps its
+     * plain form). Used ONLY for exact/begins-with ranking boosts; matching uses [skeletonTokens].
+     */
+    fun skeletonKey(str: String?): String =
+        plainTokens(str).joinToString(" ") { tok -> latinToSkeleton(romanizeHebrewToSkeleton(tok)).ifEmpty { tok } }
+
+    fun skeletonTokens(str: String?): List<String> {
+        val cleaned = Normalizer.normalize(str ?: "", Normalizer.Form.NFD)
+            .replace(COMBINING, "").lowercase().replace(JOINMARK, "")
+        val out = ArrayList<String>()
+        for (word in cleaned.split(NON_TOKEN).filter { it.isNotEmpty() }) {
+            val sk = latinToSkeleton(romanizeHebrewToSkeleton(word))
+            if (sk.length >= 2) out.add(sk)
+        }
+        return out
+    }
+
+    /**
+     * Damerau-Levenshtein (optimal string alignment) with an early cap; adjacent transposition costs 1.
+     * Returns `max + 1` once the best row value exceeds [max] (early exit).
+     */
+    fun damerau(a: String, b: String, max: Int = 2): Int {
+        val al = a.length
+        val bl = b.length
+        if (abs(al - bl) > max) return max + 1
+        if (al == 0) return if (bl <= max) bl else max + 1
+        if (bl == 0) return if (al <= max) al else max + 1
+        val d = Array(al + 1) { IntArray(bl + 1) }
+        for (i in 0..al) d[i][0] = i
+        for (j in 0..bl) d[0][j] = j
+        for (i in 1..al) {
+            var best = max + 1
+            for (j in 1..bl) {
+                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                var v = minOf(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + cost)
+                if (i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1]) {
+                    v = minOf(v, d[i - 2][j - 2] + 1)
+                }
+                d[i][j] = v
+                if (v < best) best = v
+            }
+            if (best > max) return max + 1
+        }
+        return d[al][bl]
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
@@ -10,6 +10,7 @@ import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
 import com.jtech.zemer.search.ZemerHomeRowsResponse
 import com.jtech.zemer.search.ZemerPlaylist
 import com.jtech.zemer.search.ZemerTrack
+import com.jtech.zemer.search.resolveZemerUrl
 import java.util.WeakHashMap
 
 /**
@@ -35,8 +36,9 @@ import java.util.WeakHashMap
  *  - Curated `auto-*` chart-movement badges (`prevRank` / `delta` / `new` / `reentry`) and `anchorDate`
  *    are LIVE-ONLY: the rank-history sidecar is not part of the on-device subset, so they are left
  *    null/absent offline. The 1-based [ZemerTrack.rank] (raw stored order) IS reproduced.
- *  - Curated covers are server-rendered SVGs; the relative `"/zemer-playlists/cover?id=<id>"` URL is
- *    emitted verbatim (resolved against the API host by the app), never rendered here.
+ *  - Curated covers are server-rendered SVGs; the `"/zemer-playlists/cover?id=<id>"` URL is emitted
+ *    pre-resolved against the API host (the client-side resolution the offline path bypasses), never
+ *    rendered here.
  */
 
 // ── shared helpers ───────────────────────────────────────────────────────────────────────────────
@@ -45,8 +47,11 @@ private fun ytThumb(vid: String?): String? =
     if (vid.isNullOrEmpty()) null else "https://i.ytimg.com/vi/$vid/mqdefault.jpg"
 
 // The generated-cover URL the server links from a curated card (api.mjs `zemerCoverUrl`). Curated ids
-// are slugs (alnum + hyphen), so `encodeURIComponent` is a no-op — interpolated verbatim.
-private fun zemerCoverUrl(id: String): String = "/zemer-playlists/cover?id=$id"
+// are slugs (alnum + hyphen), so `encodeURIComponent` is a no-op. Emitted ABSOLUTE (resolveZemerUrl):
+// the server path absolutizes relative covers inside ZemerSearchClient, which the offline path
+// bypasses — a relative URL reaches Coil unloadable, and the absolute form also matches the cache
+// keys of covers Coil already has on disk from online sessions.
+private fun zemerCoverUrl(id: String): String = resolveZemerUrl("/zemer-playlists/cover?id=$id")!!
 
 /**
  * `_female` for the read filters — the female-involved videoId set (primary OR credited female, over the
@@ -60,13 +65,7 @@ private val femaleVideoIdsCache = WeakHashMap<SubsetCorpus, Set<String>>()
 private fun femaleVideoIdsFor(corpus: SubsetCorpus, female: FemaleMatcher): Set<String> =
     synchronized(femaleVideoIdsCache) {
         femaleVideoIdsCache.getOrPut(corpus) {
-            val out = HashSet<String>()
-            for (t in corpus.tracks) {
-                val artist = corpus.artistsById[t.artistId]
-                if (isFemaleInvolved(t.title, artist?.name ?: "", artist?.isFemale ?: false, female)) out.add(t.videoId)
-            }
-            out.addAll(corpus.blocked.female)
-            out
+            HashSet(collectFemaleVideoIds(corpus, female)).apply { addAll(corpus.blocked.female) }
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
@@ -1,0 +1,470 @@
+package com.jtech.zemer.offline
+
+import com.jtech.zemer.search.ZemerAlbum
+import com.jtech.zemer.search.ZemerAlbumHeader
+import com.jtech.zemer.search.ZemerAlbumResponse
+import com.jtech.zemer.search.ZemerArtist
+import com.jtech.zemer.search.ZemerCuratedPlaylist
+import com.jtech.zemer.search.ZemerCuratedPlaylistResponse
+import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
+import com.jtech.zemer.search.ZemerHomeRowsResponse
+import com.jtech.zemer.search.ZemerPlaylist
+import com.jtech.zemer.search.ZemerTrack
+import java.util.WeakHashMap
+
+/**
+ * Offline read endpoints — the on-device port of the `/album`, `/home-rows` and
+ * `/zemer-playlists` handlers in `zemer-search/server/api.mjs` and the read functions they call in
+ * `zemer-search/corpus/store.mjs` (`albumDetail`, `homeRows`, `zemerPlaylistList`,
+ * `zemerPlaylistDetail` / `zemerPlaylistTracks`). Each runs over a [SubsetCorpus] in memory exactly as
+ * the server runs it over SQLite and returns the SAME wire models the app decodes from the live server
+ * ([ZemerAlbumResponse] / [ZemerHomeRowsResponse] /
+ * [ZemerCuratedPlaylistsResponse] / [ZemerCuratedPlaylistResponse]), so an offline response is consumed
+ * by the Phase-4 router identically to a server one.
+ *
+ * All ordering, gating and filtering is pinned to the JS source; the SQL is reproduced with stable
+ * Kotlin sorts (SQLite's `GROUP BY id … ORDER BY <col>` resolves ties by the grouped id, so a `.thenBy
+ * { id }` reproduces it). Fields the current wire models do not carry are necessarily absent offline —
+ * they are absent on the server path too, on this branch, since they travel through the same models:
+ *  - [ZemerTrack] has no `thumbnail` / `album` / `playCount` / `releaseDate` (the artist/album/curated
+ *    handlers emit those; the app's [com.jtech.zemer.search.ZemerTrack] does not model them yet — see
+ *    the extended shape in the never-merged commit 4dc527f5), so per-song album art, play counts and
+ *    dates do not survive the model.
+ *  - [ZemerAlbum] carries no `type` / `trackCount` / `totalDurationSec` / `releaseDate`, and
+ *    [ZemerAlbumHeader] no `playlistId` / `type` / `trackCount` / `totalDurationSec` / `releaseDate`.
+ *  - Curated `auto-*` chart-movement badges (`prevRank` / `delta` / `new` / `reentry`) and `anchorDate`
+ *    are LIVE-ONLY: the rank-history sidecar is not part of the on-device subset, so they are left
+ *    null/absent offline. The 1-based [ZemerTrack.rank] (raw stored order) IS reproduced.
+ *  - Curated covers are server-rendered SVGs; the relative `"/zemer-playlists/cover?id=<id>"` URL is
+ *    emitted verbatim (resolved against the API host by the app), never rendered here.
+ */
+
+// ── shared helpers ───────────────────────────────────────────────────────────────────────────────
+
+private fun ytThumb(vid: String?): String? =
+    if (vid.isNullOrEmpty()) null else "https://i.ytimg.com/vi/$vid/mqdefault.jpg"
+
+// The generated-cover URL the server links from a curated card (api.mjs `zemerCoverUrl`). Curated ids
+// are slugs (alnum + hyphen), so `encodeURIComponent` is a no-op — interpolated verbatim.
+private fun zemerCoverUrl(id: String): String = "/zemer-playlists/cover?id=$id"
+
+/**
+ * `_female` for the read filters — the female-involved videoId set (primary OR credited female, over the
+ * whole corpus) UNION the curated `female` blocked ids, exactly as `api.mjs setFemaleSet` builds it
+ * (`collectFemaleVideoIds` ∪ `blocked.female`). Cached per corpus so the curated-list read (which asks
+ * every playlist for its tracks) rebuilds it once, not per playlist. `WeakHashMap` so a discarded corpus
+ * is collectable, mirroring [SubsetCategories]'s index cache.
+ */
+private val femaleVideoIdsCache = WeakHashMap<SubsetCorpus, Set<String>>()
+
+private fun femaleVideoIdsFor(corpus: SubsetCorpus, female: FemaleMatcher): Set<String> =
+    synchronized(femaleVideoIdsCache) {
+        femaleVideoIdsCache.getOrPut(corpus) {
+            val out = HashSet<String>()
+            for (t in corpus.tracks) {
+                val artist = corpus.artistsById[t.artistId]
+                if (isFemaleInvolved(t.title, artist?.name ?: "", artist?.isFemale ?: false, female)) out.add(t.videoId)
+            }
+            out.addAll(corpus.blocked.female)
+            out
+        }
+    }
+
+// videoId → the resolved release date `COALESCE(track.uploadDate, MAX(album.uploadDate))` (store.mjs
+// `allTracks` / the year-rule read). Only the DYNAMIC year playlists need it, so it is computed lazily
+// and cached per corpus.
+private val releaseDatesCache = WeakHashMap<SubsetCorpus, Map<String, String?>>()
+
+private fun releaseDatesFor(corpus: SubsetCorpus): Map<String, String?> =
+    synchronized(releaseDatesCache) {
+        releaseDatesCache.getOrPut(corpus) {
+            val maxAlbumDate = HashMap<String, String>()
+            for (at in corpus.albumTracks) {
+                val d = corpus.albumsById[at.albumId]?.uploadDate ?: continue
+                val cur = maxAlbumDate[at.videoId]
+                if (cur == null || d > cur) maxAlbumDate[at.videoId] = d // MAX(al.uploadDate)
+            }
+            corpus.tracks.associate { it.videoId to (it.uploadDate ?: maxAlbumDate[it.videoId]) }
+        }
+    }
+
+// videoIds that belong to at least one album — the year-rule `fromAlbum` (onAlbum) flag.
+private val tracksOnAlbumCache = WeakHashMap<SubsetCorpus, Set<String>>()
+
+private fun tracksOnAlbumFor(corpus: SubsetCorpus): Set<String> =
+    synchronized(tracksOnAlbumCache) {
+        tracksOnAlbumCache.getOrPut(corpus) { corpus.albumTracks.mapTo(HashSet()) { it.videoId } }
+    }
+
+// Server-curated id override (api.mjs `idDropped`): `global` ids dropped always, `female` ids only when
+// female is blocked. Matches a result's videoId / id / playlistId / channelId / browseId.
+private fun SubsetCorpus.idDropped(id: String?, allowFemale: Boolean): Boolean =
+    id != null && id.isNotBlank() &&
+        (blocked.global.contains(id) || (!allowFemale && blocked.female.contains(id)))
+
+// ── /album ───────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `GET /album?id=` — [albumDetail] + the api.mjs gate/per-track id-override filter. Null (404) when the
+ * album is unknown, its id is blocked, or its artist fails the female/KidZone gate. Tracks come from the
+ * album members in stored order (`ORDER BY pos`), each per-track female/KidZone/video-filtered, with
+ * `trackNumber = pos + 1`.
+ */
+fun offlineAlbum(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    id: String,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerAlbumResponse? {
+    if (corpus.idDropped(id, allowFemale)) return null
+    val al = corpus.albumsById[id] ?: return null
+    val albumArtist = corpus.artistsById[al.artistId]
+    // Gate the whole album by its artist (same predicate as artistDetail).
+    if ((!allowFemale && (albumArtist?.isFemale == true)) || (kidZone && !(albumArtist?.isKidZone == true))) return null
+
+    val femaleIds = femaleVideoIdsFor(corpus, female)
+    val tracks = corpus.albumTracksByAlbum[id].orEmpty().mapNotNull { at ->
+        val t = corpus.tracksById[at.videoId] ?: return@mapNotNull null
+        val trackArtist = corpus.artistsById[t.artistId]
+        val femInv = femaleIds.contains(t.videoId)
+        val pass = (allowFemale || !femInv) && (!kidZone || (trackArtist?.isKidZone == true)) && (!blockVideos || !t.isVideo)
+        if (!pass || corpus.idDropped(t.videoId, allowFemale)) return@mapNotNull null
+        ZemerTrack(
+            videoId = t.videoId,
+            title = t.title,
+            artist = trackArtist?.name ?: "",
+            explicit = t.explicit,
+            durationSec = t.durationSec,
+            trackNumber = at.pos + 1,
+        )
+    }
+    return ZemerAlbumResponse(
+        album = ZemerAlbumHeader(
+            id = al.id,
+            title = al.title,
+            artist = albumArtist?.name ?: "",
+            year = al.year,
+            thumbnail = al.thumbnail,
+        ),
+        tracks = tracks,
+    )
+}
+
+// ── /home-rows ───────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `GET /home-rows` — store.mjs `homeRows`. topAlbums / topVideos / topArtists hydrate the `home_rank`
+ * shard order (female/KidZone on the card + id-override on the ref AND the artist; famous/american does
+ * NOT apply). topCommunity is computed LIVE (not from `home_rank`): the view-ranked eligible pool, then
+ * female-owned hide + per-member survival + surviving-cover, capped at [HOME_COMMUNITY_N].
+ */
+fun offlineHomeRows(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerHomeRowsResponse {
+    val femaleIds = femaleVideoIdsFor(corpus, female)
+    fun ranked(row: String) = corpus.homeRankByRow[row].orEmpty()
+
+    // top-albums → ZemerAlbum(+artistId). Gate by the album's primary artist; require it still exists;
+    // drop id-blocked ref/artist. (explicit is emitted by the server but not modeled by ZemerAlbum.)
+    val topAlbums = ranked("top-albums").mapNotNull { corpus.albumsById[it.refId] }
+        .filter { al ->
+            val artist = corpus.artistsById[al.artistId]
+            (allowFemale || !(artist?.isFemale == true)) && (!kidZone || (artist?.isKidZone == true)) &&
+                !corpus.idDropped(al.id, allowFemale) && !corpus.idDropped(al.artistId, allowFemale)
+        }
+        .map { ZemerAlbum(id = it.id, playlistId = it.playlistId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, year = it.year, thumbnail = it.thumbnail) }
+
+    // top-videos → ZemerTrack(+artistId). These ARE videos, so blockVideos empties the row. Female =
+    // primary OR credited (the _female set).
+    val topVideos = if (blockVideos) emptyList() else ranked("top-videos")
+        .mapNotNull { corpus.tracksById[it.refId] }
+        .filter { it.isVideo } // vidRow WHERE t.isVideo=1
+        .filter { t ->
+            val artist = corpus.artistsById[t.artistId]
+            val femInv = (artist?.isFemale == true) || femaleIds.contains(t.videoId)
+            (allowFemale || !femInv) && (!kidZone || (artist?.isKidZone == true)) &&
+                !corpus.idDropped(t.videoId, allowFemale) && !corpus.idDropped(t.artistId, allowFemale)
+        }
+        .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec) }
+
+    // top-artists → ZemerArtist. Gate by the artist's own flags + id-override; no _female cross-credit.
+    val topArtists = ranked("top-artists").mapNotNull { corpus.artistsById[it.refId] }
+        .filter { (allowFemale || !it.isFemale) && (!kidZone || it.isKidZone) && !corpus.idDropped(it.id, allowFemale) }
+        .map { ZemerArtist(id = it.id, name = it.name, thumbnail = it.thumbnail) }
+
+    return ZemerHomeRowsResponse(
+        topAlbums = topAlbums,
+        topVideos = topVideos,
+        topArtists = topArtists,
+        topCommunity = topCommunity(corpus, female, allowFemale, blockVideos, kidZone),
+    )
+}
+
+private const val HOME_COMMUNITY_POOL = 80
+private const val HOME_COMMUNITY_N = 32
+private const val HOME_COMMUNITY_MIN_SEC = 40 * 60 // 2400
+private val ENGAGED_LISTS = listOf("auto-top-50", "auto-trending", "auto-favorites")
+
+// store.mjs `homeRows` topCommunity: view-ranked pool (viewCount!=null AND runtime>=MIN_SEC AND — unless
+// no engagement data — a member in an ENGAGED_LISTS track), ordered viewCount desc, whitelisted desc, id
+// asc, LIMIT POOL; then female-owned hide + per-member survival + surviving-cover, take <= N.
+private fun topCommunity(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): List<ZemerPlaylist> {
+    // Engagement signal: the raw track refIds across the ENGAGED_LISTS (kind='track' only).
+    val engaged = HashSet<String>()
+    for (pl in ENGAGED_LISTS) {
+        for (it in corpus.zemerItemsByPlaylist[pl].orEmpty()) if (it.kind == "track") engaged.add(it.refId)
+    }
+    val engagedActive = engaged.isNotEmpty() // fail-safe: no data → runtime-only gate, pure view-count rank
+
+    fun runtimeSec(id: String): Int =
+        corpus.communityTracksByPlaylist[id].orEmpty().sumOf { corpus.tracksById[it.videoId]?.durationSec ?: 0 }
+    fun hasEngaged(id: String): Boolean =
+        corpus.communityTracksByPlaylist[id].orEmpty().any { engaged.contains(it.videoId) }
+
+    val pool = corpus.community.asSequence()
+        .filter { it.viewCount != null && runtimeSec(it.id) >= HOME_COMMUNITY_MIN_SEC && (!engagedActive || hasEngaged(it.id)) }
+        .sortedWith(compareByDescending<SubCommunity> { it.viewCount ?: 0L }.thenByDescending { it.whitelisted }.thenBy { it.id })
+        .take(HOME_COMMUNITY_POOL)
+        .toList()
+
+    val filterActive = !allowFemale || kidZone || blockVideos
+    val out = ArrayList<ZemerPlaylist>()
+    for (c in pool) {
+        if (out.size >= HOME_COMMUNITY_N) break
+        if (corpus.idDropped(c.id, allowFemale)) continue
+        if (!allowFemale && isCommunityFemaleOwned(c.author, female)) continue // gotcha #7 rule 2
+        var songCount = c.whitelisted
+        var cover = ytThumb(corpus.communityTracksByPlaylist[c.id].orEmpty().firstOrNull()?.videoId)
+        if (filterActive) {
+            val kept = communityKept(corpus, femaleVideoIdsFor(corpus, female), c.id, allowFemale, blockVideos, kidZone)
+            if (kept.count <= 0) continue
+            songCount = kept.count
+            cover = kept.cover
+        }
+        out.add(ZemerPlaylist(id = c.id, title = c.title, artist = c.author ?: "", thumbnail = cover, songCount = songCount))
+    }
+    return out
+}
+
+private class KeptCount(val count: Int, val cover: String?)
+
+// api.mjs `communityKeptCounts`: post-filter surviving-member count + first-surviving member's cover,
+// over the corpus membership (the same `keep` predicate /community + /search use).
+private fun communityKept(
+    corpus: SubsetCorpus,
+    femaleIds: Set<String>,
+    id: String,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): KeptCount {
+    var count = 0
+    var coverPos = Int.MAX_VALUE
+    var coverVid: String? = null
+    for (m in corpus.communityTracksByPlaylist[id].orEmpty()) {
+        val t = corpus.tracksById[m.videoId]
+        val a = t?.let { corpus.artistsById[it.artistId] }
+        val am = m.artistId?.let { corpus.artistsById[it] }
+        val keep = if (t == null && m.artistId == null) {
+            true // unknown member → kept (fail-open)
+        } else {
+            val female = (a?.isFemale ?: am?.isFemale ?: false) || femaleIds.contains(m.videoId)
+            val isKidZone = a?.isKidZone ?: am?.isKidZone ?: false
+            val isVideo = t?.isVideo ?: false
+            (allowFemale || !female) && (!kidZone || isKidZone) && (!blockVideos || !isVideo)
+        }
+        if (keep) {
+            count++
+            if (m.pos < coverPos) { coverPos = m.pos; coverVid = m.videoId }
+        }
+    }
+    return KeptCount(count, ytThumb(coverVid))
+}
+
+// ── /zemer-playlists ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `GET /zemer-playlists` (no id) — store.mjs `zemerPlaylistList` + api.mjs. Editorial order (`ORDER BY
+ * pos, id`); a playlist with no member surviving the flags is hidden; the id-override drops a blocked
+ * playlist; the thumbnail is the relative generated-cover URL (never a member's art).
+ */
+fun offlineCuratedPlaylists(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerCuratedPlaylistsResponse {
+    val femaleIds = femaleVideoIdsFor(corpus, female)
+    val playlists = corpus.zemerPlaylists.sortedWith(compareBy<SubZemerPlaylist> { it.pos }.thenBy { it.id })
+        .filter { !corpus.idDropped(it.id, allowFemale) }
+        .mapNotNull { p ->
+            val tracks = zemerPlaylistTracks(corpus, femaleIds, p, allowFemale, blockVideos, kidZone)
+            if (tracks.isEmpty()) null else zemerCard(p.id, p.title, tracks)
+        }
+    return ZemerCuratedPlaylistsResponse(playlists = playlists)
+}
+
+/**
+ * `GET /zemer-playlists?id=` — store.mjs `zemerPlaylistDetail` + api.mjs. Null (404) for an unknown/
+ * blocked id or when every member is filtered out. `{playlist, albums, tracks}`; for `auto-*` ids each
+ * track's [ZemerTrack.rank] is its 1-based position in the RAW stored track order (`applyRanks`). The
+ * chart-movement badges and `anchorDate` are LIVE-ONLY (rank-history sidecar absent from the subset) and
+ * stay null/absent offline.
+ */
+fun offlineCuratedPlaylist(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    id: String,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerCuratedPlaylistResponse? {
+    if (corpus.idDropped(id, allowFemale)) return null
+    val p = corpus.zemerPlaylists.firstOrNull { it.id == id } ?: return null
+    val femaleIds = femaleVideoIdsFor(corpus, female)
+    var tracks = zemerPlaylistTracks(corpus, femaleIds, p, allowFemale, blockVideos, kidZone)
+    if (tracks.isEmpty()) return null
+
+    val albums = curatedAlbums(corpus, p, tracks, allowFemale)
+
+    if (id.startsWith("auto-")) {
+        // rank = 1-based position on the RAW stored chart (a filtered row index is NOT the chart
+        // position). Badges/anchorDate stay absent — LIVE-ONLY.
+        val raw = corpus.zemerItemsByPlaylist[id].orEmpty().filter { it.kind == "track" }.map { it.refId }
+        val rankOf = raw.withIndex().associate { (i, v) -> v to i + 1 }
+        tracks = tracks.map { t -> rankOf[t.videoId]?.let { t.copy(rank = it) } ?: t }
+    }
+
+    return ZemerCuratedPlaylistResponse(
+        playlist = zemerCard(p.id, p.title, tracks),
+        albums = albums,
+        tracks = tracks,
+    )
+}
+
+// store.mjs `zemerCard`: post-filter count/runtime, cover = the relative generated-cover URL (api.mjs
+// overrides the track-art the store computes). totalDurationSec is null unless ≥1 track carries one.
+private fun zemerCard(id: String, title: String, tracks: List<ZemerTrack>): ZemerCuratedPlaylist =
+    ZemerCuratedPlaylist(
+        id = id,
+        title = title,
+        thumbnail = zemerCoverUrl(id),
+        trackCount = tracks.size,
+        totalDurationSec = if (tracks.any { it.durationSec != null }) tracks.sumOf { it.durationSec ?: 0 } else null,
+    )
+
+/**
+ * store.mjs `zemerPlaylistTracks`: the expanded, filtered, curated-ordered tracks of one playlist.
+ *  - DYNAMIC year rule (`year != null`): every track whose resolved release date's year matches, newest
+ *    first (releaseDate desc, videoId asc); `fromAlbum` = the track is on any album.
+ *  - item rule: direct videoIds in file order, then each album expanded in album order; a videoId
+ *    reached twice keeps its FIRST position (`fromAlbum` = the kind that owns that kept position).
+ * Both apply the same female/KidZone/video + id-override filters. Returns the wire [ZemerTrack]s (rank
+ * is added by the caller for `auto-*`).
+ */
+private fun zemerPlaylistTracks(
+    corpus: SubsetCorpus,
+    femaleIds: Set<String>,
+    p: SubZemerPlaylist,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): List<ZemerTrack> {
+    // Ordered (videoId, fromAlbum) candidate pairs, before dedup/filter.
+    val ordered: List<Pair<String, Boolean>> = if (p.year != null) {
+        val dates = releaseDatesFor(corpus)
+        val onAlbum = tracksOnAlbumFor(corpus)
+        val y = p.year.toString()
+        corpus.tracks.asSequence()
+            .filter { (dates[it.videoId] ?: "").take(4) == y }
+            .sortedWith(compareByDescending<SubTrack> { dates[it.videoId] ?: "" }.thenBy { it.videoId })
+            .map { it.videoId to onAlbum.contains(it.videoId) }
+            .toList()
+    } else {
+        val items = corpus.zemerItemsByPlaylist[p.id].orEmpty()
+        // Reproduce the UNION ordered by (ipos, spos): direct tracks (spos = -1) sort before an album
+        // expansion sharing the same item pos; album members keep album order.
+        data class Cand(val ipos: Int, val spos: Int, val videoId: String)
+        val cands = ArrayList<Cand>()
+        for (it in items) {
+            when (it.kind) {
+                "track" -> cands.add(Cand(it.pos, -1, it.refId))
+                "album" -> for (at in corpus.albumTracksByAlbum[it.refId].orEmpty()) cands.add(Cand(it.pos, at.pos, at.videoId))
+            }
+        }
+        cands.sortedWith(compareBy<Cand> { it.ipos }.thenBy { it.spos })
+            .map { it.videoId to (it.spos >= 0) }
+    }
+
+    val seen = HashSet<String>()
+    val out = ArrayList<ZemerTrack>()
+    for ((videoId, fromAlbum) in ordered) {
+        if (!seen.add(videoId)) continue // first position wins
+        val t = corpus.tracksById[videoId] ?: continue // JOIN track — only corpus tracks serve
+        val artist = corpus.artistsById[t.artistId]
+        if (corpus.idDropped(videoId, allowFemale)) continue
+        val femInv = femaleIds.contains(videoId)
+        if ((!allowFemale && femInv) || (kidZone && !(artist?.isKidZone == true)) || (blockVideos && t.isVideo)) continue
+        out.add(
+            ZemerTrack(
+                videoId = t.videoId,
+                title = t.title,
+                artist = artist?.name ?: "",
+                explicit = t.explicit,
+                durationSec = t.durationSec,
+                fromAlbum = fromAlbum,
+            ),
+        )
+    }
+    return out
+}
+
+// store.mjs `zemerPlaylistDetail` album rows: the curated album items (or, for a year rule, the albums
+// released in the year), each describing ONLY its members that actually serve in this playlist (aggregate
+// over the KEPT tracks); an album with zero surviving members is omitted. Album rows keep their real art.
+private fun curatedAlbums(
+    corpus: SubsetCorpus,
+    p: SubZemerPlaylist,
+    tracks: List<ZemerTrack>,
+    allowFemale: Boolean,
+): List<ZemerAlbum> {
+    val kept = tracks.mapTo(HashSet()) { it.videoId }
+
+    // (album, its member videoIds) in the correct order.
+    val albumOrder: List<SubAlbum> = if (p.year != null) {
+        val y = p.year.toString()
+        corpus.albums.asSequence()
+            .filter { (it.uploadDate?.take(4) == y) || (it.uploadDate == null && it.year == p.year) }
+            .sortedWith(compareBy<SubAlbum> { it.uploadDate == null }.thenByDescending { it.uploadDate ?: "" }.thenBy { it.id })
+            .toList()
+    } else {
+        corpus.zemerItemsByPlaylist[p.id].orEmpty().filter { it.kind == "album" }.mapNotNull { corpus.albumsById[it.refId] }
+    }
+
+    return albumOrder.mapNotNull { al ->
+        if (corpus.idDropped(al.id, allowFemale)) return@mapNotNull null
+        val members = corpus.albumTracksByAlbum[al.id].orEmpty().count { kept.contains(it.videoId) }
+        if (members == 0) return@mapNotNull null
+        ZemerAlbum(
+            id = al.id,
+            playlistId = al.playlistId,
+            title = al.title,
+            artist = corpus.artistsById[al.artistId]?.name ?: "",
+            year = al.year,
+            thumbnail = al.thumbnail,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
@@ -4,6 +4,7 @@ import com.jtech.zemer.search.ZemerAlbum
 import com.jtech.zemer.search.ZemerAlbumHeader
 import com.jtech.zemer.search.ZemerAlbumResponse
 import com.jtech.zemer.search.ZemerArtist
+import com.jtech.zemer.search.ZemerArtistResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylist
 import com.jtech.zemer.search.ZemerCuratedPlaylistResponse
 import com.jtech.zemer.search.ZemerCuratedPlaylistsResponse
@@ -32,7 +33,8 @@ import java.util.WeakHashMap
  *    the extended shape in the never-merged commit 4dc527f5), so per-song album art, play counts and
  *    dates do not survive the model.
  *  - [ZemerAlbum] carries no `type` / `trackCount` / `totalDurationSec` / `releaseDate`, and
- *    [ZemerAlbumHeader] no `playlistId` / `type` / `trackCount` / `totalDurationSec` / `releaseDate`.
+ *    [ZemerAlbumHeader] no `type` / `trackCount` / `totalDurationSec` / `releaseDate` (it DOES carry
+ *    `playlistId`, which [offlineAlbum] forwards).
  *  - Curated `auto-*` chart-movement badges (`prevRank` / `delta` / `new` / `reentry`) and `anchorDate`
  *    are LIVE-ONLY: the rank-history sidecar is not part of the on-device subset, so they are left
  *    null/absent offline. The 1-based [ZemerTrack.rank] (raw stored order) IS reproduced.
@@ -43,8 +45,32 @@ import java.util.WeakHashMap
 
 // ── shared helpers ───────────────────────────────────────────────────────────────────────────────
 
-private fun ytThumb(vid: String?): String? =
+/**
+ * The derived video-frame thumbnail for server-parity fields — `mqdefault` because that is what the
+ * LIVE server emits for these very fields (store.mjs `ytThumb`, api.mjs community covers), so the
+ * online and offline paths produce the SAME URL (one Coil cache key, verified by the end-to-end
+ * parity diff). This is deliberately NOT [com.jtech.zemer.search.ZemerResultMapper.thumbnailFor]
+ * (`hqdefault`): that helper covers the client-side derivation for items the server sends NO
+ * thumbnail for — a different contract. THE single Kotlin copy; [BuiltCategories] uses it too.
+ */
+internal fun ytThumb(vid: String?): String? =
     if (vid.isNullOrEmpty()) null else "https://i.ytimg.com/vi/$vid/mqdefault.jpg"
+
+/**
+ * THE per-item content gate every offline surface funnels through — the api.mjs/store.mjs `keep`
+ * predicate: female-involved content hidden only when female is blocked, KidZone keeps only KidZone
+ * artists, blockVideos drops videos. ONE definition (SubsetCategories' `allowed` delegates here
+ * too): a hand-inlined copy per surface is how a new filter dimension gets missed on one site and
+ * silently leaks — invisible online, where the server filters separately.
+ */
+internal fun contentGatePasses(
+    femaleInvolved: Boolean,
+    isKidZone: Boolean,
+    isVideo: Boolean,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): Boolean = (allowFemale || !femaleInvolved) && (!kidZone || isKidZone) && (!blockVideos || !isVideo)
 
 // The generated-cover URL the server links from a curated card (api.mjs `zemerCoverUrl`). Curated ids
 // are slugs (alnum + hyphen), so `encodeURIComponent` is a no-op. Emitted ABSOLUTE (resolveZemerUrl):
@@ -121,14 +147,14 @@ fun offlineAlbum(
     val al = corpus.albumsById[id] ?: return null
     val albumArtist = corpus.artistsById[al.artistId]
     // Gate the whole album by its artist (same predicate as artistDetail).
-    if ((!allowFemale && (albumArtist?.isFemale == true)) || (kidZone && !(albumArtist?.isKidZone == true))) return null
+    if (!contentGatePasses(albumArtist?.isFemale == true, albumArtist?.isKidZone == true, isVideo = false, allowFemale, blockVideos, kidZone)) return null
 
     val femaleIds = femaleVideoIdsFor(corpus, female)
     val tracks = corpus.albumTracksByAlbum[id].orEmpty().mapNotNull { at ->
         val t = corpus.tracksById[at.videoId] ?: return@mapNotNull null
         val trackArtist = corpus.artistsById[t.artistId]
         val femInv = femaleIds.contains(t.videoId)
-        val pass = (allowFemale || !femInv) && (!kidZone || (trackArtist?.isKidZone == true)) && (!blockVideos || !t.isVideo)
+        val pass = contentGatePasses(femInv, trackArtist?.isKidZone == true, t.isVideo, allowFemale, blockVideos, kidZone)
         if (!pass || corpus.idDropped(t.videoId, allowFemale)) return@mapNotNull null
         ZemerTrack(
             videoId = t.videoId,
@@ -142,12 +168,81 @@ fun offlineAlbum(
     return ZemerAlbumResponse(
         album = ZemerAlbumHeader(
             id = al.id,
+            // The album's own OP playlist id: without it toAlbumPage's fallback chain lands on the
+            // MPRE browseId and AlbumViewModel persists that as AlbumEntity.playlistId (dead-press
+            // album radio, wrong share links) on every offline open from a bare album route.
+            playlistId = al.playlistId,
             title = al.title,
             artist = albumArtist?.name ?: "",
             year = al.year,
             thumbnail = al.thumbnail,
         ),
         tracks = tracks,
+    )
+}
+
+// ── /artist ──────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `GET /artist?id=` — store.mjs `artistDetail` + the api.mjs gate/per-list id-override filter. Null
+ * (404) when the artist is unknown, its id is blocked, or it fails the female/KidZone gate. Songs
+ * are the real "Top songs" order (play count desc, NULL play counts last; the stable sort keeps
+ * corpus order for ties — the stored order mirrors the server's harvestedAt tie-break);
+ * albums/singles are year desc with NULL years last, ties by id (the file's SQLite convention);
+ * videos empty under blockVideos. A track FEATURING a female (the `_female` set) is dropped when
+ * female is blocked — the same featuring rule as `/search`. Aggregates the wire models don't carry
+ * (playCount, releaseDate, trackCount, totalDurationSec) are necessarily absent, as on every other
+ * offline builder.
+ */
+fun offlineArtist(
+    corpus: SubsetCorpus,
+    female: FemaleMatcher,
+    id: String,
+    allowFemale: Boolean,
+    blockVideos: Boolean,
+    kidZone: Boolean,
+): ZemerArtistResponse? {
+    if (corpus.idDropped(id, allowFemale)) return null
+    val a = corpus.artistsById[id] ?: return null
+    // Content gate (defense-in-depth, same predicate /search uses): treat a gated artist as not-found.
+    if (!contentGatePasses(a.isFemale, a.isKidZone, isVideo = false, allowFemale, blockVideos, kidZone)) return null
+
+    val femaleIds = femaleVideoIdsFor(corpus, female)
+    val tracks = corpus.tracks.asSequence()
+        .filter { it.artistId == id }
+        .filter { allowFemale || !femaleIds.contains(it.videoId) }
+        .filter { !corpus.idDropped(it.videoId, allowFemale) }
+        .sortedWith(compareBy<SubTrack> { it.playCount == null }.thenByDescending { it.playCount ?: 0L })
+        .toList()
+    fun song(t: SubTrack) = ZemerTrack(
+        videoId = t.videoId,
+        title = t.title,
+        artist = a.name,
+        explicit = t.explicit,
+        durationSec = t.durationSec,
+    )
+
+    val albums = corpus.albums
+        .filter { it.artistId == id && !corpus.idDropped(it.id, allowFemale) }
+        .sortedWith(compareBy<SubAlbum> { it.year == null }.thenByDescending { it.year ?: 0 }.thenBy { it.id })
+    fun album(x: SubAlbum) = ZemerAlbum(
+        id = x.id,
+        playlistId = x.playlistId,
+        title = x.title,
+        artist = a.name,
+        year = x.year,
+        thumbnail = x.thumbnail,
+    )
+
+    return ZemerArtistResponse(
+        artist = ZemerArtist(id = a.id, name = a.name, thumbnail = a.thumbnail),
+        songs = tracks.filter { !it.isVideo }.map(::song),
+        videos = if (blockVideos) emptyList() else tracks.filter { it.isVideo }.map(::song),
+        albums = albums.filter { it.type != "single" }.map(::album),
+        singles = albums.filter { it.type == "single" }.map(::album),
+        playlists = corpus.artistPlaylists
+            .filter { it.artistId == id && !corpus.idDropped(it.id, allowFemale) }
+            .map { ZemerPlaylist(id = it.id, title = it.title, artist = a.name, thumbnail = it.thumbnail, songCount = null) },
     )
 }
 
@@ -174,7 +269,7 @@ fun offlineHomeRows(
     val topAlbums = ranked("top-albums").mapNotNull { corpus.albumsById[it.refId] }
         .filter { al ->
             val artist = corpus.artistsById[al.artistId]
-            (allowFemale || !(artist?.isFemale == true)) && (!kidZone || (artist?.isKidZone == true)) &&
+            contentGatePasses(artist?.isFemale == true, artist?.isKidZone == true, isVideo = false, allowFemale, blockVideos, kidZone) &&
                 !corpus.idDropped(al.id, allowFemale) && !corpus.idDropped(al.artistId, allowFemale)
         }
         .map { ZemerAlbum(id = it.id, playlistId = it.playlistId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, year = it.year, thumbnail = it.thumbnail) }
@@ -187,14 +282,15 @@ fun offlineHomeRows(
         .filter { t ->
             val artist = corpus.artistsById[t.artistId]
             val femInv = (artist?.isFemale == true) || femaleIds.contains(t.videoId)
-            (allowFemale || !femInv) && (!kidZone || (artist?.isKidZone == true)) &&
+            // isVideo = false: the whole row is already emptied under blockVideos above.
+            contentGatePasses(femInv, artist?.isKidZone == true, isVideo = false, allowFemale, blockVideos, kidZone) &&
                 !corpus.idDropped(t.videoId, allowFemale) && !corpus.idDropped(t.artistId, allowFemale)
         }
         .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec) }
 
     // top-artists → ZemerArtist. Gate by the artist's own flags + id-override; no _female cross-credit.
     val topArtists = ranked("top-artists").mapNotNull { corpus.artistsById[it.refId] }
-        .filter { (allowFemale || !it.isFemale) && (!kidZone || it.isKidZone) && !corpus.idDropped(it.id, allowFemale) }
+        .filter { contentGatePasses(it.isFemale, it.isKidZone, isVideo = false, allowFemale, blockVideos, kidZone) && !corpus.idDropped(it.id, allowFemale) }
         .map { ZemerArtist(id = it.id, name = it.name, thumbnail = it.thumbnail) }
 
     return ZemerHomeRowsResponse(
@@ -282,7 +378,7 @@ private fun communityKept(
             val female = (a?.isFemale ?: am?.isFemale ?: false) || femaleIds.contains(m.videoId)
             val isKidZone = a?.isKidZone ?: am?.isKidZone ?: false
             val isVideo = t?.isVideo ?: false
-            (allowFemale || !female) && (!kidZone || isKidZone) && (!blockVideos || !isVideo)
+            contentGatePasses(female, isKidZone, isVideo, allowFemale, blockVideos, kidZone)
         }
         if (keep) {
             count++
@@ -416,7 +512,7 @@ private fun zemerPlaylistTracks(
         val artist = corpus.artistsById[t.artistId]
         if (corpus.idDropped(videoId, allowFemale)) continue
         val femInv = femaleIds.contains(videoId)
-        if ((!allowFemale && femInv) || (kidZone && !(artist?.isKidZone == true)) || (blockVideos && t.isVideo)) continue
+        if (!contentGatePasses(femInv, artist?.isKidZone == true, t.isVideo, allowFemale, blockVideos, kidZone)) continue
         out.add(
             ZemerTrack(
                 videoId = t.videoId,

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSearch.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSearch.kt
@@ -1,0 +1,315 @@
+package com.jtech.zemer.offline
+
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.ln
+import kotlin.math.max
+
+/**
+ * In-memory relevance search — the offline (on-device subset) port of `zemer-search/index/search.mjs`,
+ * ported faithfully so an offline result ranks identically to the live server's. Two inverted indexes
+ * (plain Latin tokens + Hebrew-aware consonant skeletons) with prefix + Damerau typo tolerance, synonym
+ * expansion ([SubsetSynonyms]) and IDF-weighted, field-aware, coverage-gated ranking. Deterministic,
+ * pure data ops.
+ *
+ * The scoring is load-bearing: the exact weight tables ([PLAIN]/[SKEL]/[PLAIN_LAST]/[SKEL_LAST]),
+ * [ARTIST_AFFINITY], [REL_FLOOR], the `need = ceil(origCount/2)` coverage gate, the boost stack and the
+ * sort/precision-floor are pinned byte-for-byte to search.mjs. Do NOT tune them here — change the JS
+ * source and re-port.
+ *
+ * Generic over any [SearchDoc]; the category layer ([SubsetCategories]) supplies typed docs whose
+ * `title`/`artistName`/`sortId` drive matching, ranking and the tie-break exactly as the JS `{title,
+ * artistName, videoId ?? id}` shape does.
+ */
+
+/** A document the index can match/rank. Mirrors the JS doc shape used by buildIndex/search. */
+interface SearchDoc {
+    /** The primary matched field (a track/album title, or an artist's own name). */
+    val title: String
+    /** The secondary matched field; `""` for artists and community playlists (title-only ranking). */
+    val artistName: String
+    /** `videoId ?? id ?? ""` — the stable sort tie-break key (search.mjs sort clause 3). */
+    val sortId: String
+}
+
+/** One ranked result: the matched [doc], its [score] and query-token [coverage]. */
+data class SearchHit<T : SearchDoc>(val doc: T, val score: Double, val coverage: Int)
+
+// --- weight tables (pinned to search.mjs) --------------------------------------------------------
+
+private const val TITLE = 1
+private const val ARTIST = 2
+
+/** A COMPLETED plain word: exact + typo, NO prefix (only the word being typed prefix-matches). */
+private val PLAIN = Weights(exact = 10, prefix = 0, fuzzy = 5)
+// Skeletons cross-script EXACTLY; vowel typos are already absorbed by dropping vowels — so NO skeleton
+// fuzzy (double-lossy). Precision-first.
+private val SKEL = Weights(exact = 8, prefix = 0, fuzzy = 0)
+/** The LAST plain token is the word being typed — a prefix of it IS the intent, weighted near-exact. */
+private val PLAIN_LAST = Weights(exact = 10, prefix = 9, fuzzy = 5)
+private val SKEL_LAST = Weights(exact = 8, prefix = 7, fuzzy = 0)
+
+// Bonus per query word matching the ARTIST name — being BY the searched artist beats being merely
+// mentioned in another track's title. Applied only to multi-word queries (see [searchIndex]).
+private const val ARTIST_AFFINITY = 25
+
+// Precision-first: drop any result scoring below this fraction of the top hit. (search.mjs reads
+// process.env.REL_FLOOR; on device the default is the only value.)
+private const val REL_FLOOR = 0.4
+
+private data class Weights(val exact: Int, val prefix: Int, val fuzzy: Int)
+
+// Boundary-padded bigrams: "abc" -> ^a, ab, bc, c$ (so abc<->axc still share ^a and c$).
+private fun bigrams(s: String): List<String> {
+    if (s.isEmpty()) return emptyList()
+    if (s.length == 1) return listOf("^" + s, s + "$")
+    val g = ArrayList<String>(s.length + 1)
+    g.add("^" + s[0])
+    for (i in 0 until s.length - 1) g.add(s.substring(i, i + 2))
+    g.add(s[s.length - 1] + "$")
+    return g
+}
+
+/** One inverted field (plain OR skeleton): postings, bigram candidate index, sorted vocab, idf. */
+internal class Field {
+    // token -> (doc -> field-bit mask: TITLE|ARTIST)
+    val inv = HashMap<String, HashMap<Int, Int>>()
+    val bg = HashMap<String, HashSet<String>>()
+    var sorted: List<String> = emptyList()
+    val idf = HashMap<String, Double>()
+
+    fun put(tok: String, doc: Int, bit: Int) {
+        val m = inv.getOrPut(tok) { HashMap() }
+        m[doc] = (m[doc] ?: 0) or bit
+    }
+
+    fun finalize(n: Int) {
+        for ((tok, postings) in inv) {
+            idf[tok] = ln(1.0 + n.toDouble() / postings.size) // rare token -> high idf
+            for (g in bigrams(tok)) bg.getOrPut(g) { HashSet() }.add(tok)
+        }
+        sorted = inv.keys.sorted()
+    }
+}
+
+/** A built index over [docs]. Immutable; reused across queries. */
+class SubsetIndex<T : SearchDoc> internal constructor(
+    internal val docs: List<T>,
+    private val plain: Field,
+    private val skel: Field,
+    private val titleP: Array<String>,
+    private val artistP: Array<String>,
+    private val titleS: Array<String>,
+    private val artistS: Array<String>,
+) {
+    internal fun plainField() = plain
+    internal fun skelField() = skel
+    internal fun titleP(i: Int) = titleP[i]
+    internal fun artistP(i: Int) = artistP[i]
+    internal fun titleS(i: Int) = titleS[i]
+    internal fun artistS(i: Int) = artistS[i]
+}
+
+private fun <T> uniq(a: List<T>): List<T> = a.distinct()
+
+/** buildIndex(tracks) — one plain + one skeleton inverted index plus the stored field keys. */
+fun <T : SearchDoc> buildSubsetIndex(docs: List<T>): SubsetIndex<T> {
+    val n = if (docs.isEmpty()) 1 else docs.size
+    val plain = Field()
+    val skel = Field()
+    val titleP = Array(docs.size) { "" }
+    val artistP = Array(docs.size) { "" }
+    val titleS = Array(docs.size) { "" }
+    val artistS = Array(docs.size) { "" }
+    docs.forEachIndexed { i, t ->
+        val tp = uniq(SubsetNormalize.plainTokens(t.title))
+        val ap = uniq(SubsetNormalize.plainTokens(t.artistName))
+        val ts = uniq(SubsetNormalize.skeletonTokens(t.title))
+        val ask = uniq(SubsetNormalize.skeletonTokens(t.artistName))
+        for (tok in tp) plain.put(tok, i, TITLE)
+        for (tok in ap) plain.put(tok, i, ARTIST)
+        for (tok in ts) skel.put(tok, i, TITLE)
+        for (tok in ask) skel.put(tok, i, ARTIST)
+        titleP[i] = tp.joinToString(" ")
+        artistP[i] = ap.joinToString(" ")
+        titleS[i] = SubsetNormalize.skeletonKey(t.title)
+        artistS[i] = SubsetNormalize.skeletonKey(t.artistName)
+    }
+    plain.finalize(n)
+    skel.finalize(n)
+    return SubsetIndex(docs, plain, skel, titleP, artistP, titleS, artistS)
+}
+
+// prefixMatches: binary-search lower bound over sorted vocab, then all entries that startWith qt (!= qt).
+private fun prefixMatches(sorted: List<String>, qt: String): List<String> {
+    var lo = 0
+    var hi = sorted.size
+    while (lo < hi) {
+        val m = (lo + hi) ushr 1
+        if (sorted[m] < qt) lo = m + 1 else hi = m
+    }
+    val out = ArrayList<String>()
+    var i = lo
+    while (i < sorted.size && sorted[i].startsWith(qt)) {
+        if (sorted[i] != qt) out.add(sorted[i])
+        i++
+    }
+    return out
+}
+
+private fun bigramCandidates(field: Field, qt: String): Set<String> {
+    val cand = HashSet<String>()
+    for (g in bigrams(qt)) field.bg[g]?.let { cand.addAll(it) }
+    cand.remove(qt)
+    return cand
+}
+
+private class Match(var w: Double, var mask: Int)
+
+// One query token -> Map<doc, {w, mask}>. w = base(matchType) x idf(matchedToken); mask = where it hit
+// (0 for fuzzy — a fuzzy hit can't grant artist-affinity/field boosts it didn't earn).
+private fun matchToken(field: Field, qt: String, cap: Int, weights: Weights, minPrefix: Int): Map<Int, Match> {
+    val out = HashMap<Int, Match>()
+    fun consider(v: String, base: Int, strong: Boolean) {
+        val postings = field.inv[v] ?: return
+        val idf = field.idf[v] ?: 1.0
+        val w = base * idf
+        for ((doc, mask) in postings) {
+            val eff = if (strong) mask else 0
+            val cur = out[doc]
+            if (cur == null) {
+                out[doc] = Match(w, eff)
+            } else {
+                cur.mask = cur.mask or eff
+                if (w > cur.w) cur.w = w
+            }
+        }
+    }
+    if (field.inv.containsKey(qt)) consider(qt, weights.exact, true)
+    if (weights.prefix != 0 && qt.length >= minPrefix) for (v in prefixMatches(field.sorted, qt)) consider(v, weights.prefix, true)
+    // Fuzzy only when this field uses it (plain only) and both tokens >=3.
+    if (weights.fuzzy != 0 && qt.length >= 3) for (v in bigramCandidates(field, qt)) {
+        if (v.length >= 3 && abs(v.length - qt.length) <= cap && SubsetNormalize.damerau(v, qt, cap) <= cap) {
+            consider(v, weights.fuzzy, false)
+        }
+    }
+    return out
+}
+
+private class Acc {
+    var score = 0.0
+    var mP = 0
+    var mS = 0
+    var aP = 0
+    var aS = 0
+}
+
+private fun startsWith(key: String, prefix: String): Boolean = prefix.isNotEmpty() && key.startsWith(prefix)
+
+// The sort tie-break mirrors JS `String.localeCompare` (Node's default en/ICU root collation, verified
+// against the live server): over the YouTube id alphabet [A-Za-z0-9_-] that ordering is punctuation
+// (`-` then `_`), then digits, then letters COMPARED CASE-INSENSITIVELY with lowercase sorting before
+// uppercase as the tie-break — NOT UTF-16 code-unit order (which would put every uppercase letter before
+// every lowercase one). Reproduced explicitly here so it is identical on the JVM (tests) and on Android's
+// ICU-backed Collator (which handle punctuation weighting differently), and never platform-dependent.
+// Only fires on an exact (score, title-length) tie.
+private fun idCharWeight(c: Char): Int = when {
+    c == '-' -> 0
+    c == '_' -> 1
+    c in '0'..'9' -> 2 + (c - '0') // 2..11
+    c in 'a'..'z' -> 20 + (c - 'a') * 2 // lowercase: even
+    c in 'A'..'Z' -> 20 + (c - 'A') * 2 + 1 // uppercase: after its lowercase
+    else -> 1000 + c.code // any other char sorts last, by code point (ids never contain these)
+}
+
+private fun localeCompareIds(a: String, b: String): Int {
+    val n = minOf(a.length, b.length)
+    for (i in 0 until n) {
+        val d = idCharWeight(a[i]) - idCharWeight(b[i])
+        if (d != 0) return d
+    }
+    return a.length - b.length
+}
+
+/**
+ * search(index, query, k) — ranked docs for [query]. Faithful port of search.mjs: synonym expansion,
+ * per-token plain+skeleton matching, IDF-weighted scoring, coverage gate, the boost stack and the
+ * precision floor. Returns at most [k] hits.
+ */
+fun <T : SearchDoc> searchIndex(index: SubsetIndex<T>, query: String, k: Int = 10): List<SearchHit<T>> {
+    val qp0 = uniq(SubsetNormalize.plainTokens(query))
+    val qs0 = uniq(SubsetNormalize.skeletonTokens(query))
+    if (qp0.isEmpty() && qs0.isEmpty()) return emptyList()
+    val expanded = SubsetSynonyms.expand(qp0, qs0)
+    val qp = expanded.plain
+    val qs = expanded.skel
+    val qpKey = qp0.joinToString(" ")
+    // Word-aligned skeleton key for the exact/begins boosts, used only when >=3 chars.
+    val skKeyRaw = SubsetNormalize.skeletonKey(query)
+    val skKey = if (skKeyRaw.length >= 3) skKeyRaw else ""
+    val origCount = max(qp0.size, qs0.size)
+    val need = max(1, ceil(origCount / 2.0).toInt())
+
+    val acc = HashMap<Int, Acc>()
+    fun get(doc: Int): Acc = acc.getOrPut(doc) { Acc() }
+    // A trailing space => last word finished => no prefix anywhere. No trailing space => last token is the prefix.
+    val typing = !(query.isNotEmpty() && query.last().isWhitespace())
+    val lastP = if (typing) qp0.size - 1 else -1
+    val lastS = if (typing) qs0.size - 1 else -1
+
+    qp.forEachIndexed { i, qt ->
+        val bit = if (i < 31) 1 shl i else 0
+        val last = i == lastP
+        for ((doc, m) in matchToken(index.plainField(), qt, 1, if (last) PLAIN_LAST else PLAIN, if (last) 2 else 3)) {
+            val a = get(doc)
+            a.score += m.w
+            a.mP = a.mP or bit
+            if (m.mask and ARTIST != 0) a.aP = a.aP or bit
+        }
+    }
+    // A 2-char consonant skeleton is far too ambiguous — skip skeleton matching below 3 chars.
+    qs.forEachIndexed { i, qt ->
+        if (qt.length < 3) return@forEachIndexed
+        val bit = if (i < 31) 1 shl i else 0
+        val last = i == lastS
+        val cap = if (qt.length <= 4) 1 else 2
+        for ((doc, m) in matchToken(index.skelField(), qt, cap, if (last) SKEL_LAST else SKEL, 2)) {
+            val a = get(doc)
+            a.score += m.w
+            a.mS = a.mS or bit
+            if (m.mask and ARTIST != 0) a.aS = a.aS or bit
+        }
+    }
+
+    val out = ArrayList<SearchHit<T>>(acc.size)
+    for ((doc, a) in acc) {
+        val cov = max(Integer.bitCount(a.mP), Integer.bitCount(a.mS))
+        if (cov < need) continue
+        val artistCov = max(Integer.bitCount(a.aP), Integer.bitCount(a.aS))
+        var boost = 1.0 + (if (cov >= origCount) 0.4 else 0.0) // matched the whole query
+        // Rank by MATCH POSITION: exact > begins-with > contains (begins-with checked before contains).
+        if (index.artistP(doc) == qpKey || (skKey.isNotEmpty() && index.artistS(doc) == skKey)) boost += 2.5 // exact artist
+        else if (startsWith(index.artistP(doc), qpKey) || startsWith(index.artistS(doc), skKey)) boost += 1.6 // artist BEGINS WITH
+        else if (artistCov >= origCount) boost += 0.8 // artist CONTAINS query
+        if (index.titleP(doc) == qpKey || (skKey.isNotEmpty() && index.titleS(doc) == skKey)) boost += 2.0 // exact title
+        else if (startsWith(index.titleP(doc), qpKey) || startsWith(index.titleS(doc), skKey)) boost += 1.4 // title BEGINS WITH
+        // cov*8: matching MORE query words wins. artistCov*AFFINITY applies only to MULTI-word queries.
+        val score = (a.score + cov * 8 + (if (origCount >= 2) artistCov * ARTIST_AFFINITY else 0)) * boost
+        out.add(SearchHit(index.docs[doc], score, cov))
+    }
+    out.sortWith(Comparator { x, y ->
+        val s = y.score.compareTo(x.score)
+        if (s != 0) return@Comparator s
+        val tl = x.doc.title.length - y.doc.title.length
+        if (tl != 0) return@Comparator tl
+        localeCompareIds(x.doc.sortId, y.doc.sortId)
+    })
+    if (out.isEmpty()) return out
+    val floor = out[0].score * REL_FLOOR
+    val kept = ArrayList<SearchHit<T>>()
+    for (r in out) {
+        if (r.score < floor || kept.size >= k) break
+        kept.add(r)
+    }
+    return kept
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt
@@ -45,6 +45,32 @@ class SubsetStore(private val root: File) {
         }
     }
 
+    /**
+     * Stages one downloaded shard WITHOUT touching the live copy. A sync stages every changed shard
+     * first and [promoteStagedShard]s them only once ALL downloads verified — overwriting live shards
+     * one at a time meant a failure partway left a silently mixed-version corpus under the committed
+     * (old) manifest.
+     */
+    fun stageShard(name: String, gzippedBytes: ByteArray) {
+        root.mkdirs()
+        File(root, "${shardFile(name).name}$STAGED_EXT").writeBytes(gzippedBytes)
+    }
+
+    /** Promotes a previously-[stageShard]d shard over the live copy (rename — fast, no re-verify). */
+    fun promoteStagedShard(name: String) {
+        val target = shardFile(name)
+        val staged = File(root, "${target.name}$STAGED_EXT")
+        if (!staged.renameTo(target)) {
+            target.delete()
+            check(staged.renameTo(target)) { "failed to promote staged shard $name" }
+        }
+    }
+
+    /** Deletes any leftover staged files (an interrupted previous sync). */
+    fun clearStaged() {
+        root.listFiles { f -> f.isFile && f.name.endsWith(STAGED_EXT) }?.forEach { it.delete() }
+    }
+
     fun deleteShard(name: String) {
         shardFile(name).delete()
     }
@@ -84,5 +110,6 @@ class SubsetStore(private val root: File) {
         private const val MANIFEST_FILE = "manifest.json"
         private const val SHARD_EXT = ".gz"
         private const val TMP_EXT = ".tmp"
+        private const val STAGED_EXT = ".staged"
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt
@@ -1,0 +1,88 @@
+package com.jtech.zemer.offline
+
+import android.content.Context
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * On-disk store for the subset snapshot under `filesDir/subset/`: the gzipped shard files
+ * (`<name>.gz`) plus the last successfully-committed `manifest.json`. The committed manifest is the
+ * record of what is actually present, so it is written only AFTER every shard it lists is on disk and
+ * verified — an interrupted sync leaves the previous manifest (and its shards) intact, never a
+ * half-updated snapshot.
+ */
+class SubsetStore(private val root: File) {
+
+    constructor(context: Context) : this(File(context.filesDir, DIR_NAME))
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val manifestFile: File get() = File(root, MANIFEST_FILE)
+
+    fun shardFile(name: String): File {
+        require(isValidShardName(name)) { "invalid shard name: $name" }
+        return File(root, "$name$SHARD_EXT")
+    }
+
+    /** The last committed local manifest, or null if nothing is stored / it is unreadable. */
+    fun localManifest(): SubsetManifest? = runCatching {
+        manifestFile.takeIf { it.isFile }?.readText()?.let { json.decodeFromString<SubsetManifest>(it) }
+    }.getOrNull()
+
+    fun shardBytes(name: String): ByteArray? = shardFile(name).takeIf { it.isFile }?.readBytes()
+
+    /** Writes one shard atomically (temp + rename) so a partial write is never observed as complete. */
+    fun writeShard(name: String, gzippedBytes: ByteArray) {
+        root.mkdirs()
+        val target = shardFile(name)
+        val tmp = File(root, "$name$SHARD_EXT$TMP_EXT")
+        tmp.writeBytes(gzippedBytes)
+        if (!tmp.renameTo(target)) {
+            target.delete()
+            check(tmp.renameTo(target)) { "failed to commit shard $name" }
+        }
+    }
+
+    fun deleteShard(name: String) {
+        shardFile(name).delete()
+    }
+
+    /**
+     * Commits [manifest] as the new local record, atomically. Callers MUST have written and verified
+     * every shard it lists first — this write is the point at which the new snapshot becomes live.
+     */
+    fun commitManifest(manifest: SubsetManifest) {
+        root.mkdirs()
+        val tmp = File(root, "$MANIFEST_FILE$TMP_EXT")
+        tmp.writeText(json.encodeToString(manifest))
+        if (!tmp.renameTo(manifestFile)) {
+            manifestFile.delete()
+            check(tmp.renameTo(manifestFile)) { "failed to commit manifest" }
+        }
+    }
+
+    /** Deletes any `*.gz` shard file whose name is not in [keep] (belt-and-suspenders over the diff). */
+    fun pruneOrphans(keep: Set<String>) {
+        root.listFiles { f -> f.isFile && f.name.endsWith(SHARD_EXT) }?.forEach { f ->
+            if (f.name.removeSuffix(SHARD_EXT) !in keep) f.delete()
+        }
+    }
+
+    /** Total gzipped bytes currently on disk (for a "downloaded size" readout). */
+    fun sizeOnDisk(): Long =
+        root.listFiles { f -> f.isFile && f.name.endsWith(SHARD_EXT) }?.sumOf { it.length() } ?: 0L
+
+    /** Wipes the whole store (used when the user turns offline search off). */
+    fun clear() {
+        root.deleteRecursively()
+    }
+
+    companion object {
+        const val DIR_NAME = "subset"
+        private const val MANIFEST_FILE = "manifest.json"
+        private const val SHARD_EXT = ".gz"
+        private const val TMP_EXT = ".tmp"
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt
@@ -53,7 +53,8 @@ class SubsetSyncClient @Inject constructor() {
     }
 
     companion object {
-        const val BASE_URL = "https://search.zemer.io"
+        /** Same host as the search client — one definition, so the two can never drift. */
+        val BASE_URL = com.jtech.zemer.search.ZemerSearchClient.BASE_URL
         private const val CONNECT_TIMEOUT_MS = 10_000L
         private const val SHARD_TIMEOUT_MS = 60_000L
     }

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt
@@ -1,0 +1,60 @@
+package com.jtech.zemer.offline
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.readRawBytes
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches the subset manifest and shards from the Zemer search server. Deliberately separate from
+ * [com.jtech.zemer.search.ZemerSearchClient] so a large shard download never contends with the
+ * latency-sensitive search client (longer timeouts here, and no JSON body handling for shards).
+ *
+ * No `ContentEncoding` plugin is installed, so [downloadShard] returns the shard's raw
+ * `application/gzip` payload untouched — which is exactly what [subsetShardHash] is computed over.
+ */
+@Singleton
+class SubsetSyncClient @Inject constructor() {
+
+    private val client = HttpClient(CIO) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = SHARD_TIMEOUT_MS
+            connectTimeoutMillis = CONNECT_TIMEOUT_MS
+        }
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** The current server manifest. Throws [IOException] on a non-2xx response or transport failure. */
+    suspend fun fetchManifest(): SubsetManifest {
+        val response: HttpResponse = client.get("$BASE_URL/subset/manifest")
+        if (!response.status.isSuccess()) {
+            throw IOException("subset manifest returned HTTP ${response.status.value}")
+        }
+        return json.decodeFromString(SubsetManifest.serializer(), response.bodyAsText())
+    }
+
+    /** Raw gzipped bytes of one shard. Throws [IOException] on a non-2xx response or transport failure. */
+    suspend fun downloadShard(name: String): ByteArray {
+        require(isValidShardName(name)) { "invalid shard name: $name" }
+        val response: HttpResponse = client.get("$BASE_URL/subset/$name")
+        if (!response.status.isSuccess()) {
+            throw IOException("subset shard $name returned HTTP ${response.status.value}")
+        }
+        return response.readRawBytes()
+    }
+
+    companion object {
+        const val BASE_URL = "https://search.zemer.io"
+        private const val CONNECT_TIMEOUT_MS = 10_000L
+        private const val SHARD_TIMEOUT_MS = 60_000L
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSynonyms.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetSynonyms.kt
@@ -1,0 +1,59 @@
+package com.jtech.zemer.offline
+
+/**
+ * Synonym expansion — the offline port of `zemer-search/index/synonyms.mjs` (`compileSynonyms` +
+ * `expandQuery`). For equivalences the consonant skeleton can't infer (abbreviations, acronyms,
+ * nicknames — e.g. "MBD" <-> "Mordechai Ben David"): each group is a list of equivalent surface forms;
+ * at compile time we precompute the union of plain + skeleton tokens across the group, and at query
+ * time a query that hits ANY token of a group is expanded with ALL of the group's tokens.
+ *
+ * The server loads the groups from `zemer-search/data/synonyms.json`. That file is tiny and rarely
+ * changes, so the on-device subset EMBEDS its current contents as [GROUPS] rather than shipping a data
+ * file — keep it byte-equivalent to `data/synonyms.json` when that file changes.
+ */
+
+/** Result of [SubsetSynonyms.expand] — original tokens first, synonym tokens appended (JS Set order). */
+data class ExpandedQuery(val plain: List<String>, val skel: List<String>)
+
+object SubsetSynonyms {
+
+    // Verbatim mirror of zemer-search/data/synonyms.json (as of the port). Keep in sync with that file.
+    private val GROUPS: List<List<String>> = listOf(
+        listOf("mbd", "mordechai ben david"),
+        listOf("lipa", "lipa schmeltzer"),
+        listOf("8th day", "eighth day"),
+    )
+
+    /** A compiled group: the de-duplicated union of plain + skeleton tokens across its surface forms. */
+    private class Group(val plain: List<String>, val skel: List<String>)
+
+    // compileSynonyms: keep groups with >=2 forms; union each form's plain + skeleton tokens (Set order).
+    private val compiled: List<Group> = GROUPS
+        .filter { it.size >= 2 }
+        .map { forms ->
+            val plain = LinkedHashSet<String>()
+            val skel = LinkedHashSet<String>()
+            for (f in forms) {
+                SubsetNormalize.plainTokens(f).forEach { plain.add(it) }
+                SubsetNormalize.skeletonTokens(f).forEach { skel.add(it) }
+            }
+            Group(plain.toList(), skel.toList())
+        }
+
+    /**
+     * Expand the original query token sets with any synonym group the query overlaps (by plain OR
+     * skeleton token). Original tokens are preserved in order; each matched group's tokens are appended
+     * after — matching JS `Set` insertion order (`new Set(qPlain)` then group forEach).
+     */
+    fun expand(plain: List<String>, skel: List<String>): ExpandedQuery {
+        val outPlain = LinkedHashSet(plain)
+        val outSkel = LinkedHashSet(skel)
+        for (g in compiled) {
+            if (g.plain.any { outPlain.contains(it) } || g.skel.any { outSkel.contains(it) }) {
+                g.plain.forEach { outPlain.add(it) }
+                g.skel.forEach { outSkel.add(it) }
+            }
+        }
+        return ExpandedQuery(outPlain.toList(), outSkel.toList())
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -184,13 +184,16 @@ class ZemerSearchRepository @Inject constructor(
     /**
      * Open an artist through the server's `/artist` endpoint (whitelist-scoped + content-filtered),
      * mapped to the [AlbumPage]-sibling [ArtistPage] the artist screen already consumes. Null = 404
-     * (the artist is filtered out entirely, or is absent from the corpus) — the caller falls back to the
-     * InnerTube artist path. Not cached: a single user-initiated open, same freshness contract as
-     * [album]/[playlist].
+     * (the artist is filtered out entirely, or is absent from the corpus) — the screen shows its
+     * not-available state. Offline-covered: search/home-rows render tappable artist cards from the
+     * snapshot, so an artist open must not be the one dead surface in the outage mode. Not cached: a
+     * single user-initiated open, same freshness contract as [album]/[playlist].
      */
     suspend fun artist(id: String, options: ZemerSearchOptions): ArtistPage? =
-        client.artist(id, options.allowFemale, options.blockVideos)
-            ?.toArtistPage(options.hideExplicit, formatSongCount)
+        serverOrOffline(
+            server = { client.artist(id, options.allowFemale, options.blockVideos) },
+            offline = { offlineReads.artist(id, options.allowFemale, options.blockVideos) },
+        )?.toArtistPage(options.hideExplicit, formatSongCount)
 
     /**
      * Corpus-native radio (see [ZemerRadioResponse]): the first page seeded by [kind]/[seed] (`artist` /

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -19,6 +19,8 @@ import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
+import java.nio.channels.UnresolvedAddressException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -59,16 +61,30 @@ data class ZemerCuratedPlaylistPage(
 )
 
 /**
- * Server-first with offline fallback: run [server]; if it fails because the service is unreachable (an
- * [IOException] from [ZemerSearchClient]), serve [offline] from the on-device snapshot when one is
- * present, else rethrow so the ViewModel keeps its normal error/retry behavior. A non-network null (a
- * 404 the client returns as null) is returned as-is and never triggers the fallback. Top-level +
- * `internal` so the routing policy is unit-tested without an Android runtime or mocking.
+ * Whether [this] is the server being unreachable, as opposed to a code bug. Timeouts and non-2xx
+ * responses surface as [IOException] (the client wraps them), but Ktor CIO signals missing
+ * connectivity / dead DNS — the offline feature's flagship scenario — as
+ * [UnresolvedAddressException], which is an [IllegalArgumentException], NOT an [IOException]
+ * (same hazard `LyricsHelper` documents). Both must trigger the fallback.
+ */
+internal fun Throwable.isZemerServerUnreachable(): Boolean =
+    this is IOException || this is UnresolvedAddressException
+
+/**
+ * Server-first with offline fallback: run [server]; if it fails because the service is unreachable
+ * ([isZemerServerUnreachable]), serve [offline] from the on-device snapshot when one is present, else
+ * rethrow so the ViewModel keeps its normal error/retry behavior. A non-network null (a 404 the
+ * client returns as null) is returned as-is and never triggers the fallback; a non-network exception
+ * is never masked. Top-level + `internal` so the routing policy is unit-tested without an Android
+ * runtime or mocking.
  */
 internal suspend fun <T> serverOrOffline(server: suspend () -> T, offline: suspend () -> T?): T =
     try {
         server()
-    } catch (e: IOException) {
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        if (!e.isZemerServerUnreachable()) throw e
         offline() ?: throw e
     }
 
@@ -255,12 +271,17 @@ class ZemerSearchRepository @Inject constructor(
         val trimmed = query.trim()
         val key = "$k|${options.allowFemale}|${options.blockVideos}|$trimmed"
         cacheMutex.withLock { cache[key] }?.let { return it }
-        val response = serverOrOffline(
-            server = { client.search(trimmed, options.allowFemale, options.blockVideos, k) },
+        // Only a SERVER response is memoized. Caching an offline-fallback response would keep serving
+        // the reduced snapshot result for the rest of the process after the server recovers: the
+        // access-ordered LRU refreshes the entry on every hit so it never ages out, and invalidate()
+        // only runs from the error-state Retry path — which a "successfully" cached result never shows.
+        return serverOrOffline(
+            server = {
+                client.search(trimmed, options.allowFemale, options.blockVideos, k)
+                    .also { response -> cacheMutex.withLock { cache[key] = response } }
+            },
             offline = { offlineReads.search(trimmed, k, options.allowFemale, options.blockVideos) },
         )
-        cacheMutex.withLock { cache[key] = response }
-        return response
     }
 
     companion object {

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -2,6 +2,7 @@ package com.jtech.zemer.search
 
 import android.content.Context
 import com.jtech.zemer.R
+import com.jtech.zemer.offline.OfflineReadProvider
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumItems
 import com.jtech.zemer.search.ZemerResultMapper.toAlbumPage
 import com.jtech.zemer.search.ZemerResultMapper.toArtistPage
@@ -17,6 +18,7 @@ import com.metrolist.innertube.pages.ArtistPage
 import com.metrolist.innertube.pages.SearchResult
 import com.metrolist.innertube.pages.SearchSummaryPage
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -57,12 +59,28 @@ data class ZemerCuratedPlaylistPage(
 )
 
 /**
+ * Server-first with offline fallback: run [server]; if it fails because the service is unreachable (an
+ * [IOException] from [ZemerSearchClient]), serve [offline] from the on-device snapshot when one is
+ * present, else rethrow so the ViewModel keeps its normal error/retry behavior. A non-network null (a
+ * 404 the client returns as null) is returned as-is and never triggers the fallback. Top-level +
+ * `internal` so the routing policy is unit-tested without an Android runtime or mocking.
+ */
+internal suspend fun <T> serverOrOffline(server: suspend () -> T, offline: suspend () -> T?): T =
+    try {
+        server()
+    } catch (e: IOException) {
+        offline() ?: throw e
+    }
+
+/**
  * Entry point for Zemer-engine search. It returns the same `YTItem`/page types the YouTube path does,
  * so the ViewModels can swap providers with a one-line branch and the UI is reused verbatim.
  *
- * Every query goes to [ZemerSearchClient] (search.zemer.io); there is no on-device fallback by design.
- * If the service is unreachable the call throws, the ViewModel shows the search-error state, and the
- * user can flip the toggle to YouTube Music search.
+ * Queries go to [ZemerSearchClient] (search.zemer.io) first; if the service is unreachable AND the user
+ * has downloaded an on-device snapshot, the reproducible endpoints fall back to [OfflineReadProvider]
+ * (search / album / home-rows / curated playlists) so browse + search keep working offline. With no
+ * snapshot the call throws as before, the ViewModel shows the search-error state, and the user can flip
+ * the toggle to YouTube Music search. `/playlist` and `/radio` are live-only (not in the snapshot).
  *
  * Responses are memoized in a small LRU keyed by (k, filters, query): the song/video/album/artist/
  * featured-playlist chips all request the same k, so after the first they hit the cache instead of
@@ -73,6 +91,7 @@ data class ZemerCuratedPlaylistPage(
 @Singleton
 class ZemerSearchRepository @Inject constructor(
     private val client: ZemerSearchClient,
+    private val offlineReads: OfflineReadProvider,
     @ApplicationContext private val context: Context,
 ) {
     // Localized "N songs" for a playlist's whitelisted track count (reuses the shared n_song plural).
@@ -125,7 +144,10 @@ class ZemerSearchRepository @Inject constructor(
      * single fetch.
      */
     suspend fun album(browseId: String, playlistId: String?, options: ZemerSearchOptions): AlbumPage? =
-        client.album(browseId, options.allowFemale, options.blockVideos)?.toAlbumPage(playlistId)
+        serverOrOffline(
+            server = { client.album(browseId, options.allowFemale, options.blockVideos) },
+            offline = { offlineReads.album(browseId, options.allowFemale, options.blockVideos) },
+        )?.toAlbumPage(playlistId)
 
     /**
      * The telemetry-ranked home rows (albums / videos / artists), already whitelist-scoped and
@@ -136,7 +158,10 @@ class ZemerSearchRepository @Inject constructor(
      */
     suspend fun homeRows(options: ZemerSearchOptions): ZemerResultMapper.HomeRows =
         ZemerResultMapper.homeRows(
-            client.homeRows(options.allowFemale, options.blockVideos),
+            serverOrOffline(
+                server = { client.homeRows(options.allowFemale, options.blockVideos) },
+                offline = { offlineReads.homeRows(options.allowFemale, options.blockVideos) },
+            ),
             formatSongCount,
         )
 
@@ -178,7 +203,10 @@ class ZemerSearchRepository @Inject constructor(
      * Sparse/duplicate rows are dropped defensively (the id keys a Compose lazy list).
      */
     suspend fun curatedPlaylists(options: ZemerSearchOptions): List<ZemerCuratedPlaylist> =
-        client.curatedPlaylists(options.allowFemale, options.blockVideos)
+        serverOrOffline(
+            server = { client.curatedPlaylists(options.allowFemale, options.blockVideos) },
+            offline = { offlineReads.curatedPlaylists(options.allowFemale, options.blockVideos) },
+        )
             .playlists
             .filter { it.id.isNotBlank() }
             .distinctBy { it.id }
@@ -188,7 +216,10 @@ class ZemerSearchRepository @Inject constructor(
      * list. Null = 404 (gone, or nothing survives these flags) — the screen backs out gracefully.
      */
     suspend fun curatedPlaylist(id: String, options: ZemerSearchOptions): ZemerCuratedPlaylistPage? =
-        client.curatedPlaylist(id, options.allowFemale, options.blockVideos)?.let { response ->
+        serverOrOffline(
+            server = { client.curatedPlaylist(id, options.allowFemale, options.blockVideos) },
+            offline = { offlineReads.curatedPlaylist(id, options.allowFemale, options.blockVideos) },
+        )?.let { response ->
             ZemerCuratedPlaylistPage(
                 playlist = response.playlist,
                 songs = response.toSongItems(options.hideExplicit),
@@ -224,7 +255,10 @@ class ZemerSearchRepository @Inject constructor(
         val trimmed = query.trim()
         val key = "$k|${options.allowFemale}|${options.blockVideos}|$trimmed"
         cacheMutex.withLock { cache[key] }?.let { return it }
-        val response = client.search(trimmed, options.allowFemale, options.blockVideos, k)
+        val response = serverOrOffline(
+            server = { client.search(trimmed, options.allowFemale, options.blockVideos, k) },
+            offline = { offlineReads.search(trimmed, k, options.allowFemale, options.blockVideos) },
+        )
         cacheMutex.withLock { cache[key] = response }
         return response
     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/OfflineBackupPromo.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/OfflineBackupPromo.kt
@@ -1,0 +1,91 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.OfflineSubsetEnabledKey
+import com.jtech.zemer.constants.OfflineSubsetPromoDismissedKey
+import com.jtech.zemer.utils.rememberPreference
+
+/**
+ * One-time "search backup exists" promo above the Zemer search results — the pre-failure discovery
+ * surface for EXISTING installs (new users get the onboarding step): the user must learn the backup
+ * exists BEFORE the first outage, not from a failed search. Renders nothing once the feature is
+ * enabled or the promo was dismissed (here, or by declining the onboarding step).
+ */
+@Composable
+fun OfflineBackupPromoCard(
+    onSetUp: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val (enabled, _) = rememberPreference(OfflineSubsetEnabledKey, defaultValue = false)
+    val (dismissed, onDismissedChange) = rememberPreference(OfflineSubsetPromoDismissedKey, defaultValue = false)
+    if (enabled || dismissed) return
+
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 4.dp),
+        ) {
+            Icon(
+                painterResource(R.drawable.offline),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(24.dp),
+            )
+            Column(modifier = Modifier.weight(1f).padding(start = 12.dp)) {
+                Text(
+                    text = stringResource(R.string.offline_search_promo_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    text = stringResource(R.string.offline_search_promo_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+        }
+        Row(
+            horizontalArrangement = Arrangement.End,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            TextButton(
+                onClick = { onDismissedChange(true) },
+                modifier = Modifier.focusBorder(),
+            ) {
+                Text(stringResource(R.string.offline_search_promo_dismiss))
+            }
+            TextButton(
+                onClick = onSetUp,
+                modifier = Modifier.focusBorder(),
+            ) {
+                Text(stringResource(R.string.offline_search_promo_action))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -38,6 +38,7 @@ import com.jtech.zemer.ui.screens.settings.ButtonSetupScreen
 import com.jtech.zemer.ui.screens.settings.ContentSettings
 import com.jtech.zemer.ui.screens.settings.GeneralSettings
 import com.jtech.zemer.ui.screens.settings.LogViewerScreen
+import com.jtech.zemer.ui.screens.settings.OfflineSearchSettings
 import com.jtech.zemer.ui.screens.settings.PlayerSettings
 import com.jtech.zemer.ui.screens.settings.PrivacySettings
 import com.jtech.zemer.ui.screens.settings.SettingsScreen
@@ -393,6 +394,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings/storage") {
         StorageSettings(navController, scrollBehavior)
+    }
+    composable("settings/offline_search") {
+        OfflineSearchSettings(navController, scrollBehavior)
     }
     composable("settings/privacy") {
         PrivacySettings(navController, scrollBehavior)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
@@ -89,6 +89,7 @@ import com.airbnb.lottie.compose.rememberLottieDynamicProperty
 import com.jtech.zemer.R
 import com.jtech.zemer.ui.component.SyncAccountWarning
 import com.jtech.zemer.ui.component.DefaultDialog
+import com.jtech.zemer.ui.screens.onboarding.OnboardingSearchBackupScreen
 import com.jtech.zemer.constants.DensityScale
 import com.jtech.zemer.utils.PermissionHelper
 import com.jtech.zemer.extensions.isInternetConnected
@@ -114,7 +115,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 
-private enum class OnboardingStep { Welcome, Density, ContentFilters, Permissions, BottomNavSetup, Loading }
+private enum class OnboardingStep { Welcome, Density, ContentFilters, Permissions, BottomNavSetup, SearchBackup, Loading }
 private enum class LegalKind { TOS, PRIVACY }
 
 @Composable
@@ -256,6 +257,11 @@ fun OnboardingFlow(
 
         OnboardingStep.BottomNavSetup -> BottomNavSetupScreen(
             onBack = { step = OnboardingStep.Permissions },
+            onComplete = { step = OnboardingStep.SearchBackup }
+        )
+
+        OnboardingStep.SearchBackup -> OnboardingSearchBackupScreen(
+            onBack = { step = OnboardingStep.BottomNavSetup },
             onComplete = { step = OnboardingStep.Loading }
         )
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
@@ -89,6 +89,7 @@ import com.airbnb.lottie.compose.rememberLottieDynamicProperty
 import com.jtech.zemer.R
 import com.jtech.zemer.ui.component.SyncAccountWarning
 import com.jtech.zemer.ui.component.DefaultDialog
+import com.jtech.zemer.ui.screens.onboarding.OnboardingChoiceCard
 import com.jtech.zemer.ui.screens.onboarding.OnboardingSearchBackupScreen
 import com.jtech.zemer.constants.DensityScale
 import com.jtech.zemer.utils.PermissionHelper
@@ -1865,111 +1866,22 @@ private fun BottomNavSetupScreen(
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            // Choice cards similar to permission cards
+            // Choice cards — the shared onboarding radio card (D-pad focus treatment included)
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                // Enable option
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 1.5.dp,
-                            color = if (enableBottomNav)
-                                MaterialTheme.colorScheme.primary
-                            else
-                                MaterialTheme.colorScheme.outline,
-                            shape = RoundedCornerShape(12.dp)
-                        ),
-                    colors = CardDefaults.cardColors(
-                        containerColor = if (enableBottomNav)
-                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
-                        else
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                    ),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { enableBottomNav = true }
-                            .padding(14.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(R.string.onboarding_nav_enable),
-                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Text(
-                                text = stringResource(R.string.onboarding_nav_enable_desc),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(top = 2.dp)
-                            )
-                        }
-                        androidx.compose.material3.RadioButton(
-                            selected = enableBottomNav,
-                            onClick = { enableBottomNav = true },
-                            colors = androidx.compose.material3.RadioButtonDefaults.colors(
-                                selectedColor = MaterialTheme.colorScheme.primary
-                            )
-                        )
-                    }
-                }
-
-                // Disable option
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 1.5.dp,
-                            color = if (!enableBottomNav)
-                                MaterialTheme.colorScheme.primary
-                            else
-                                MaterialTheme.colorScheme.outline,
-                            shape = RoundedCornerShape(12.dp)
-                        ),
-                    colors = CardDefaults.cardColors(
-                        containerColor = if (!enableBottomNav)
-                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
-                        else
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                    ),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { enableBottomNav = false }
-                            .padding(14.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(R.string.onboarding_nav_no_thanks),
-                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Text(
-                                text = stringResource(R.string.onboarding_nav_later),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(top = 2.dp)
-                            )
-                        }
-                        androidx.compose.material3.RadioButton(
-                            selected = !enableBottomNav,
-                            onClick = { enableBottomNav = false },
-                            colors = androidx.compose.material3.RadioButtonDefaults.colors(
-                                selectedColor = MaterialTheme.colorScheme.primary
-                            )
-                        )
-                    }
-                }
+                OnboardingChoiceCard(
+                    selected = enableBottomNav,
+                    title = stringResource(R.string.onboarding_nav_enable),
+                    description = stringResource(R.string.onboarding_nav_enable_desc),
+                    onSelect = { enableBottomNav = true },
+                )
+                OnboardingChoiceCard(
+                    selected = !enableBottomNav,
+                    title = stringResource(R.string.onboarding_nav_no_thanks),
+                    description = stringResource(R.string.onboarding_nav_later),
+                    onSelect = { enableBottomNav = false },
+                )
             }
 
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingChoiceCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingChoiceCard.kt
@@ -1,0 +1,83 @@
+package com.jtech.zemer.ui.screens.onboarding
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.ui.component.focusBorder
+
+/**
+ * The shared radio-select choice card the onboarding steps use (bottom-nav setup, search backup) —
+ * one implementation instead of a per-screen copy, carrying the mandatory D-pad treatment
+ * (`.focusBorder()` before the clickable, per docs/ui/standards.md §11) that a bespoke card is
+ * exactly how a screen forgets.
+ */
+@Composable
+fun OnboardingChoiceCard(
+    selected: Boolean,
+    title: String,
+    description: String,
+    onSelect: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.5.dp,
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(12.dp),
+            ),
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            },
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusBorder()
+                .clickable(onClick = onSelect)
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+            RadioButton(
+                selected = selected,
+                onClick = onSelect,
+                colors = RadioButtonDefaults.colors(selectedColor = MaterialTheme.colorScheme.primary),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingSearchBackupScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingSearchBackupScreen.kt
@@ -1,25 +1,17 @@
 package com.jtech.zemer.ui.screens.onboarding
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -85,13 +77,13 @@ fun OnboardingSearchBackupScreen(
             Spacer(modifier = Modifier.height(12.dp))
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                BackupChoiceCard(
+                OnboardingChoiceCard(
                     selected = enableBackup,
                     title = stringResource(R.string.onboarding_backup_enable),
                     description = stringResource(R.string.onboarding_backup_enable_desc),
                     onSelect = { enableBackup = true },
                 )
-                BackupChoiceCard(
+                OnboardingChoiceCard(
                     selected = !enableBackup,
                     title = stringResource(R.string.onboarding_backup_skip),
                     description = stringResource(R.string.onboarding_backup_skip_desc),
@@ -133,60 +125,6 @@ fun OnboardingSearchBackupScreen(
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun BackupChoiceCard(
-    selected: Boolean,
-    title: String,
-    description: String,
-    onSelect: () -> Unit,
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .border(
-                width = 1.5.dp,
-                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
-                shape = RoundedCornerShape(12.dp),
-            ),
-        colors = CardDefaults.cardColors(
-            containerColor = if (selected) {
-                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
-            } else {
-                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-            },
-        ),
-        shape = RoundedCornerShape(12.dp),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onSelect)
-                .padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 2.dp),
-                )
-            }
-            RadioButton(
-                selected = selected,
-                onClick = onSelect,
-                colors = RadioButtonDefaults.colors(selectedColor = MaterialTheme.colorScheme.primary),
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingSearchBackupScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/onboarding/OnboardingSearchBackupScreen.kt
@@ -1,0 +1,192 @@
+package com.jtech.zemer.ui.screens.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.jtech.zemer.R
+import com.jtech.zemer.viewmodels.OfflineSearchSettingsViewModel
+
+/**
+ * Onboarding step offering the offline search backup — every new user learns the feature exists
+ * BEFORE the first server outage, not from a failed search. Enable-selected by default; declining
+ * also silences the one-time search-screen promo ([OfflineSearchSettingsViewModel.dismissPromo]) so
+ * an explicit "no" is not re-asked. The download itself runs on the syncer's own scope, so leaving
+ * onboarding never cancels it.
+ */
+@Composable
+fun OnboardingSearchBackupScreen(
+    onBack: () -> Unit,
+    onComplete: () -> Unit,
+    viewModel: OfflineSearchSettingsViewModel = hiltViewModel(),
+) {
+    var enableBackup by remember { mutableStateOf(true) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(0.9f),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.onboarding_backup_title),
+                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = stringResource(R.string.onboarding_backup_question),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                BackupChoiceCard(
+                    selected = enableBackup,
+                    title = stringResource(R.string.onboarding_backup_enable),
+                    description = stringResource(R.string.onboarding_backup_enable_desc),
+                    onSelect = { enableBackup = true },
+                )
+                BackupChoiceCard(
+                    selected = !enableBackup,
+                    title = stringResource(R.string.onboarding_backup_skip),
+                    description = stringResource(R.string.onboarding_backup_skip_desc),
+                    onSelect = { enableBackup = false },
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = {
+                        if (enableBackup) viewModel.setEnabled(true) else viewModel.dismissPromo()
+                        onComplete()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(44.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                ) {
+                    Text(
+                        text = stringResource(R.string.onboarding_continue),
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+
+                TextButton(
+                    onClick = onBack,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = stringResource(R.string.onboarding_back),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BackupChoiceCard(
+    selected: Boolean,
+    title: String,
+    description: String,
+    onSelect: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.5.dp,
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(12.dp),
+            ),
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            },
+        ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onSelect)
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+            RadioButton(
+                selected = selected,
+                onClick = onSelect,
+                colors = RadioButtonDefaults.colors(selectedColor = MaterialTheme.colorScheme.primary),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -64,6 +64,7 @@ import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.NavigationTitle
+import com.jtech.zemer.ui.component.OfflineBackupPromoCard
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.shimmer.ListItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
@@ -326,6 +327,18 @@ fun OnlineSearchResult(
                     )
                     .fillMaxWidth()
             )
+        }
+        if (searchProvider == SearchProvider.ZEMER) {
+            item(key = "offline_backup_promo") {
+                // One-time pre-failure discovery of the search backup (self-hides once
+                // enabled/dismissed) — existing installs never see the onboarding step.
+                OfflineBackupPromoCard(
+                    onSetUp = { navController.navigate("settings/offline_search") },
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .animateItem(),
+                )
+            }
         }
         if (searchFilter == null) {
             when {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -1,0 +1,150 @@
+package com.jtech.zemer.ui.screens.settings
+
+import android.text.format.DateUtils
+import android.text.format.Formatter
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.OfflineSubsetEnabledKey
+import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
+import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.PreferenceEntry
+import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.utils.rememberPreference
+import com.jtech.zemer.viewmodels.OfflineSearchSettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OfflineSearchSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: OfflineSearchSettingsViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val status by viewModel.status.collectAsStateWithLifecycle()
+
+    val (enabled, onEnabledChange) = rememberPreference(OfflineSubsetEnabledKey, defaultValue = false)
+    val (wifiOnly, onWifiOnlyChange) = rememberPreference(OfflineSubsetWifiOnlyKey, defaultValue = true)
+
+    val backFocus = remember { FocusRequester() }
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        firstFocus.requestFocus()
+    }
+
+    val statusDescription = remember(status) {
+        buildString {
+            append(context.getString(R.string.offline_search_size, Formatter.formatShortFileSize(context, status.sizeOnDisk)))
+            append(" · ")
+            val lastUpdated = if (status.lastSyncedAt <= 0L) {
+                context.getString(R.string.offline_search_never)
+            } else {
+                DateUtils.getRelativeTimeSpanString(
+                    status.lastSyncedAt,
+                    System.currentTimeMillis(),
+                    DateUtils.MINUTE_IN_MILLIS,
+                ).toString()
+            }
+            append(context.getString(R.string.offline_search_last_updated, lastUpdated))
+            status.lastError?.let {
+                append("\n")
+                append(context.getString(R.string.offline_search_last_error, it))
+            }
+        }
+    }
+
+    Column(
+        Modifier
+            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        PreferenceGroupTitle(
+            title = stringResource(R.string.offline_search),
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.offline_search_enable)) },
+            description = stringResource(R.string.offline_search_enable_desc),
+            icon = { Icon(painterResource(R.drawable.offline), null) },
+            checked = enabled,
+            onCheckedChange = {
+                onEnabledChange(it)
+                viewModel.setEnabled(it)
+            },
+            modifier = Modifier.focusRequester(firstFocus),
+        )
+
+        if (enabled) {
+            SwitchPreference(
+                title = { Text(stringResource(R.string.offline_search_wifi_only)) },
+                description = stringResource(R.string.offline_search_wifi_only_desc),
+                icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
+                checked = wifiOnly,
+                onCheckedChange = {
+                    onWifiOnlyChange(it)
+                    viewModel.setWifiOnly(it)
+                },
+            )
+
+            PreferenceEntry(
+                title = {
+                    Text(
+                        if (status.running) {
+                            stringResource(R.string.offline_search_updating)
+                        } else {
+                            stringResource(R.string.offline_search_download_now)
+                        }
+                    )
+                },
+                description = statusDescription,
+                icon = { Icon(painterResource(R.drawable.download), null) },
+                onClick = { viewModel.downloadNow() },
+                isEnabled = !status.running,
+            )
+        }
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.offline_search)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .focusRequester(backFocus)
+                        .focusProperties { down = firstFocus }
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -47,8 +47,10 @@ fun OfflineSearchSettings(
     val context = LocalContext.current
     val status by viewModel.status.collectAsStateWithLifecycle()
 
-    val (enabled, onEnabledChange) = rememberPreference(OfflineSubsetEnabledKey, defaultValue = false)
-    val (wifiOnly, onWifiOnlyChange) = rememberPreference(OfflineSubsetWifiOnlyKey, defaultValue = true)
+    // Read-only here: the ViewModel is the single writer of both keys (writing from both places
+    // double-committed every toggle).
+    val (enabled, _) = rememberPreference(OfflineSubsetEnabledKey, defaultValue = false)
+    val (wifiOnly, _) = rememberPreference(OfflineSubsetWifiOnlyKey, defaultValue = true)
 
     val backFocus = remember { FocusRequester() }
     val firstFocus = remember { FocusRequester() }
@@ -71,6 +73,10 @@ fun OfflineSearchSettings(
                 ).toString()
             }
             append(context.getString(R.string.offline_search_last_updated, lastUpdated))
+            if (status.waitingForWifi) {
+                append("\n")
+                append(context.getString(R.string.offline_search_waiting_wifi))
+            }
             status.lastError?.let {
                 append("\n")
                 append(context.getString(R.string.offline_search_last_error, it))
@@ -92,10 +98,7 @@ fun OfflineSearchSettings(
             description = stringResource(R.string.offline_search_enable_desc),
             icon = { Icon(painterResource(R.drawable.offline), null) },
             checked = enabled,
-            onCheckedChange = {
-                onEnabledChange(it)
-                viewModel.setEnabled(it)
-            },
+            onCheckedChange = viewModel::setEnabled,
             modifier = Modifier.focusRequester(firstFocus),
         )
 
@@ -105,10 +108,7 @@ fun OfflineSearchSettings(
                 description = stringResource(R.string.offline_search_wifi_only_desc),
                 icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
                 checked = wifiOnly,
-                onCheckedChange = {
-                    onWifiOnlyChange(it)
-                    viewModel.setWifiOnly(it)
-                },
+                onCheckedChange = viewModel::setWifiOnly,
             )
 
             PreferenceEntry(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -28,7 +28,6 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.OfflineSubsetEnabledKey
-import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -47,10 +46,9 @@ fun OfflineSearchSettings(
     val context = LocalContext.current
     val status by viewModel.status.collectAsStateWithLifecycle()
 
-    // Read-only here: the ViewModel is the single writer of both keys (writing from both places
-    // double-committed every toggle).
+    // Read-only here: the ViewModel is the single writer (writing from both places double-committed
+    // every toggle).
     val (enabled, _) = rememberPreference(OfflineSubsetEnabledKey, defaultValue = false)
-    val (wifiOnly, _) = rememberPreference(OfflineSubsetWifiOnlyKey, defaultValue = true)
 
     val backFocus = remember { FocusRequester() }
     val firstFocus = remember { FocusRequester() }
@@ -73,10 +71,6 @@ fun OfflineSearchSettings(
                 ).toString()
             }
             append(context.getString(R.string.offline_search_last_updated, lastUpdated))
-            if (status.waitingForWifi) {
-                append("\n")
-                append(context.getString(R.string.offline_search_waiting_wifi))
-            }
             status.lastError?.let {
                 append("\n")
                 append(context.getString(R.string.offline_search_last_error, it))
@@ -103,14 +97,6 @@ fun OfflineSearchSettings(
         )
 
         if (enabled) {
-            SwitchPreference(
-                title = { Text(stringResource(R.string.offline_search_wifi_only)) },
-                description = stringResource(R.string.offline_search_wifi_only_desc),
-                icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
-                checked = wifiOnly,
-                onCheckedChange = viewModel::setWifiOnly,
-            )
-
             PreferenceEntry(
                 title = {
                     Text(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -144,6 +144,14 @@ fun SettingsScreen(
             route = "settings/storage"
         ),
         SettingItem(
+            id = "offline_search",
+            title = stringResource(R.string.offline_search),
+            description = stringResource(R.string.settings_desc_offline_search),
+            icon = R.drawable.offline,
+            section = stringResource(R.string.settings_section_storage),
+            route = "settings/offline_search"
+        ),
+        SettingItem(
             id = "backup",
             title = stringResource(R.string.backup_restore),
             description = stringResource(R.string.settings_desc_backup),

--- a/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt
@@ -1,18 +1,22 @@
 package com.jtech.zemer.utils
 
 import com.jtech.zemer.db.entities.ArtistWhitelistEntity
-import java.util.concurrent.ConcurrentHashMap
 
 object WhitelistCache {
-    private val memory = ConcurrentHashMap<String, ArtistWhitelistEntity>()
+    // A @Volatile immutable map swapped whole, NOT a mutable map mutated in place: the old
+    // clear-then-refill left a window where concurrent readers (notably the offline subset's
+    // live-whitelist overlay) saw an empty or partial whitelist mid-refresh — an empty read
+    // short-circuits the overlay and briefly serves de-whitelisted content.
+    @Volatile
+    private var memory: Map<String, ArtistWhitelistEntity> = emptyMap()
 
     fun updateAll(entries: List<ArtistWhitelistEntity>) {
-        memory.clear()
-        entries.forEach { memory[it.artistId] = it }
+        memory = entries.associateBy { it.artistId }
     }
 
     fun get(artistId: String): ArtistWhitelistEntity? = memory[artistId]
 
+    /** An immutable, point-in-time view — safe to iterate while a refresh swaps the map. */
     fun snapshot(): Collection<ArtistWhitelistEntity> = memory.values
 
     suspend fun allowedEntries(database: com.jtech.zemer.db.MusicDatabase, config: ContentFilterConfig): List<ArtistWhitelistEntity> {

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OfflineSearchSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OfflineSearchSettingsViewModel.kt
@@ -1,0 +1,61 @@
+package com.jtech.zemer.viewmodels
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jtech.zemer.constants.OfflineSubsetEnabledKey
+import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
+import com.jtech.zemer.offline.OfflineSubsetSyncer
+import com.jtech.zemer.offline.SubsetSyncStatus
+import com.jtech.zemer.utils.dataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Backs the "Offline search" settings screen: the opt-in + WiFi-only toggles and the
+ * status/download-now action. All state comes from the injected [OfflineSubsetSyncer]
+ * (the single owner of the on-device snapshot); this ViewModel only writes the two prefs
+ * and drives the syncer's actions.
+ */
+@HiltViewModel
+class OfflineSearchSettingsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val syncer: OfflineSubsetSyncer,
+) : ViewModel() {
+
+    val status: StateFlow<SubsetSyncStatus> = syncer.status
+
+    init {
+        viewModelScope.launch { syncer.refresh() }
+    }
+
+    /**
+     * Persists the opt-in. Turning it on kicks off the first download ([sync] with force so the
+     * initial fetch runs even though the enabled flag has only just been written); turning it off
+     * wipes the downloaded snapshot.
+     */
+    fun setEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            context.dataStore.edit { it[OfflineSubsetEnabledKey] = enabled }
+            if (enabled) {
+                syncer.sync(force = true)
+            } else {
+                syncer.clear()
+            }
+        }
+    }
+
+    fun setWifiOnly(wifiOnly: Boolean) {
+        viewModelScope.launch {
+            context.dataStore.edit { it[OfflineSubsetWifiOnlyKey] = wifiOnly }
+        }
+    }
+
+    fun downloadNow() {
+        viewModelScope.launch { syncer.sync(force = true) }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/OfflineSearchSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/OfflineSearchSettingsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jtech.zemer.constants.OfflineSubsetEnabledKey
-import com.jtech.zemer.constants.OfflineSubsetWifiOnlyKey
+import com.jtech.zemer.constants.OfflineSubsetPromoDismissedKey
 import com.jtech.zemer.offline.OfflineSubsetSyncer
 import com.jtech.zemer.offline.SubsetSyncStatus
 import com.jtech.zemer.utils.dataStore
@@ -16,10 +16,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * Backs the "Offline search" settings screen: the opt-in + WiFi-only toggles and the
- * status/download-now action. All state comes from the injected [OfflineSubsetSyncer]
- * (the single owner of the on-device snapshot); this ViewModel only writes the two prefs
- * and drives the syncer's actions.
+ * Backs the "Search backup" settings screen AND the onboarding step: the opt-in toggle and the
+ * status/download-now action. All state comes from the injected [OfflineSubsetSyncer] (the single
+ * owner of the on-device snapshot); this ViewModel only writes the prefs and drives the syncer.
  */
 @HiltViewModel
 class OfflineSearchSettingsViewModel @Inject constructor(
@@ -34,28 +33,29 @@ class OfflineSearchSettingsViewModel @Inject constructor(
     }
 
     /**
-     * Persists the opt-in. Turning it on kicks off the first download ([sync] with force so the
-     * initial fetch runs even though the enabled flag has only just been written); turning it off
-     * wipes the downloaded snapshot.
+     * Persists the opt-in. Turning it on kicks off the first download on the SYNCER's own scope
+     * ([OfflineSubsetSyncer.requestSync] — a viewModelScope launch dies with the screen, cancelling
+     * the download the moment the user navigates on); turning it off wipes the snapshot.
      */
     fun setEnabled(enabled: Boolean) {
         viewModelScope.launch {
             context.dataStore.edit { it[OfflineSubsetEnabledKey] = enabled }
             if (enabled) {
-                syncer.sync(force = true)
+                syncer.requestSync(force = true)
             } else {
                 syncer.clear()
             }
         }
     }
 
-    fun setWifiOnly(wifiOnly: Boolean) {
-        viewModelScope.launch {
-            context.dataStore.edit { it[OfflineSubsetWifiOnlyKey] = wifiOnly }
-        }
+    fun downloadNow() {
+        syncer.requestSync(force = true)
     }
 
-    fun downloadNow() {
-        viewModelScope.launch { syncer.sync(force = true) }
+    /** The user declined the onboarding offer — also silence the one-time search-screen promo. */
+    fun dismissPromo() {
+        viewModelScope.launch {
+            context.dataStore.edit { it[OfflineSubsetPromoDismissedKey] = true }
+        }
     }
 }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -545,14 +545,21 @@
     <string name="offline_search">Search backup</string>
     <string name="settings_desc_offline_search">Keep searching if the Zemer server is briefly down</string>
     <string name="offline_search_enable">Enable search backup</string>
-    <string name="offline_search_enable_desc">Download the catalog so search and browse keep working during a short Zemer server outage</string>
-    <string name="offline_search_wifi_only">Download over Wi-Fi only</string>
-    <string name="offline_search_wifi_only_desc">Only download or update the backup catalog on an unmetered network</string>
+    <string name="offline_search_enable_desc">Download the catalog so search and browse keep working during a short Zemer server outage. Updates automatically every day.</string>
     <string name="offline_search_download_now">Download now</string>
     <string name="offline_search_updating">Updating…</string>
     <string name="offline_search_size">%1$s downloaded</string>
     <string name="offline_search_last_updated">Updated %1$s</string>
     <string name="offline_search_never">Never</string>
     <string name="offline_search_last_error">Last error: %1$s</string>
-    <string name="offline_search_waiting_wifi">Waiting for Wi-Fi — connect to an unmetered network or turn off “Download over Wi-Fi only”</string>
+    <string name="offline_search_promo_title">Keep search working offline</string>
+    <string name="offline_search_promo_body">Download a backup of the catalog once and search keeps working even when the Zemer server is unreachable</string>
+    <string name="offline_search_promo_action">Set up</string>
+    <string name="offline_search_promo_dismiss">Not now</string>
+    <string name="onboarding_backup_title">Search backup</string>
+    <string name="onboarding_backup_question">Should search keep working even when the Zemer server is unreachable?</string>
+    <string name="onboarding_backup_enable">Download a backup</string>
+    <string name="onboarding_backup_enable_desc">Downloads the catalog now and keeps it updated automatically every day</string>
+    <string name="onboarding_backup_skip">Not now</string>
+    <string name="onboarding_backup_skip_desc">You can enable it any time in Settings → Search backup</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -542,4 +542,16 @@
     <string name="enable_casting">Enable casting</string>
     <string name="enable_casting_description">Show a cast button to play to Chromecast and FCast devices on your network.</string>
     <string name="stop_casting">Stop casting</string>
+    <string name="offline_search">Offline search</string>
+    <string name="settings_desc_offline_search">Search and browse without a connection</string>
+    <string name="offline_search_enable">Enable offline search</string>
+    <string name="offline_search_enable_desc">Download the music catalog to search and browse when offline</string>
+    <string name="offline_search_wifi_only">Download over Wi-Fi only</string>
+    <string name="offline_search_wifi_only_desc">Only download or update the offline catalog on an unmetered network</string>
+    <string name="offline_search_download_now">Download now</string>
+    <string name="offline_search_updating">Updating…</string>
+    <string name="offline_search_size">%1$s downloaded</string>
+    <string name="offline_search_last_updated">Updated %1$s</string>
+    <string name="offline_search_never">Never</string>
+    <string name="offline_search_last_error">Last error: %1$s</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -542,12 +542,12 @@
     <string name="enable_casting">Enable casting</string>
     <string name="enable_casting_description">Show a cast button to play to Chromecast and FCast devices on your network.</string>
     <string name="stop_casting">Stop casting</string>
-    <string name="offline_search">Offline search</string>
-    <string name="settings_desc_offline_search">Search and browse without a connection</string>
-    <string name="offline_search_enable">Enable offline search</string>
-    <string name="offline_search_enable_desc">Download the music catalog to search and browse when offline</string>
+    <string name="offline_search">Search backup</string>
+    <string name="settings_desc_offline_search">Keep searching if the Zemer server is briefly down</string>
+    <string name="offline_search_enable">Enable search backup</string>
+    <string name="offline_search_enable_desc">Download the catalog so search and browse keep working during a short Zemer server outage</string>
     <string name="offline_search_wifi_only">Download over Wi-Fi only</string>
-    <string name="offline_search_wifi_only_desc">Only download or update the offline catalog on an unmetered network</string>
+    <string name="offline_search_wifi_only_desc">Only download or update the backup catalog on an unmetered network</string>
     <string name="offline_search_download_now">Download now</string>
     <string name="offline_search_updating">Updating…</string>
     <string name="offline_search_size">%1$s downloaded</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -554,4 +554,5 @@
     <string name="offline_search_last_updated">Updated %1$s</string>
     <string name="offline_search_never">Never</string>
     <string name="offline_search_last_error">Last error: %1$s</string>
+    <string name="offline_search_waiting_wifi">Waiting for Wi-Fi — connect to an unmetered network or turn off “Download over Wi-Fi only”</string>
 </resources>

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetDecoderTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetDecoderTest.kt
@@ -1,0 +1,99 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the shard decoders to the real wire format, using rows sampled from the live
+ * `search.zemer.io` subset shards. Guards the positional layouts and packed-flag bits against a
+ * drift in `zemer-search/index/build-subset.mjs`.
+ */
+class SubsetDecoderTest {
+
+    @Test
+    fun `artists decode with packed flag bits`() {
+        val a = SubsetDecoder.decodeArtists(
+            """[["UC-2KKdSj6zy8SZ8jFngR91g","נתנאל זלבסקי","https://yt3/x=w2880",0],
+                ["UCx","Fem Chasid Kid","https://t",7]]""",
+        )
+        assertEquals("UC-2KKdSj6zy8SZ8jFngR91g", a[0].id)
+        assertEquals("נתנאל זלבסקי", a[0].name)
+        assertFalse(a[0].isFemale); assertFalse(a[0].isChasid); assertFalse(a[0].isKidZone)
+        // flags = 7 = 1|2|4
+        assertTrue(a[1].isFemale); assertTrue(a[1].isChasid); assertTrue(a[1].isKidZone)
+    }
+
+    @Test
+    fun `tracks decode positions, video and explicit bits, and nullable playCount and date`() {
+        val t = SubsetDecoder.decodeTracks(
+            """[["--CBg_MWYAI","Mi Ha'ish","UCPgvMW042hVrcLn73zGyeqg",0,239,7300,"2015-07-02T05:27:44-07:00"],
+                ["--sU8olZCYM","Nafshi Acapella","UCu6IT3jTOtAcNfjIQSIyCQQ",1,262,null,null],
+                ["x","Ex","UCa",2,100,5,null]]""",
+        )
+        assertEquals("--CBg_MWYAI", t[0].videoId)
+        assertEquals("UCPgvMW042hVrcLn73zGyeqg", t[0].artistId)
+        assertFalse(t[0].isVideo); assertFalse(t[0].explicit)
+        assertEquals(239, t[0].durationSec); assertEquals(7300L, t[0].playCount)
+        assertEquals("2015-07-02T05:27:44-07:00", t[0].uploadDate)
+        assertTrue(t[1].isVideo); assertFalse(t[1].explicit)
+        assertNull(t[1].playCount); assertNull(t[1].uploadDate)
+        // flags = 2 → explicit, not video
+        assertFalse(t[2].isVideo); assertTrue(t[2].explicit)
+    }
+
+    @Test
+    fun `albums and album_tracks decode`() {
+        val al = SubsetDecoder.decodeAlbums(
+            """[["MPREb_01R54uSBAcI","OLAK5uy_ktyH","Misratzeh","UCchRbwcne","single",2025,"https://t","2026-06-15T10:55:35-07:00"],
+                ["MPREb_x",null,"NoPlaylist","UCa","album",null,null,null]]""",
+        )
+        assertEquals("OLAK5uy_ktyH", al[0].playlistId)
+        assertEquals("single", al[0].type); assertEquals(2025, al[0].year)
+        assertNull(al[1].playlistId); assertNull(al[1].year); assertEquals("album", al[1].type)
+
+        val at = SubsetDecoder.decodeAlbumTracks("""[["MPREb_01R54uSBAcI","6wA415N97Xs",0],["MPREb_Y","vid2",7]]""")
+        assertEquals("MPREb_01R54uSBAcI", at[0].albumId); assertEquals("6wA415N97Xs", at[0].videoId); assertEquals(0, at[0].pos)
+        assertEquals(7, at[1].pos)
+    }
+
+    @Test
+    fun `community and community_tracks decode with nullable resolved artist`() {
+        val c = SubsetDecoder.decodeCommunity(
+            """[["LRSR4D8","March-May Recap '24","Moris SEVILLA","https://t",48,37,null],
+                ["LRb","T","auth","https://t",10,3,999]]""",
+        )
+        assertEquals(48, c[0].total); assertEquals(37, c[0].whitelisted); assertNull(c[0].viewCount)
+        assertEquals(999L, c[1].viewCount)
+
+        val ct = SubsetDecoder.decodeCommunityTracks(
+            """[["LRSR4D8","cUMhXx3HssY",0,null],["LRSR4D8","RD0m1pI8uPg",2,"UCzqpZ8XdZsLBGNYKbEZn-TA"]]""",
+        )
+        assertNull(ct[0].artistId)
+        assertEquals("UCzqpZ8XdZsLBGNYKbEZn-TA", ct[1].artistId); assertEquals(2, ct[1].pos)
+    }
+
+    @Test
+    fun `homerank, zemer and blocked object shards decode`() {
+        val hr = SubsetDecoder.decodeHomeRank(
+            """[{"row":"top-albums","kind":"album","refId":"MPREb_BSx5FtOl9u3","artistId":"UC4yNv","pos":0,"score":0.95},
+                {"row":"top-artists","kind":"artist","refId":"UCa","artistId":null,"pos":1,"score":null}]""",
+        )
+        assertEquals("top-albums", hr[0].row); assertEquals("MPREb_BSx5FtOl9u3", hr[0].refId); assertEquals(0.95, hr[0].score!!, 1e-9)
+        assertNull(hr[1].artistId); assertNull(hr[1].score)
+
+        val (pls, items) = SubsetDecoder.decodeZemer(
+            """{"playlists":[{"id":"auto-top-50","title":"Top 50","pos":0,"year":null},{"id":"auto-year-2026","title":"Year of 2026","pos":4,"year":2026}],
+                "items":[{"playlistId":"auto-top-50","kind":"track","refId":"MJUjf4hLTlo","pos":0}]}""",
+        )
+        assertEquals("auto-top-50", pls[0].id); assertNull(pls[0].year); assertEquals(2026, pls[1].year)
+        assertEquals("track", items[0].kind); assertEquals("MJUjf4hLTlo", items[0].refId)
+
+        val blocked = SubsetDecoder.decodeBlocked("""{"global":["jvEXWajQUlQ"],"female":["0ynSwHjCOSQ","6V8hM6RbaAI"]}""")
+        assertTrue("jvEXWajQUlQ" in blocked.global)
+        assertEquals(2, blocked.female.size)
+        assertTrue("6V8hM6RbaAI" in blocked.female)
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetFemaleSynonymsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetFemaleSynonymsTest.kt
@@ -1,0 +1,57 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Cross-language parity for the female-involvement port ([SubsetFemale]) and the synonym expander
+ * ([SubsetSynonyms]). Every expected value here was produced by RUNNING the real JS
+ * (`zemer-search/index/{credits,female-owned,synonyms}.mjs`) on the same inputs, not hand-guessed —
+ * so this proves the Kotlin matches the server, it does not merely restate the port.
+ */
+class SubsetFemaleSynonymsTest {
+
+    // Same female whitelist the JS ground-truth generator used to build the matcher.
+    private val artists = listOf(
+        SubArtist("a1", "Franciska", null, isFemale = true, isChasid = false, isKidZone = false),
+        // Shiri Maimon, written in Hebrew — exercises CROSS-SCRIPT skeleton matching.
+        SubArtist("a2", "שירי מימון", null, isFemale = true, isChasid = false, isKidZone = false),
+        SubArtist("a3", "Avraham Fried", null, isFemale = false, isChasid = false, isKidZone = false),
+        SubArtist("a4", "Yaakov Shwekey", null, isFemale = false, isChasid = false, isKidZone = false),
+    )
+    private val matcher = buildFemaleMatcher(artists)
+
+    @Test
+    fun `isFemaleInvolved matches the JS on primary, feat, non-female and cross-script cases`() {
+        // primaryIsFemale short-circuits to true.
+        assertTrue(isFemaleInvolved("Some Song", "Franciska", true, matcher))
+        // male primary, female credited in the title parenthetical.
+        assertTrue(isFemaleInvolved("Shiru (feat. Franciska)", "Yaakov Shwekey", false, matcher))
+        // no credited female anywhere.
+        assertFalse(isFemaleInvolved("Kah Amar", "Avraham Fried", false, matcher))
+        // romanized title credit aligns with the Hebrew whitelist entry via the consonant skeleton.
+        assertTrue(isFemaleInvolved("Kol Haolam (feat. Shiri Maimon)", "Avraham Fried", false, matcher))
+    }
+
+    @Test
+    fun `isCommunityFemaleOwned matches the JS author-name check (empty offline id set)`() {
+        assertTrue(isCommunityFemaleOwned("Franciska", matcher))
+        assertFalse(isCommunityFemaleOwned("Avraham Fried", matcher))
+        assertFalse(isCommunityFemaleOwned(null, matcher))
+    }
+
+    @Test
+    fun `expand unions in synonym-group tokens for a matching query and leaves a non-match unchanged`() {
+        // "mbd" hits the ["mbd", "mordechai ben david"] group.
+        val mbd = SubsetSynonyms.expand(listOf("mbd"), listOf("mbd"))
+        assertEquals(listOf("mbd", "mordechai", "ben", "david"), mbd.plain)
+        assertEquals(listOf("mbd", "mrdk", "bn", "dbd"), mbd.skel)
+
+        // "shwekey" overlaps no group — returned unchanged (skeleton token is "sk").
+        val shwekey = SubsetSynonyms.expand(listOf("shwekey"), listOf("sk"))
+        assertEquals(listOf("shwekey"), shwekey.plain)
+        assertEquals(listOf("sk"), shwekey.skel)
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelistTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelistTest.kt
@@ -1,0 +1,121 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The offline snapshot's kosher defenses: the freshness gate (an unsyncable device must not serve an
+ * ever-aging copy) and the live-whitelist overlay (a de-whitelisted or since-female-flagged artist is
+ * hidden the moment the app's whitelist sync lands, not on the next snapshot download).
+ */
+class SubsetLiveWhitelistTest {
+
+    private fun corpus(
+        artists: List<SubArtist> = listOf(
+            SubArtist("UC1", "Kept", null, isFemale = false, isChasid = false, isKidZone = false),
+            SubArtist("UC2", "Dropped", null, isFemale = false, isChasid = false, isKidZone = false),
+        ),
+    ) = SubsetCorpus(
+        artists = artists,
+        tracks = listOf(
+            SubTrack("v1", "T1", "UC1", isVideo = false, explicit = false, durationSec = null, playCount = null, uploadDate = null),
+            SubTrack("v2", "T2", "UC2", isVideo = false, explicit = false, durationSec = null, playCount = null, uploadDate = null),
+        ),
+        albums = listOf(
+            SubAlbum("AL1", null, "A1", "UC1", "album", null, null, null),
+            SubAlbum("AL2", null, "A2", "UC2", "album", null, null, null),
+        ),
+        albumTracks = listOf(
+            SubAlbumTrack("AL1", "v1", 0),
+            SubAlbumTrack("AL2", "v2", 0),
+        ),
+        artistPlaylists = listOf(
+            SubArtistPlaylist("PL1", "P1", "UC1", null),
+            SubArtistPlaylist("PL2", "P2", "UC2", null),
+        ),
+        community = listOf(SubCommunity("C1", "Comm", null, null, total = 2, whitelisted = 2, viewCount = null)),
+        communityTracks = listOf(
+            SubCommunityTrack("C1", "v1", 0, null),
+            SubCommunityTrack("C1", "v2", 1, null),
+            SubCommunityTrack("C1", "vx", 2, "UC2"), // discovery member resolved to the dropped artist
+            SubCommunityTrack("C1", "vy", 3, null), // unknown member — untouched by the overlay
+        ),
+        homeRank = listOf(
+            SubHomeRank("top-albums", "album", "AL1", "UC1", 0, null),
+            SubHomeRank("top-albums", "album", "AL2", "UC2", 1, null),
+            SubHomeRank("top-videos", "video", "v2", null, 0, null),
+            SubHomeRank("top-artists", "artist", "UC2", null, 0, null),
+        ),
+        zemerPlaylists = listOf(SubZemerPlaylist("z1", "Z", 0, null)),
+        zemerItems = listOf(
+            SubZemerItem("z1", "track", "v1", 0),
+            SubZemerItem("z1", "track", "v2", 1),
+            SubZemerItem("z1", "album", "AL2", 2),
+        ),
+        blocked = SubBlocked(emptySet(), emptySet()),
+    )
+
+    // --- freshness gate ---
+
+    @Test
+    fun `snapshot is fresh only within the max age and only when ever synced`() {
+        val now = 1_000_000_000_000L
+        assertTrue(subsetSnapshotIsFresh(now - 1, now))
+        assertTrue(subsetSnapshotIsFresh(now - SUBSET_MAX_SNAPSHOT_AGE_MS, now))
+        assertFalse("past the cap", subsetSnapshotIsFresh(now - SUBSET_MAX_SNAPSHOT_AGE_MS - 1, now))
+        assertFalse("never synced", subsetSnapshotIsFresh(0L, now))
+    }
+
+    // --- live overlay ---
+
+    @Test
+    fun `empty live whitelist is a no-op - never wipe the snapshot before the first sync`() {
+        val c = corpus()
+        assertSame(c, c.withLiveWhitelist(emptyMap()))
+    }
+
+    @Test
+    fun `unchanged live whitelist returns the same corpus`() {
+        val c = corpus()
+        assertSame(c, c.withLiveWhitelist(mapOf("UC1" to false, "UC2" to false)))
+    }
+
+    @Test
+    fun `a de-whitelisted artist is dropped with every row referencing it`() {
+        val c = corpus().withLiveWhitelist(mapOf("UC1" to false))
+
+        assertEquals(listOf("UC1"), c.artists.map { it.id })
+        assertEquals(listOf("v1"), c.tracks.map { it.videoId })
+        assertEquals(listOf("AL1"), c.albums.map { it.id })
+        assertEquals(listOf("AL1"), c.albumTracks.map { it.albumId })
+        assertEquals(listOf("PL1"), c.artistPlaylists.map { it.id })
+        // Community: the dropped artist's corpus track and its discovery member go; the unknown stays.
+        assertEquals(listOf("v1", "vy"), c.communityTracks.map { it.videoId })
+        // Home rank: rows referencing the dropped album/video/artist go.
+        assertEquals(listOf("AL1"), c.homeRank.map { it.refId })
+        // Curated items: the dropped track and album go.
+        assertEquals(listOf("v1"), c.zemerItems.map { it.refId })
+    }
+
+    @Test
+    fun `live isFemale overrides the shard flag`() {
+        val c = corpus().withLiveWhitelist(mapOf("UC1" to true, "UC2" to false))
+        assertTrue(c.artistsById.getValue("UC1").isFemale)
+        assertFalse(c.artistsById.getValue("UC2").isFemale)
+    }
+
+    // --- fingerprint (cache key for the overlaid corpus) ---
+
+    @Test
+    fun `fingerprint changes on membership and on a female flag flip`() {
+        val base = liveWhitelistFingerprint(mapOf("UC1" to false, "UC2" to false))
+        assertNotEquals(base, liveWhitelistFingerprint(mapOf("UC1" to false)))
+        assertNotEquals(base, liveWhitelistFingerprint(mapOf("UC1" to true, "UC2" to false)))
+        // Order-independent: same content → same fingerprint.
+        assertEquals(base, liveWhitelistFingerprint(linkedMapOf("UC2" to false, "UC1" to false)))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetNormalizeTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetNormalizeTest.kt
@@ -1,0 +1,53 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Verifies the Kotlin normalizer matches `zemer-search/index/normalize.mjs` exactly. Every expected
+ * value here was produced by RUNNING the real JS on the same input — so this is a cross-language parity
+ * check, not a restatement of the port.
+ */
+class SubsetNormalizeTest {
+
+    private fun check(input: String, plain: List<String>, skKey: String, skTok: List<String>) {
+        assertEquals("plain($input)", plain, SubsetNormalize.plainTokens(input))
+        assertEquals("skKey($input)", skKey, SubsetNormalize.skeletonKey(input))
+        assertEquals("skTok($input)", skTok, SubsetNormalize.skeletonTokens(input))
+    }
+
+    @Test
+    fun `matches real JS on representative Hebrew, latin, mixed and apostrophe inputs`() {
+        check("Mi Ha'ish", listOf("mi", "haish"), "m s", emptyList())
+        check("דודי פולק", listOf("דודי", "פולק"), "dd plk", listOf("dd", "plk"))
+        check("Dudi Polak", listOf("dudi", "polak"), "dd plk", listOf("dd", "plk"))
+        check("כבקרת", listOf("כבקרת"), "kbkrt", listOf("kbkrt"))
+        check("kevakarat", listOf("kevakarat"), "kbkrt", listOf("kbkrt"))
+        check("L'Chaim", listOf("lchaim"), "lkm", listOf("lkm"))
+        check("ג'רופי", listOf("גרופי"), "grp", listOf("grp"))
+        check(
+            "Nafshi | SIMCHA LEINER | Acapella",
+            listOf("nafshi", "simcha", "leiner", "acapella"),
+            "nps smk lnr cpll",
+            listOf("nps", "smk", "lnr", "cpll"),
+        )
+        check("8th Day", listOf("8th", "day"), "8t d", listOf("8t"))
+        check("שלום עליכם", listOf("שלום", "עליכם"), "slm lkm", listOf("slm", "lkm"))
+        check("Yoni Shlomo", listOf("yoni", "shlomo"), "n slm", listOf("slm"))
+        check("MBD", listOf("mbd"), "mbd", listOf("mbd"))
+        check(
+            "Avraham Fried אברהם פריד",
+            listOf("avraham", "fried", "אברהם", "פריד"),
+            "brm prd brm prd",
+            listOf("brm", "prd", "brm", "prd"),
+        )
+    }
+
+    @Test
+    fun `damerau matches real JS`() {
+        assertEquals(1, SubsetNormalize.damerau("kbkrt", "kbkr", 2)) // one deletion
+        assertEquals(1, SubsetNormalize.damerau("abc", "acb", 2))    // adjacent transposition
+        assertEquals(1, SubsetNormalize.damerau("hello", "helo", 2))
+        assertEquals(3, SubsetNormalize.damerau("far", "xyz", 2))    // capped at max+1
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
@@ -1,0 +1,138 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Assembly-rule parity for the offline read layer ([SubsetReadLayer]) — the on-device port of the
+ * `/album`, `/home-rows` and `/zemer-playlists` handlers. Each rule is asserted deterministically
+ * over a tiny hand-built [SubsetCorpus] (no Android runtime, network or files); byte-for-byte parity vs the
+ * LIVE server over the full corpus is covered separately by the end-to-end check run during the port.
+ *
+ * Covered: album `trackNumber = pos+1` + per-track filter + header; `home_rank` ranked order + a blockVideos/female
+ * filter; curated item expansion + first-position-wins dedup + `auto-*` raw-order rank; a playlist with no
+ * surviving member hidden from the list and 404 on detail.
+ */
+class SubsetReadLayerTest {
+
+    // --- artists (id, name, thumbnail, isFemale, isChasid, isKidZone) -----------------------------
+    private val alef = SubArtist("UCa", "Alef", "ta", isFemale = false, isChasid = false, isKidZone = false)
+    private val fem = SubArtist("UCf", "Franciska", "tf", isFemale = true, isChasid = false, isKidZone = false)
+    private val kid = SubArtist("UCk", "KidStar", "tk", isFemale = false, isChasid = false, isKidZone = true)
+
+    // --- tracks (videoId, title, artistId, isVideo, explicit, durationSec, playCount, uploadDate) --
+    private val v1 = SubTrack("v1", "Song One", "UCa", false, false, 200, 100, null)
+    private val v2 = SubTrack("v2", "Song Two", "UCa", false, false, 100, 300, null)
+    private val v3 = SubTrack("v3", "No Plays", "UCa", false, false, 150, null, null)
+    private val v4 = SubTrack("v4", "A Video", "UCa", true, false, 50, 500, null)
+    private val v5 = SubTrack("v5", "Duet (feat. Franciska)", "UCa", false, false, 120, 999, null) // credited female
+
+    // --- albums (id, playlistId, title, artistId, type, year, thumbnail, uploadDate) --------------
+    private val al1 = SubAlbum("al1", "OLAK1", "Album X", "UCa", "album", 2020, "art1", null)
+    private val al2 = SubAlbum("al2", "OLAK2", "Album Y", "UCa", "album", 2022, "art2", null)
+    private val al3 = SubAlbum("al3", "OLAK3", "Single Z", "UCa", "single", 2021, "art3", null)
+    private val alf = SubAlbum("alf", null, "Fem Album", "UCf", "album", 2023, "artf", null)
+
+    private val corpus = SubsetCorpus(
+        artists = listOf(alef, fem, kid),
+        tracks = listOf(v1, v2, v3, v4, v5),
+        albums = listOf(al1, al2, al3, alf),
+        albumTracks = listOf(
+            SubAlbumTrack("al1", "v1", 0), SubAlbumTrack("al1", "v2", 1), // al1 = {v1, v2}
+            SubAlbumTrack("al2", "v3", 0), SubAlbumTrack("al2", "v4", 1), // al2 = {v3, v4(video)}
+        ),
+        artistPlaylists = emptyList(),
+        community = emptyList(),
+        communityTracks = emptyList(),
+        homeRank = listOf(
+            SubHomeRank("top-albums", "album", "al2", "UCa", 0, null),
+            SubHomeRank("top-albums", "album", "al1", "UCa", 1, null),
+            SubHomeRank("top-albums", "album", "alf", "UCf", 2, null),
+            SubHomeRank("top-videos", "video", "v4", "UCa", 0, null),
+            SubHomeRank("top-videos", "video", "v1", "UCa", 1, null), // NOT a video → skipped
+            SubHomeRank("top-artists", "artist", "UCa", null, 0, null),
+            SubHomeRank("top-artists", "artist", "UCf", null, 1, null),
+        ),
+        zemerPlaylists = listOf(
+            SubZemerPlaylist("auto-mix", "Auto Mix", 0, null),
+            SubZemerPlaylist("female-only", "Female Only", 1, null),
+        ),
+        zemerItems = listOf(
+            SubZemerItem("auto-mix", "track", "v1", 0), // direct
+            SubZemerItem("auto-mix", "album", "al1", 1), // expands to v1, v2
+            SubZemerItem("female-only", "track", "v5", 0),
+        ),
+        blocked = SubBlocked(global = emptySet(), female = emptySet()),
+    )
+
+    private val female = buildFemaleMatcher(corpus.artists)
+
+    // --- /album ---------------------------------------------------------------------------------------
+
+    @Test
+    fun `album lists members in pos order with trackNumber pos+1 and header from the artist`() {
+        val r = offlineAlbum(corpus, female, "al1", allowFemale = true, blockVideos = false, kidZone = false)!!
+        assertEquals("al1", r.album.id)
+        assertEquals("Alef", r.album.artist)
+        assertEquals(2020, r.album.year)
+        assertEquals(listOf("v1", "v2"), r.tracks.map { it.videoId })
+        assertEquals(listOf(1, 2), r.tracks.map { it.trackNumber })
+    }
+
+    @Test
+    fun `album per-track video filter drops video members when videos blocked`() {
+        // al2 = {v3 (audio), v4 (video)}; blockVideos drops v4 only, header still resolves.
+        val r = offlineAlbum(corpus, female, "al2", allowFemale = true, blockVideos = true, kidZone = false)!!
+        assertEquals(listOf("v3"), r.tracks.map { it.videoId })
+        assertEquals(listOf(1), r.tracks.map { it.trackNumber }) // v3 is pos 0 → trackNumber 1
+    }
+
+    // --- /home-rows -----------------------------------------------------------------------------------
+
+    @Test
+    fun `home rows follow home_rank order, skip non-videos, and honor filters`() {
+        val open = offlineHomeRows(corpus, female, allowFemale = true, blockVideos = false, kidZone = false)
+        assertEquals(listOf("al2", "al1", "alf"), open.topAlbums.map { it.id }) // ranked order
+        assertEquals(listOf("v4"), open.topVideos.map { it.videoId }) // v1 is not a video → dropped
+        assertEquals(listOf("UCa", "UCf"), open.topArtists.map { it.id })
+        assertEquals("UCa", open.topVideos.first().artistId) // artistId carried for the home dedup
+
+        val filtered = offlineHomeRows(corpus, female, allowFemale = false, blockVideos = true, kidZone = false)
+        assertEquals(listOf("al2", "al1"), filtered.topAlbums.map { it.id }) // female-artist album gone
+        assertTrue("blockVideos empties top-videos", filtered.topVideos.isEmpty())
+        assertEquals(listOf("UCa"), filtered.topArtists.map { it.id }) // female artist gone
+    }
+
+    // --- /zemer-playlists -----------------------------------------------------------------------------
+
+    @Test
+    fun `curated detail expands albums, dedupes first-position-wins, and ranks by raw order`() {
+        val r = offlineCuratedPlaylist(corpus, female, "auto-mix", allowFemale = true, blockVideos = false, kidZone = false)!!
+        // v1 appears directly (pos 0) AND inside al1 — kept once, at its first (direct) position.
+        assertEquals(listOf("v1", "v2"), r.tracks.map { it.videoId })
+        assertFalse("v1's kept position is the direct pick → fromAlbum=false", r.tracks[0].fromAlbum)
+        assertTrue("v2 only arrives via the album expansion → fromAlbum=true", r.tracks[1].fromAlbum)
+        // rank = 1-based position in the RAW stored track order (only the direct 'track' item, v1).
+        assertEquals(1, r.tracks[0].rank)
+        assertNull("v2 is not a raw track item → no rank", r.tracks[1].rank)
+        // the album item surfaces as a browsable row (its members serve here).
+        assertEquals(listOf("al1"), r.albums.map { it.id })
+        // card: relative cover URL + count + summed runtime.
+        assertEquals("/zemer-playlists/cover?id=auto-mix", r.playlist.thumbnail)
+        assertEquals(2, r.playlist.trackCount)
+        assertEquals(300, r.playlist.totalDurationSec)
+    }
+
+    @Test
+    fun `a playlist with no surviving member is hidden from the list and 404 on detail`() {
+        val open = offlineCuratedPlaylists(corpus, female, allowFemale = true, blockVideos = false, kidZone = false)
+        assertEquals(listOf("auto-mix", "female-only"), open.playlists.map { it.id }) // editorial order
+
+        val blocked = offlineCuratedPlaylists(corpus, female, allowFemale = false, blockVideos = false, kidZone = false)
+        assertEquals("female-only's sole member is credited-female → hidden", listOf("auto-mix"), blocked.playlists.map { it.id })
+        assertNull("and its detail is a 404", offlineCuratedPlaylist(corpus, female, "female-only", allowFemale = false, blockVideos = false, kidZone = false))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
@@ -121,7 +121,9 @@ class SubsetReadLayerTest {
         // the album item surfaces as a browsable row (its members serve here).
         assertEquals(listOf("al1"), r.albums.map { it.id })
         // card: relative cover URL + count + summed runtime.
-        assertEquals("/zemer-playlists/cover?id=auto-mix", r.playlist.thumbnail)
+        // Absolute (not the server's relative path): the offline path bypasses the client-side
+        // resolveZemerUrl pass, and Coil cannot load a schemeless URL.
+        assertEquals("https://search.zemer.io/zemer-playlists/cover?id=auto-mix", r.playlist.thumbnail)
         assertEquals(2, r.playlist.trackCount)
         assertEquals(300, r.playlist.totalDurationSec)
     }

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetReadLayerTest.kt
@@ -78,6 +78,9 @@ class SubsetReadLayerTest {
         assertEquals("al1", r.album.id)
         assertEquals("Alef", r.album.artist)
         assertEquals(2020, r.album.year)
+        // The album's own OP playlist id must ride the header — falling back to the MPRE browseId is
+        // what AlbumViewModel would persist as AlbumEntity.playlistId (dead-press radio, wrong shares).
+        assertEquals("OLAK1", r.album.playlistId)
         assertEquals(listOf("v1", "v2"), r.tracks.map { it.videoId })
         assertEquals(listOf(1, 2), r.tracks.map { it.trackNumber })
     }
@@ -136,5 +139,36 @@ class SubsetReadLayerTest {
         val blocked = offlineCuratedPlaylists(corpus, female, allowFemale = false, blockVideos = false, kidZone = false)
         assertEquals("female-only's sole member is credited-female → hidden", listOf("auto-mix"), blocked.playlists.map { it.id })
         assertNull("and its detail is a 404", offlineCuratedPlaylist(corpus, female, "female-only", allowFemale = false, blockVideos = false, kidZone = false))
+    }
+
+    // --- /artist --------------------------------------------------------------------------------------
+
+    @Test
+    fun `artist page splits songs-videos, ranks songs by play count with nulls last, albums year desc`() {
+        val r = offlineArtist(corpus, female, "UCa", allowFemale = true, blockVideos = false, kidZone = false)!!
+        assertEquals("Alef", r.artist.name)
+        // Top songs: v5 (999) > v2 (300) > v1 (100) > v3 (null plays last); v4 is a video.
+        assertEquals(listOf("v5", "v2", "v1", "v3"), r.songs.map { it.videoId })
+        assertEquals(listOf("v4"), r.videos.map { it.videoId })
+        // Albums newest-first (year desc); singles split off.
+        assertEquals(listOf("al2", "al1"), r.albums.map { it.id })
+        assertEquals(listOf("OLAK2", "OLAK1"), r.albums.map { it.playlistId })
+        assertEquals(listOf("al3"), r.singles.map { it.id })
+    }
+
+    @Test
+    fun `artist gate and featuring rule - female artist 404s and credited-female tracks drop when blocked`() {
+        // The female artist's page is a 404 under the gate...
+        assertNull(offlineArtist(corpus, female, "UCf", allowFemale = false, blockVideos = false, kidZone = false))
+        // ...and a male artist's track FEATURING a female (v5) drops from his page.
+        val r = offlineArtist(corpus, female, "UCa", allowFemale = false, blockVideos = false, kidZone = false)!!
+        assertEquals(listOf("v2", "v1", "v3"), r.songs.map { it.videoId })
+    }
+
+    @Test
+    fun `artist videos empty under blockVideos and unknown artist is a 404`() {
+        val r = offlineArtist(corpus, female, "UCa", allowFemale = true, blockVideos = true, kidZone = false)!!
+        assertTrue(r.videos.isEmpty())
+        assertNull(offlineArtist(corpus, female, "UCnope", allowFemale = true, blockVideos = false, kidZone = false))
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetSearchTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetSearchTest.kt
@@ -1,0 +1,159 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Scoring + category-assembly parity for the offline search port ([SubsetSearch] / [SubsetCategories]).
+ * The ranking laws are asserted directly against [searchIndex] over tiny hand-built indexes (so a
+ * precision-floor cut-off can't hide a ranking bug), and the content filters + category split are asserted
+ * end-to-end through [offlineSearch] over a small hand-built [SubsetCorpus]. Deterministic; no Android
+ * runtime, network or files. (Cross-language byte parity vs the LIVE server is covered separately by the
+ * full-corpus end-to-end check run during the port.)
+ */
+class SubsetSearchTest {
+
+    /** Minimal [SearchDoc] for the pure-ranking assertions. */
+    private data class Doc(
+        override val title: String,
+        override val artistName: String,
+        override val sortId: String,
+    ) : SearchDoc
+
+    private fun index(vararg docs: Doc) = buildSubsetIndex(docs.toList())
+
+    // --- ranking laws (search.mjs) ----------------------------------------------------------------
+
+    @Test
+    fun `exact-title match outranks a fuzzy (typo) match`() {
+        val exact = Doc(title = "Hallelujah", artistName = "Miami Boys Choir", sortId = "aaaaaaaaaaa")
+        val fuzzy = Doc(title = "Hallelujeh", artistName = "Miami Boys Choir", sortId = "bbbbbbbbbbb") // 1-edit typo
+        val hits = searchIndex(index(exact, fuzzy), "hallelujah", 10)
+        assertEquals(2, hits.size)
+        assertEquals("aaaaaaaaaaa", hits[0].doc.sortId) // exact first
+        assertTrue("exact must score strictly above fuzzy", hits[0].score > hits[1].score)
+    }
+
+    @Test
+    fun `artist affinity (origCount ge 2) lifts a track BY the searched artist above a title-only match`() {
+        // `byArtist` only CONTAINS the query in its artist name (begins with "The"), so without the
+        // multi-word ARTIST_AFFINITY bonus the title-exact `titleHit` (+2.0 boost) would win. Affinity flips it.
+        val byArtist = Doc(title = "Achas", artistName = "The Simcha Leiner Band", sortId = "by000000000")
+        val titleHit = Doc(title = "Simcha Leiner", artistName = "Someone Else", sortId = "ti000000000")
+        val hits = searchIndex(index(byArtist, titleHit), "simcha leiner", 10)
+        assertEquals("by000000000", hits.first().doc.sortId)
+        val byScore = hits.first { it.doc.sortId == "by000000000" }.score
+        val tiScore = hits.first { it.doc.sortId == "ti000000000" }.score
+        assertTrue("affinity must lift the by-artist track above the title-only match", byScore > tiScore)
+    }
+
+    @Test
+    fun `precision floor drops a weak hit that still clears the coverage gate`() {
+        val strong = Doc(title = "Shalom", artistName = "Miami Boys Choir", sortId = "strong00000")
+        val weak = Doc(title = "Shabom", artistName = "Miami Boys Choir", sortId = "weak0000000") // fuzzy-only, no boosts
+        val hits = searchIndex(index(strong, weak), "shalom", 10)
+        // `weak` matches (coverage 1 >= need 1) but scores below REL_FLOOR * top, so it is cut.
+        assertEquals(1, hits.size)
+        assertEquals("strong00000", hits[0].doc.sortId)
+    }
+
+    // --- content filters + category assembly (categories.mjs + api.mjs /search) --------------------
+
+    // female primary
+    private val fem = SubArtist("a_fem", "Franciska", null, isFemale = true, isChasid = false, isKidZone = false)
+    private val leiner = SubArtist("a_leiner", "Simcha Leiner", null, isFemale = false, isChasid = false, isKidZone = false)
+    private val miami = SubArtist("a_miami", "Miami Boys Choir", null, isFemale = false, isChasid = false, isKidZone = false)
+    private val kids = SubArtist("a_kids", "KidZone Singers", null, isFemale = false, isChasid = false, isKidZone = true)
+
+    private fun track(videoId: String, title: String, artistId: String, isVideo: Boolean = false) =
+        SubTrack(videoId, title, artistId, isVideo = isVideo, explicit = false, durationSec = 100, playCount = null, uploadDate = null)
+
+    private fun album(id: String, title: String, type: String) =
+        SubAlbum(id, playlistId = null, title = title, artistId = "a_miami", type = type, year = 2020, thumbnail = null, uploadDate = null)
+
+    private val corpus = SubsetCorpus(
+        artists = listOf(fem, leiner, miami, kids),
+        tracks = listOf(
+            track("song_femm00", "Kol Isha", "a_fem"),                 // female primary
+            track("song_feat00", "Kol Shiru (feat. Franciska)", "a_leiner"), // male primary, female credited -> involved
+            track("song_male00", "Kol Nidrei", "a_miami"),
+            track("song_kid000", "Kol Sasson", "a_kids"),               // KidZone
+            track("video_vid00", "Kol Live", "a_miami", isVideo = true), // a VIDEO
+        ),
+        albums = listOf(
+            album("MPREb_albm00", "Zbumba", "album"),
+            album("MPREb_sngl00", "Zbumba", "single"),
+        ),
+        albumTracks = emptyList(),
+        artistPlaylists = emptyList(),
+        community = emptyList(),
+        communityTracks = emptyList(),
+        homeRank = emptyList(),
+        zemerPlaylists = emptyList(),
+        zemerItems = emptyList(),
+        blocked = SubBlocked(emptySet(), emptySet()),
+    )
+    private val matcher = buildFemaleMatcher(corpus.artists)
+
+    private fun songIds(allowFemale: Boolean = true, blockVideos: Boolean = false, kidZone: Boolean = false) =
+        offlineSearch(corpus, matcher, "kol", 8, allowFemale, blockVideos, kidZone).categories.songs.map { it.videoId }.toSet()
+
+    private fun videoIds(allowFemale: Boolean = true, blockVideos: Boolean = false, kidZone: Boolean = false) =
+        offlineSearch(corpus, matcher, "kol", 8, allowFemale, blockVideos, kidZone).categories.videos.map { it.videoId }.toSet()
+
+    @Test
+    fun `song vs video split routes tracks by isVideo`() {
+        assertTrue("audio track is a song", "song_male00" in songIds())
+        assertFalse("a video is never in songs", "video_vid00" in songIds())
+        assertEquals("the video is in videos", setOf("video_vid00"), videoIds())
+    }
+
+    @Test
+    fun `album vs single split routes by type`() {
+        val cats = offlineSearch(corpus, matcher, "zbumba", 8, allowFemale = true, blockVideos = false, kidZone = false).categories
+        assertEquals(setOf("MPREb_albm00"), cats.albums.map { it.id }.toSet())
+        assertEquals(setOf("MPREb_sngl00"), cats.singles.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `allowFemale=false drops female-primary AND female-credited tracks`() {
+        val open = songIds(allowFemale = true)
+        assertTrue("Kol Isha present when female allowed", "song_femm00" in open)
+        assertTrue("feat. Franciska present when female allowed", "song_feat00" in open)
+
+        val blocked = songIds(allowFemale = false)
+        assertFalse("female primary dropped", "song_femm00" in blocked)
+        assertFalse("female-credited (feat.) dropped", "song_feat00" in blocked)
+        assertTrue("male track survives", "song_male00" in blocked)
+    }
+
+    @Test
+    fun `kidZone keeps only KidZone artists across every category`() {
+        assertEquals(setOf("song_kid000"), songIds(kidZone = true))
+        assertTrue("non-KidZone video is dropped under kidZone", videoIds(kidZone = true).isEmpty())
+    }
+
+    @Test
+    fun `blockVideos empties the videos category and leaves songs intact`() {
+        assertTrue("videos empty under blockVideos", videoIds(blockVideos = true).isEmpty())
+        assertTrue("songs unaffected by blockVideos", "song_male00" in songIds(blockVideos = true))
+    }
+
+    @Test
+    fun `coverage gate drops a hit that matches too few query words`() {
+        val hi = track("cov_high000", "Aleph Beis Gimel", "a_miami")
+        val lo = track("cov_low0000", "Gimel", "a_miami") // matches only 1 of 3 words -> cov < need(2)
+        val c = SubsetCorpus(
+            artists = listOf(miami), tracks = listOf(hi, lo), albums = emptyList(), albumTracks = emptyList(),
+            artistPlaylists = emptyList(), community = emptyList(), communityTracks = emptyList(),
+            homeRank = emptyList(), zemerPlaylists = emptyList(), zemerItems = emptyList(),
+            blocked = SubBlocked(emptySet(), emptySet()),
+        )
+        val songs = offlineSearch(c, buildFemaleMatcher(c.artists), "aleph beis gimel", 8, allowFemale = true, blockVideos = false, kidZone = false)
+            .categories.songs.map { it.videoId }.toSet()
+        assertTrue("full-coverage hit kept", "cov_high000" in songs)
+        assertFalse("single-word hit dropped by the coverage gate", "cov_low0000" in songs)
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetStoreStagingTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetStoreStagingTest.kt
@@ -1,0 +1,74 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The staged-commit contract: a sync stages every downloaded shard without touching the live copy and
+ * promotes only after ALL downloads verified, so a failure partway can never leave a mixed-version
+ * corpus on disk — plus the read-time hash check that guards the residual window.
+ */
+class SubsetStoreStagingTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun store() = SubsetStore(tmp.root)
+
+    @Test
+    fun `staging leaves the live shard untouched until promotion`() {
+        val s = store()
+        s.writeShard("tracks-0", byteArrayOf(1))
+        s.stageShard("tracks-0", byteArrayOf(2))
+
+        assertArrayEquals(byteArrayOf(1), s.shardBytes("tracks-0"))
+
+        s.promoteStagedShard("tracks-0")
+        assertArrayEquals(byteArrayOf(2), s.shardBytes("tracks-0"))
+    }
+
+    @Test
+    fun `clearStaged removes leftovers and keeps live shards`() {
+        val s = store()
+        s.writeShard("tracks-0", byteArrayOf(1))
+        s.stageShard("tracks-0", byteArrayOf(2))
+        s.stageShard("albums-0", byteArrayOf(3))
+
+        s.clearStaged()
+
+        assertArrayEquals(byteArrayOf(1), s.shardBytes("tracks-0"))
+        assertNull("staged-only shard must not become live", s.shardBytes("albums-0"))
+    }
+
+    @Test
+    fun `staged files are invisible to sizeOnDisk and pruneOrphans`() {
+        val s = store()
+        s.writeShard("tracks-0", byteArrayOf(1, 2, 3))
+        s.stageShard("albums-0", ByteArray(100))
+
+        assertEquals(3L, s.sizeOnDisk())
+        s.pruneOrphans(keep = setOf("tracks-0"))
+        s.promoteStagedShard("albums-0")
+        assertArrayEquals("prune must not delete a pending staged file", ByteArray(100), s.shardBytes("albums-0"))
+    }
+
+    @Test
+    fun `loadCorpus refuses a shard whose bytes do not match the committed manifest`() {
+        val s = store()
+        val bytes = byteArrayOf(9, 9, 9)
+        s.writeShard("artists", bytes)
+        s.commitManifest(
+            SubsetManifest(
+                v = 1,
+                builtAt = "2026-07-29T00:00:00Z",
+                shards = listOf(SubsetShard("artists", hash = "0000000000000000", bytes = bytes.size.toLong())),
+            ),
+        )
+
+        assertNull("mixed/corrupt shard must read as no-snapshot", SubsetDecoder.loadCorpus(s))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/offline/SubsetSyncTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/offline/SubsetSyncTest.kt
@@ -1,0 +1,72 @@
+package com.jtech.zemer.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the pure core of the offline-subset sync: the content-addressed diff that decides what to
+ * download vs delete, the shard hash the verification depends on, and the shard-name validation that
+ * keeps a server-supplied name from escaping the store directory.
+ */
+class SubsetSyncTest {
+
+    private fun shard(name: String, hash: String) = SubsetShard(name, hash, bytes = 1)
+    private fun manifest(v: Int, vararg shards: SubsetShard) = SubsetManifest(v, "2026-07-27T00:00:00Z", shards.toList())
+
+    @Test
+    fun `no local manifest downloads every shard and deletes nothing`() {
+        val remote = manifest(1, shard("tracks-0", "aaa"), shard("artists", "bbb"))
+        val plan = subsetSyncPlan(local = null, remote = remote)
+        assertEquals(listOf("tracks-0", "artists"), plan.toDownload.map { it.name })
+        assertTrue(plan.toDelete.isEmpty())
+        assertFalse(plan.isNoOp)
+    }
+
+    @Test
+    fun `identical manifests are a no-op`() {
+        val m = manifest(2, shard("tracks-0", "aaa"), shard("artists", "bbb"))
+        val plan = subsetSyncPlan(local = m, remote = m)
+        assertTrue(plan.toDownload.isEmpty())
+        assertTrue(plan.toDelete.isEmpty())
+        assertTrue(plan.isNoOp)
+    }
+
+    @Test
+    fun `only the changed shard is re-downloaded`() {
+        val local = manifest(1, shard("tracks-0", "aaa"), shard("artists", "bbb"))
+        val remote = manifest(2, shard("tracks-0", "aaa"), shard("artists", "ZZZ"))
+        val plan = subsetSyncPlan(local, remote)
+        assertEquals(listOf("artists"), plan.toDownload.map { it.name })
+        assertTrue(plan.toDelete.isEmpty())
+    }
+
+    @Test
+    fun `a shard dropped from the remote manifest is deleted, a new one is downloaded`() {
+        val local = manifest(1, shard("tracks-0", "aaa"), shard("legacy", "bbb"))
+        val remote = manifest(2, shard("tracks-0", "aaa"), shard("community", "ccc"))
+        val plan = subsetSyncPlan(local, remote)
+        assertEquals(listOf("community"), plan.toDownload.map { it.name })
+        assertEquals(listOf("legacy"), plan.toDelete)
+    }
+
+    @Test
+    fun `shard hash is the first 16 hex chars of sha256 over the raw bytes`() {
+        // Known SHA-256 vectors: sha256("") and sha256("abc").
+        assertEquals("e3b0c44298fc1c14", subsetShardHash(ByteArray(0)))
+        assertEquals("ba7816bf8f01cfea", subsetShardHash("abc".toByteArray()))
+    }
+
+    @Test
+    fun `shard names are validated to prevent path traversal`() {
+        assertTrue(isValidShardName("tracks-0"))
+        assertTrue(isValidShardName("albumtracks-15"))
+        assertTrue(isValidShardName("community"))
+        assertFalse(isValidShardName("../secrets"))
+        assertFalse(isValidShardName("Tracks"))      // uppercase
+        assertFalse(isValidShardName("a b"))          // space
+        assertFalse(isValidShardName("a_b"))          // underscore
+        assertFalse(isValidShardName(""))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt
@@ -1,11 +1,13 @@
 package com.jtech.zemer.search
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.io.IOException
+import java.nio.channels.UnresolvedAddressException
 
 /**
  * The offline-fallback routing policy ([serverOrOffline]): server-first, fall back to the on-device
@@ -48,5 +50,32 @@ class ZemerSearchRoutingTest {
         val r = serverOrOffline<String?>(server = { null }, offline = { offlineCalled = true; "x" })
         assertEquals(null, r)
         assertFalse(offlineCalled)
+    }
+
+    @Test
+    fun `falls back on UnresolvedAddressException - Ktor CIO's no-network signal`() = runBlocking {
+        // Airplane mode / dead DNS surfaces as UnresolvedAddressException (an IllegalArgumentException,
+        // NOT an IOException) — the feature's flagship scenario must trigger the fallback.
+        val r = serverOrOffline<String>(
+            server = { throw UnresolvedAddressException() },
+            offline = { "offline" },
+        )
+        assertEquals("offline", r)
+    }
+
+    @Test
+    fun `rethrows UnresolvedAddressException when there is no snapshot`() {
+        assertThrows(UnresolvedAddressException::class.java) {
+            runBlocking { serverOrOffline<String>(server = { throw UnresolvedAddressException() }, offline = { null }) }
+        }
+    }
+
+    @Test
+    fun `cancellation propagates - never swallowed into the fallback`() {
+        assertThrows(CancellationException::class.java) {
+            runBlocking {
+                serverOrOffline<String>(server = { throw CancellationException("cancelled") }, offline = { "offline" })
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt
@@ -1,0 +1,52 @@
+package com.jtech.zemer.search
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * The offline-fallback routing policy ([serverOrOffline]): server-first, fall back to the on-device
+ * snapshot ONLY when the server is unreachable (an [IOException]) and the snapshot has an answer.
+ */
+class ZemerSearchRoutingTest {
+
+    @Test
+    fun `server result is used when the server succeeds`() = runBlocking {
+        var offlineCalled = false
+        val r = serverOrOffline(server = { "server" }, offline = { offlineCalled = true; "offline" })
+        assertEquals("server", r)
+        assertFalse("offline must not be consulted when the server answers", offlineCalled)
+    }
+
+    @Test
+    fun `falls back to the snapshot when the server is unreachable`() = runBlocking {
+        val r = serverOrOffline<String>(server = { throw IOException("unreachable") }, offline = { "offline" })
+        assertEquals("offline", r)
+    }
+
+    @Test
+    fun `rethrows the network error when there is no snapshot`() {
+        val e = assertThrows(IOException::class.java) {
+            runBlocking { serverOrOffline<String>(server = { throw IOException("unreachable") }, offline = { null }) }
+        }
+        assertEquals("unreachable", e.message)
+    }
+
+    @Test
+    fun `a non-network failure is never masked by the fallback`() {
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking { serverOrOffline<String>(server = { throw IllegalStateException("bug") }, offline = { "offline" }) }
+        }
+    }
+
+    @Test
+    fun `a legitimate null (e-g- a 404) is returned as-is, offline never consulted`() = runBlocking {
+        var offlineCalled = false
+        val r = serverOrOffline<String?>(server = { null }, offline = { offlineCalled = true; "x" })
+        assertEquals(null, r)
+        assertFalse(offlineCalled)
+    }
+}


### PR DESCRIPTION
A **fallback for a brief Zemer-server outage** — not a general offline mode. Requests still go to `search.zemer.io` first; only when it's unreachable does the app fall back to a downloaded on-device copy of the catalog so **search and browse keep working until the server is back**. Playback is unaffected either way (streaming stays InnerTube + the cipher, out of scope).

This is a faithful, **verified** Kotlin port of the zemer-search read layer, built in reviewable layers.

## What the backup covers (only while the server is down)
`/search` (full Hebrew-aware matcher), `/artist`, `/album`, `/home-rows` (incl. the community row), and `/zemer-playlists` (list + detail).

**Always live / never from the backup:** everything works normally when the server is up (server-first). `/playlist` and `/radio` are never reproduced locally (radio needs the co-occurrence graph, not shipped); the `/new` live feed, curated chart-movement badges, and server-rendered SVG covers are also live-only.

## Layers (each committed + tested)
1. **Sync engine** — downloads the manifest, diffs shards by content hash (`sha256(gz)[:16]`), fetches only changed shards, **stages every download and promotes only after all verify** (a failure partway can never leave a mixed-version corpus), prunes dropped ones, commits the manifest last (crash-safe; shard hashes are also re-verified at read time). Opt-in gated; failure is logged, never a crash, and leaves the prior copy intact. **Enabled = mandatory freshness: daily auto-update on ANY connection** (no Wi-Fi-only gate — incremental diffs are small), running on the syncer's own scope so leaving the screen never cancels a download.
2. **Shard decoders + in-memory corpus** — the gzipped shards → the SQLite tables the reads run over; schema pinned to real sample rows, with a manifest `schema` generation guard (cipher precedent: an unknown wire format is rejected wholesale, last-good snapshot kept).
3. **The read layer** — ports `normalize.mjs` (Hebrew consonant-skeleton transliteration), `credits.mjs`/`synonyms.mjs` (female detection + query expansion), `search.mjs`/`categories.mjs` (the scoring engine), and the `/album`/`/home-rows`/`/zemer-playlists` read functions — all over the in-memory corpus, returning the **same response models** the app decodes from the server, so a fallback response is consumed identically to a live one.
4. **Routing + auto-update + UI** — `ZemerSearchRepository` is **server-first with fallback only on network failure** (`IOException` *and* `UnresolvedAddressException`, Ktor CIO's no-network signal); a daily background refresh keeps the copy fresh; a **Settings → "Search backup"** screen opts in, shows size/last-updated, and downloads/updates on demand.

## Kosher defenses on the snapshot
- **14-day staleness cap** — a device that can't sync must not serve an ever-aging copy.
- **Live-whitelist overlay at corpus load** — the minutes-fresh Firestore-synced whitelist overrides the shard flags: de-whitelisted artists are dropped with every referencing row, and `isFemale` is taken from the live flag, so an admin change lands offline the moment the app's whitelist sync does, not on the next snapshot download.
- The surgical blocked-id overrides (`dropBlocked`) apply to fallback responses exactly as to live ones (shared mapper).

## Discovery before the first outage
- **Onboarding step** (new users): "Download a backup" (pre-selected) vs "Not now" — enable starts the download right there; declining also silences the promo below.
- **One-time promo card** above Zemer search results (existing installs): "Set up" deep-links to the settings screen, "Not now" dismisses permanently.

## Verification
- **The normalizer + female/synonyms + search + read endpoints are verified against the real server**: parity tests whose expected values were produced by running the actual JS, and an end-to-end diff of the ported read layer against captured live `/search`, `/album`, `/home-rows`, and `/zemer-playlists` responses over the same corpus build — every id-pinned endpoint matched **exactly** (id-set + order). The one numeric delta (a dynamic year-playlist count) is benign catalog drift between the snapshot build and the live capture.
- Committable unit tests cover the sync diff/hash/path-traversal guard, the staging contract + read-time hash refusal, every shard decoder, the normalizer, female/synonyms, the search scoring/filter laws, the read-endpoint assembly rules, the fallback routing policy (incl. `UnresolvedAddressException` and cancellation), the live-whitelist overlay cascade + freshness gate, and the search-LRU rule that only server responses are memoized.
- Debug build, **release (R8)**, `ui-audit`, `check-dead-resources`, `check-download-unification`, and the full unit suite: green.

## Not in this PR (tracked)
- The enriched `ZemerTrack`/`ZemerAlbum` fields (playCount, releaseDate, trackCount, totalDurationSec) — the current wire models don't carry them, so the offline `/artist`/`/album` responses (like the server path on this branch) omit them.
- Serving the local copy *while the server is up* (to offload it) — a perf optimization on top of this outage-fallback; deferred to avoid stale-while-online risk.

