### PR TITLE
fix(playback): stop the post-boot media notification by gating queue restore on user intent

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -581,54 +581,6 @@ class MusicService :
                 }
         }
 
-        if (dataStore.get(PersistentQueueKey, true)) {
-            runCatching {
-                filesDir.resolve(PERSISTENT_QUEUE_FILE).inputStream().use { fis ->
-                    ObjectInputStream(fis).use { oos ->
-                        oos.readObject() as PersistQueue
-                    }
-                }
-            }.onSuccess { queue ->
-                // Convert back to proper queue type
-                val restoredQueue = queue.toQueue()
-                playQueue(
-                    queue = restoredQueue,
-                    playWhenReady = false,
-                )
-            }
-            runCatching {
-                filesDir.resolve(PERSISTENT_AUTOMIX_FILE).inputStream().use { fis ->
-                    ObjectInputStream(fis).use { oos ->
-                        oos.readObject() as PersistQueue
-                    }
-                }
-            }.onSuccess { queue ->
-                automixItems.value = queue.items.map { it.toMediaItem() }
-            }
-
-            // Restore player state
-            runCatching {
-                filesDir.resolve(PERSISTENT_PLAYER_STATE_FILE).inputStream().use { fis ->
-                    ObjectInputStream(fis).use { oos ->
-                        oos.readObject() as PersistPlayerState
-                    }
-                }
-            }.onSuccess { playerState ->
-                // Restore player settings after queue is loaded
-                scope.launch {
-                    delay(1000) // Wait for queue to be loaded
-                    player.repeatMode = playerState.repeatMode
-                    player.shuffleModeEnabled = playerState.shuffleModeEnabled
-                    player.volume = playerState.volume
-
-                    // Restore position if it's still valid
-                    if (playerState.currentMediaItemIndex < player.mediaItemCount) {
-                        player.seekTo(playerState.currentMediaItemIndex, playerState.currentPosition)
-                    }
-                }
-            }
-        }
-
         // Save queue periodically to prevent queue loss from crash or force kill
         scope.launch {
             while (isActive) {
@@ -1956,6 +1908,74 @@ class MusicService :
         }
     }
 
+
+    // Set once the persisted-queue restore has RUN (not merely been offered): a skipped scanner
+    // connection must leave the restore available to the next real caller.
+    private var persistedQueueRestored = false
+
+    /**
+     * Restores the persisted queue / automix / player state the first time a USER-intent connection
+     * arrives (gate: [shouldRestorePersistedQueue]). This ran unconditionally from [onCreate] until
+     * the reboot follow-up on issue #109: after a reboot, SystemUI's media-resumption scanner binds
+     * the exported browse service with no user present, and the eager restore loaded the player and
+     * made media3 resurrect the media notification (+ launcher badge). Every real connection (the
+     * in-app binder, media controllers, explicit start commands from widget taps / media buttons)
+     * still restores through the exact same [playQueue] call as before. Main-thread only (player
+     * access) — every call site is a service entry point.
+     */
+    private fun maybeRestorePersistedQueue(callerPackage: String?) {
+        if (persistedQueueRestored || !shouldRestorePersistedQueue(callerPackage)) return
+        persistedQueueRestored = true
+        if (player.mediaItemCount > 0) return // a live queue must never be clobbered by the restore
+        if (dataStore.get(PersistentQueueKey, true)) {
+            runCatching {
+                filesDir.resolve(PERSISTENT_QUEUE_FILE).inputStream().use { fis ->
+                    ObjectInputStream(fis).use { oos ->
+                        oos.readObject() as PersistQueue
+                    }
+                }
+            }.onSuccess { queue ->
+                // Convert back to proper queue type
+                val restoredQueue = queue.toQueue()
+                playQueue(
+                    queue = restoredQueue,
+                    playWhenReady = false,
+                )
+            }
+            runCatching {
+                filesDir.resolve(PERSISTENT_AUTOMIX_FILE).inputStream().use { fis ->
+                    ObjectInputStream(fis).use { oos ->
+                        oos.readObject() as PersistQueue
+                    }
+                }
+            }.onSuccess { queue ->
+                automixItems.value = queue.items.map { it.toMediaItem() }
+            }
+
+            // Restore player state
+            runCatching {
+                filesDir.resolve(PERSISTENT_PLAYER_STATE_FILE).inputStream().use { fis ->
+                    ObjectInputStream(fis).use { oos ->
+                        oos.readObject() as PersistPlayerState
+                    }
+                }
+            }.onSuccess { playerState ->
+                // Restore player settings after queue is loaded
+                scope.launch {
+                    delay(1000) // Wait for queue to be loaded
+                    player.repeatMode = playerState.repeatMode
+                    player.shuffleModeEnabled = playerState.shuffleModeEnabled
+                    player.volume = playerState.volume
+
+                    // Restore position if it's still valid
+                    if (playerState.currentMediaItemIndex < player.mediaItemCount) {
+                        player.seekTo(playerState.currentMediaItemIndex, playerState.currentPosition)
+                    }
+                }
+            }
+        }
+    }
+
     private fun saveQueueToDisk() {
         if (player.mediaItemCount == 0) {
             return
@@ -2047,6 +2067,10 @@ class MusicService :
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Explicit start commands are user actions (widget taps, media buttons) — the boot scanner
+        // BINDS, it never startService()s — so a dead-service widget/button press still finds the
+        // restored queue, exactly as when the restore lived in onCreate().
+        maybeRestorePersistedQueue(packageName)
         when (intent?.action) {
             MusicWidget.ACTION_PLAY_PAUSE -> {
                 if (discoveryHandler.isConnected) {
@@ -2073,7 +2097,12 @@ class MusicService :
         return super.onStartCommand(intent, flags, startId)
     }
 
-    override fun onBind(intent: Intent?) = super.onBind(intent) ?: binder
+    // The custom-binder path is the app's own PlayerConnection (media3 controllers take the
+    // super.onBind branch and land in onGetSession) — always user intent, restore before returning
+    // the binder so the UI sees the queue exactly as when the restore lived in onCreate().
+    override fun onBind(intent: Intent?) = super.onBind(intent) ?: binder.also {
+        maybeRestorePersistedQueue(packageName)
+    }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         // Issue #109: when "stop music on task clear" is enabled, swiping the app away from recents
@@ -2096,7 +2125,13 @@ class MusicService :
         super.onTaskRemoved(rootIntent)
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaSession
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession {
+        // Every media3 controller funnels through here with its identity — restore for all of them
+        // (Auto, Bluetooth/headset, third parties) except the post-boot SystemUI resumption scan,
+        // which must find an empty player so no media notification is resurrected (issue #109).
+        maybeRestorePersistedQueue(controllerInfo.packageName)
+        return mediaSession
+    }
 
     inner class MusicBinder : Binder() {
         val service: MusicService

--- a/app/src/main/kotlin/com/jtech/zemer/playback/QueueRestoreGate.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/QueueRestoreGate.kt
@@ -1,0 +1,21 @@
+package com.jtech.zemer.playback
+
+/**
+ * Issue #109 (reboot follow-up): connections from these callers must NOT trigger the persisted-queue
+ * restore. After boot, SystemUI's media-resumption scanner binds the exported browse service with no
+ * user in the loop; eagerly restoring for it loads the player and makes media3 resurrect the media
+ * notification (+ launcher badge) on a phone nobody touched. An OEM skin that renames its SystemUI
+ * package can be appended here — a data-only change.
+ */
+internal val QUEUE_RESTORE_SKIPPED_CALLERS = setOf(
+    "com.android.systemui",
+)
+
+/**
+ * Whether a service connection counts as USER intent for restoring the persisted queue. Every real
+ * controller — the app's own UI, Android Auto, Bluetooth/headset, third-party controllers — passes
+ * and restores exactly as before; the boot scanner (and an anonymous null caller) is the only thing
+ * that gets an empty player. Pure + top-level so the gate is unit-tested without an Android runtime.
+ */
+internal fun shouldRestorePersistedQueue(callerPackage: String?): Boolean =
+    callerPackage != null && callerPackage !in QUEUE_RESTORE_SKIPPED_CALLERS

--- a/app/src/test/kotlin/com/jtech/zemer/playback/QueueRestoreGateTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/QueueRestoreGateTest.kt
@@ -1,0 +1,31 @@
+package com.jtech.zemer.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The issue #109 reboot gate: the post-boot SystemUI media-resumption scan must NOT trigger the
+ * persisted-queue restore (an eager restore resurrects the media notification on a phone nobody
+ * touched), while every real controller keeps restoring exactly as before.
+ */
+class QueueRestoreGateTest {
+
+    @Test
+    fun `the boot-time SystemUI resumption scanner never restores`() {
+        assertFalse(shouldRestorePersistedQueue("com.android.systemui"))
+    }
+
+    @Test
+    fun `an anonymous caller never restores`() {
+        assertFalse(shouldRestorePersistedQueue(null))
+    }
+
+    @Test
+    fun `every real controller restores - own app, Auto, Bluetooth, third parties`() {
+        assertTrue(shouldRestorePersistedQueue("com.jtech.zemer"))
+        assertTrue(shouldRestorePersistedQueue("com.google.android.projection.gearhead"))
+        assertTrue(shouldRestorePersistedQueue("com.android.bluetooth"))
+        assertTrue(shouldRestorePersistedQueue("com.example.some.controller"))
+    }
+}


### PR DESCRIPTION
Follow-up for the reopened #109: after a phone restart the media notification (and a launcher badge) reappeared with the app never opened.

## Cause
`MusicService.onCreate()` restored the persisted queue unconditionally, so *any* service creation loaded the player and made media3 post the notification. After boot, SystemUI's media-resumption scanner binds the exported browse service (declared for Android Auto) with no user in the loop - service created, queue loaded, notification resurrected.

## Fix (boot fix only, nothing else affected)
The restore moves from creation to the first **user-intent** connection, through the exact same `playQueue(restored, playWhenReady = false)` call as before:
- **In-app binder** (opening the app): unchanged UX, paused queue present.
- **Any media3 controller** via `onGetSession` - Android Auto, Bluetooth/headset, third parties - all unchanged. The one exception is `com.android.systemui` (the boot scanner, the only caller that is never a user). OEM scanners that rename SystemUI are a data-only addition to the skip set.
- **Any explicit start command** (widget taps, media buttons) - the scanner only binds, it never `startService()`s.

Safety properties: the restored flag is set only when the restore actually runs, so a skipped scanner bind leaves it available to the next real caller; a live queue is never clobbered by a late restore; `saveQueueToDisk`'s existing `mediaItemCount == 0` guard means a scanner-created empty service can never overwrite the saved queue file. No setting added, `onPlaybackResumption` untouched, "Stop music on task clear" untouched.

## Testing
The gate is a pure function with JVM tests (`QueueRestoreGateTest`). Full unit suite, debug + release (R8) builds, and ui-audit green. The reboot scenario needs on-device verification:
1. Play something, reboot the phone: no notification, no badge.
2. Open the app: last queue present, paused.
3. With the service dead: widget play tap and headset play button still work.
4. Android Auto connect: unchanged.

Refs #109.