### PR TITLE
feat(stations): Zemer Stations - synchronized broadcast radio (Zemer Radio row, StationQueue, LIVE treatment)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,15 +225,24 @@ only. Rules that must not regress:
 **Zemer Stations** (`playback/queues/StationQueue`, the "Zemer Radio" home row) are the OTHER radio
 product: one shared, server-programmed wall-clock schedule per station — every listener hears the
 same track at the same moment (contract: `~/zemer-fix/handoff-docs/zemer-app-stations.md`). Rules
-that must not regress: join at the live offset (`stationJoinPositionMs` + the start-at-0 negative
-case), drift corrections at track BOUNDARIES only (never mid-track), **pause = stop, resume =
-rejoin live** (`resyncStationOnResume`), a broadcast is NEVER persisted (`saveQueueToDisk` guard),
-the session player masks all skip/seek commands while a station plays (`CastAwarePlayer.
-maskTransportForStation` — notification/Auto/Bluetooth get play/stop only) and the in-app UI swaps
-the seek slider for the read-only LIVE bar; no content flags are sent (pools are pre-filtered
-server-side; blocked-ids still run client-side as the third layer); an unstreamable slot skips and
-rejoins the wall clock, and the zero-play-time guard keeps it out of the play stats; every station
-play tags `station:<id>`.
+that must not regress: ALL drift funnels through the BIDIRECTIONAL `resyncStationPlayback` (seek
+forward when behind, WAIT — pause until startMs — when ahead, full re-tune when nothing queued is
+on-air; never a mid-track jump, never a backward seek into a played/unplayable slot), invoked from
+boundaries, pause-resume, error skips and STATE_ENDED; **pause = stop, resume = rejoin live**; a
+broadcast is NEVER persisted (`saveQueueToDisk` guard) and a queue MUTATION (Play next / Add to
+queue) EXITS broadcast mode (`exitStationOnQueueMutation` — without it station state latches and
+queue persistence dies for the process); the session player masks all skip/seek/repeat/shuffle
+commands AND no-ops them against stale controllers, notifying command changes on every mask flip
+(`CastAwarePlayer.maskTransportForStation`/`notifyStationMaskChanged`); every raw-player transport
+surface (mini-player swipes, queue-sheet taps, lyrics buttons, the widget's onStartCommand skips,
+repeat/shuffle toggles) is gated on `isStationBroadcast`, and `PlayerConnection.seekTo/Next/
+Previous` early-return during a broadcast; the station runway top-up ignores the Auto-load-more
+preference and repeat is forced OFF at station start; station items map through
+`ZemerResultMapper.toSongItem` (coverless slots get the derived artwork fallback); the row's
+now-playing ticker is LIFECYCLE-scoped (`repeatOnLifecycle(RESUMED)` — nothing polls while
+backgrounded); no content flags are sent (pools pre-filtered server-side; blocked-ids still run
+client-side as the third layer); a failed slot is marked unplayable and produces no play event
+(zero-play-time guard); every station play tags `PlaySource.station(id)`.
 
 ### Corpus-native artist/album opens (no InnerTube fallback)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,19 @@ only. Rules that must not regress:
 - Tracking: radio fill reports as `radio` (`initialItemsAreContext = false`,
   `continuationIsContext = false`); the preloaded seed is the one user-chosen context item.
 
+**Zemer Stations** (`playback/queues/StationQueue`, the "Zemer Radio" home row) are the OTHER radio
+product: one shared, server-programmed wall-clock schedule per station — every listener hears the
+same track at the same moment (contract: `~/zemer-fix/handoff-docs/zemer-app-stations.md`). Rules
+that must not regress: join at the live offset (`stationJoinPositionMs` + the start-at-0 negative
+case), drift corrections at track BOUNDARIES only (never mid-track), **pause = stop, resume =
+rejoin live** (`resyncStationOnResume`), a broadcast is NEVER persisted (`saveQueueToDisk` guard),
+the session player masks all skip/seek commands while a station plays (`CastAwarePlayer.
+maskTransportForStation` — notification/Auto/Bluetooth get play/stop only) and the in-app UI swaps
+the seek slider for the read-only LIVE bar; no content flags are sent (pools are pre-filtered
+server-side; blocked-ids still run client-side as the third layer); an unstreamable slot skips and
+rejoins the wall clock, and the zero-play-time guard keeps it out of the play stats; every station
+play tags `station:<id>`.
+
 ### Corpus-native artist/album opens (no InnerTube fallback)
 
 Artist (`/artist`) and album (`/album`) screens load purely from the Zemer server

--- a/app/src/main/kotlin/com/jtech/zemer/playback/CastAwarePlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/CastAwarePlayer.kt
@@ -26,6 +26,16 @@ class CastAwarePlayer(
     scope: CoroutineScope,
 ) : ForwardingPlayer(player) {
     private val casting: Boolean get() = discoveryHandler.isConnected
+
+    /**
+     * Station broadcast transport mask (handoff par. 5: play/stop only). While a [StationQueue] is
+     * the active queue, every skip/seek command disappears from the SESSION's available commands, so
+     * the media notification, Android Auto and Bluetooth AVRCP all drop their skip/scrub affordances
+     * in one place. Set by MusicService's currentQueue setter; queried on every notification/state
+     * rebuild, so no explicit invalidation is needed.
+     */
+    @Volatile
+    var maskTransportForStation = false
     private val remotePositionMs: Long get() = CastPlayback.remoteSecondsToMs(discoveryHandler.remoteTime.value)
     private val remoteDurationMs: Long get() = CastPlayback.remoteSecondsToMs(discoveryHandler.remoteDuration.value)
     private val remotePlaying: Boolean get() = CastPlayback.isPlaying(discoveryHandler.remotePlaybackState.value)
@@ -79,6 +89,27 @@ class CastAwarePlayer(
     // While casting, present the receiver's play state so external surfaces show the correct play/pause
     // icon instead of the paused local player's. Kept mutually consistent (READY + playWhenReady) so
     // however the session derives isPlaying, it agrees.
+    override fun getAvailableCommands(): Player.Commands =
+        if (maskTransportForStation) {
+            super.getAvailableCommands().buildUpon()
+                .removeAll(
+                    Player.COMMAND_SEEK_TO_NEXT,
+                    Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                    Player.COMMAND_SEEK_TO_PREVIOUS,
+                    Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                    Player.COMMAND_SEEK_BACK,
+                    Player.COMMAND_SEEK_FORWARD,
+                    Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                    Player.COMMAND_SEEK_TO_MEDIA_ITEM,
+                )
+                .build()
+        } else {
+            super.getAvailableCommands()
+        }
+
+    override fun isCommandAvailable(command: Int): Boolean =
+        if (maskTransportForStation) getAvailableCommands().contains(command) else super.isCommandAvailable(command)
+
     override fun getPlayWhenReady(): Boolean = if (casting) remotePlaying else super.getPlayWhenReady()
     override fun getPlaybackState(): Int = if (casting) Player.STATE_READY else super.getPlaybackState()
     override fun isPlaying(): Boolean = if (casting) remotePlaying else super.isPlaying()

--- a/app/src/main/kotlin/com/jtech/zemer/playback/CastAwarePlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/CastAwarePlayer.kt
@@ -101,6 +101,8 @@ class CastAwarePlayer(
                     Player.COMMAND_SEEK_FORWARD,
                     Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
                     Player.COMMAND_SEEK_TO_MEDIA_ITEM,
+                    Player.COMMAND_SET_REPEAT_MODE,
+                    Player.COMMAND_SET_SHUFFLE_MODE,
                 )
                 .build()
         } else {
@@ -123,13 +125,35 @@ class CastAwarePlayer(
     }
 
     override fun seekTo(positionMs: Long) {
+        if (maskTransportForStation) return // a broadcast has no transport (stale-controller guard)
         if (casting) discoveryHandler.seek(CastPlayback.msToRemoteSeconds(positionMs)) else super.seekTo(positionMs)
     }
 
     override fun seekTo(mediaItemIndex: Int, positionMs: Long) {
+        if (maskTransportForStation) return // a broadcast has no transport (stale-controller guard)
         // While casting the receiver only holds the current item, so route the position to it (the
         // index is meaningless remotely). Local cross-item seeks are unaffected.
         if (casting) discoveryHandler.seek(CastPlayback.msToRemoteSeconds(positionMs)) else super.seekTo(mediaItemIndex, positionMs)
+    }
+
+    override fun seekToNext() { if (!maskTransportForStation) super.seekToNext() }
+    override fun seekToNextMediaItem() { if (!maskTransportForStation) super.seekToNextMediaItem() }
+    override fun seekToPrevious() { if (!maskTransportForStation) super.seekToPrevious() }
+    override fun seekToPreviousMediaItem() { if (!maskTransportForStation) super.seekToPreviousMediaItem() }
+    override fun seekToDefaultPosition() { if (!maskTransportForStation) super.seekToDefaultPosition() }
+    override fun seekToDefaultPosition(mediaItemIndex: Int) { if (!maskTransportForStation) super.seekToDefaultPosition(mediaItemIndex) }
+    override fun setRepeatMode(repeatMode: Int) { if (!maskTransportForStation) super.setRepeatMode(repeatMode) }
+    override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) { if (!maskTransportForStation) super.setShuffleModeEnabled(shuffleModeEnabled) }
+
+    /**
+     * Media3 caches per-controller command sets and only refreshes them on an
+     * onAvailableCommandsChanged - a bare field flip would leave every connected controller
+     * (notification, Auto, Bluetooth) holding the pre-station commands. Called by MusicService's
+     * currentQueue setter whenever the mask changes.
+     */
+    fun notifyStationMaskChanged() {
+        val commands = availableCommands
+        listeners.toList().forEach { it.onAvailableCommandsChanged(commands) }
     }
 
     override fun seekBack() {

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -907,18 +907,22 @@ class MusicService :
                             else -> throw IllegalStateException()
                         },
                     ).setSessionCommand(CommandToggleRepeatMode)
+                    // A broadcast has no repeat/shuffle/personal-radio: the buttons disable while a
+                    // station plays (updateNotification re-runs on every queue/track change).
+                    .setEnabled(currentQueue !is StationQueue)
                     .build(),
                 CommandButton
                     .Builder()
                     .setDisplayName(getString(if (player.shuffleModeEnabled) R.string.action_shuffle_off else R.string.action_shuffle_on))
                     .setIconResId(if (player.shuffleModeEnabled) R.drawable.shuffle_on else R.drawable.shuffle)
                     .setSessionCommand(CommandToggleShuffle)
+                    .setEnabled(currentQueue !is StationQueue)
                     .build(),
                 CommandButton.Builder()
                     .setDisplayName(getString(R.string.start_radio))
                     .setIconResId(R.drawable.radio)
                     .setSessionCommand(CommandToggleStartRadio)
-                    .setEnabled(currentSong.value != null)
+                    .setEnabled(currentSong.value != null && currentQueue !is StationQueue)
                     .build(),
                 CommandButton.Builder()
                     .setDisplayName(getString(R.string.android_auto_target_playlist))
@@ -1061,6 +1065,10 @@ class MusicService :
     }
 
     fun startRadioSeamlessly() {
+        // A live station IS radio: swapping the shared broadcast for a personal /radio queue from
+        // the same button would be a confusing silent exit - the affordance is hidden/disabled on
+        // every surface, and this chokepoint guard covers any stale controller.
+        if (currentQueue is StationQueue) return
         // Ignore re-taps while a radio fetch is in flight — two concurrent runs would both
         // append their radio items, duplicating the queue (#89).
         if (startRadioJob?.isActive == true) return

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -120,6 +120,7 @@ import com.jtech.zemer.models.PersistQueue
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.EmptyQueue
 import com.jtech.zemer.playback.queues.Queue
+import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.playback.queues.continuationItemsToAppend
@@ -242,6 +243,18 @@ class MusicService :
     private var audioQuality = com.jtech.zemer.constants.AudioQuality.AUTO
 
     private var currentQueue: Queue = EmptyQueue
+        set(value) {
+            field = value
+            // Broadcast semantics ride on the queue TYPE: the session player mask strips the
+            // skip/seek commands for every controller surface (notification, Auto, Bluetooth), and
+            // the flag drives the in-app transport gating via PlayerConnection.
+            val station = value is StationQueue
+            isStationBroadcast.value = station
+            if (::sessionPlayer.isInitialized) sessionPlayer.maskTransportForStation = station
+        }
+
+    /** True while a Zemer Station broadcast is the active queue (see [StationQueue]). */
+    val isStationBroadcast = MutableStateFlow(false)
     var queueTitle: String? = null
 
     val currentMediaMetadata = MutableStateFlow<com.jtech.zemer.models.MediaMetadata?>(null)
@@ -269,6 +282,7 @@ class MusicService :
 
     lateinit var player: ExoPlayer
     private lateinit var mediaSession: MediaLibrarySession
+    private lateinit var sessionPlayer: CastAwarePlayer
 
     private var isAudioEffectSessionOpened = false
     private var loudnessEnhancer: LoudnessEnhancer? = null
@@ -426,9 +440,10 @@ class MusicService :
             toggleLibrary = ::toggleLibrary
             addToTargetPlaylist = ::addToTargetPlaylist
         }
+        sessionPlayer = CastAwarePlayer(player, discoveryHandler, scope)
         mediaSession =
             MediaLibrarySession
-                .Builder(this, CastAwarePlayer(player, discoveryHandler, scope), mediaLibrarySessionCallback)
+                .Builder(this, sessionPlayer, mediaLibrarySessionCallback)
                 .setSessionActivity(
                     PendingIntent.getActivity(
                         this,
@@ -1431,6 +1446,18 @@ class MusicService :
         // receiver is loaded exactly once per transition.
         castController.onMediaItemTransition(mediaItem, reason)
 
+        // Station boundary sync (handoff par. 4): a new broadcast track starts at 0; if the wall
+        // clock says the station is already further in (we joined late, buffered, or a slot was
+        // skipped), seek to the live position at THIS boundary - never mid-track.
+        (currentQueue as? StationQueue)?.let { station ->
+            mediaItem?.let { item ->
+                val live = station.livePositionMs(item.mediaId, System.currentTimeMillis())
+                if (live != null && live > STATION_BOUNDARY_SEEK_MS) {
+                    player.seekTo(live)
+                }
+            }
+        }
+
         // Auto load more songs
         if (dataStore.get(AutoLoadMoreKey, true) &&
             reason != Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT &&
@@ -1482,6 +1509,7 @@ class MusicService :
     override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
         if (playWhenReady) {
             setupLoudnessEnhancer()
+            resyncStationOnResume()
         }
         updateWidget()
     }
@@ -1574,6 +1602,14 @@ class MusicService :
         // Don't treat 403 as network error - it needs URL refresh, not network wait
         if (!isNetworkConnected.value || isConnectionError) {
             waitOnNetworkError()
+            return
+        }
+
+        // A broadcast never stops for one bad slot: an unstreamable scheduled track (CDN 403 past
+        // the wall, region block) is skipped and the boundary handler rejoins the wall clock —
+        // handoff-settled; the zero-play-time guard already keeps it out of the play stats.
+        if (currentQueue is StationQueue) {
+            skipOnError()
             return
         }
 
@@ -1956,8 +1992,30 @@ class MusicService :
         }
     }
 
+    /**
+     * Broadcast pause = stop: on resume, rejoin the LIVE position (handoff par. 5) - a station that
+     * resumes where it paused is a playlist. If the wall clock has left the paused track entirely,
+     * skip forward; the boundary handler then seeks the landing track to its live offset.
+     */
+    private fun resyncStationOnResume() {
+        val station = currentQueue as? StationQueue ?: return
+        val mediaId = player.currentMediaItem?.mediaId ?: return
+        val live = station.livePositionMs(mediaId, System.currentTimeMillis()) ?: return
+        val slotLength = station.entryDurationMs(mediaId)
+        if (slotLength != null && live >= slotLength) {
+            if (player.hasNextMediaItem()) player.seekToNextMediaItem()
+        } else if (kotlin.math.abs(player.currentPosition - live) > STATION_BOUNDARY_SEEK_MS) {
+            player.seekTo(live)
+        }
+    }
+
     private fun saveQueueToDisk() {
         if (player.mediaItemCount == 0) {
+            return
+        }
+        // A broadcast is never persisted: restoring a station paused at a stale position is the
+        // exact "playlist, not a station" failure the contract forbids (pause = stop; resume = live).
+        if (currentQueue is StationQueue) {
             return
         }
 
@@ -2104,6 +2162,9 @@ class MusicService :
     }
 
     companion object {
+        /** Boundary/resume corrections only beyond this offset (the handoff's ~3s drift tolerance). */
+        private const val STATION_BOUNDARY_SEEK_MS = 3_000L
+
         const val ROOT = "root"
         const val SONG = "song"
         const val ARTIST = "artist"

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -121,6 +121,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.EmptyQueue
 import com.jtech.zemer.playback.queues.Queue
 import com.jtech.zemer.playback.queues.StationQueue
+import com.jtech.zemer.search.STATION_MAX_DRIFT_MS
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.playback.queues.continuationItemsToAppend
@@ -250,7 +251,11 @@ class MusicService :
             // the flag drives the in-app transport gating via PlayerConnection.
             val station = value is StationQueue
             isStationBroadcast.value = station
-            if (::sessionPlayer.isInitialized) sessionPlayer.maskTransportForStation = station
+            if (::sessionPlayer.isInitialized && sessionPlayer.maskTransportForStation != station) {
+                sessionPlayer.maskTransportForStation = station
+                // Push the changed command set to every connected controller - media3 caches them.
+                sessionPlayer.notifyStationMaskChanged()
+            }
         }
 
     /** True while a Zemer Station broadcast is the active queue (see [StationQueue]). */
@@ -968,9 +973,13 @@ class MusicService :
         playWhenReady: Boolean = true,
     ) {
         val previousQueue = currentQueue
+        stationWaitJob?.cancel()
         currentQueue = queue
         queueTitle = null
         player.shuffleModeEnabled = false
+        // A broadcast has exactly one order and no looping: a persisted REPEAT_ONE would otherwise
+        // trap the station on a single slot (the repeat transition reason skips the runway top-up).
+        if (queue is StationQueue) player.repeatMode = REPEAT_MODE_OFF
         // Tracking: the tapped/preloaded item is always user-chosen context for this queue.
         Tracker.playSources.onQueueStarted(queue.playSource, listOfNotNull(queue.preloadItem?.id))
         queue.preloadItem?.let { preloadItem ->
@@ -1160,6 +1169,7 @@ class MusicService :
     }
 
     fun playNext(items: List<MediaItem>) {
+        exitStationOnQueueMutation()
         // If queue is empty or player is idle, play immediately instead
         if (player.mediaItemCount == 0 || player.playbackState == STATE_IDLE) {
             player.setMediaItems(items)
@@ -1229,6 +1239,7 @@ class MusicService :
     }
 
     fun addToQueue(items: List<MediaItem>) {
+        exitStationOnQueueMutation()
         player.addMediaItems(items)
         player.prepare()
     }
@@ -1446,20 +1457,15 @@ class MusicService :
         // receiver is loaded exactly once per transition.
         castController.onMediaItemTransition(mediaItem, reason)
 
-        // Station boundary sync (handoff par. 4): a new broadcast track starts at 0; if the wall
-        // clock says the station is already further in (we joined late, buffered, or a slot was
-        // skipped), seek to the live position at THIS boundary - never mid-track.
-        (currentQueue as? StationQueue)?.let { station ->
-            mediaItem?.let { item ->
-                val live = station.livePositionMs(item.mediaId, System.currentTimeMillis())
-                if (live != null && live > STATION_BOUNDARY_SEEK_MS) {
-                    player.seekTo(live)
-                }
-            }
-        }
+        // Station boundary sync (handoff par. 4): the ONLY place broadcast drift is corrected -
+        // bidirectional (seek forward when behind, wait when ahead, re-tune when nothing queued is
+        // on-air), never mid-track.
+        (currentQueue as? StationQueue)?.let { resyncStationPlayback(it) }
 
-        // Auto load more songs
-        if (dataStore.get(AutoLoadMoreKey, true) &&
+        // Auto load more songs. A station's runway top-up is NOT optional: it ignores the user's
+        // Auto-load-more preference (a broadcast that silently ends after six slots is broken, not
+        // configured) and the repeat-reason guard (repeat is forced off for stations anyway).
+        if ((dataStore.get(AutoLoadMoreKey, true) || currentQueue is StationQueue) &&
             reason != Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT &&
             player.mediaItemCount - player.currentMediaItemIndex <= 5 &&
             currentQueue.hasNextPage() &&
@@ -1499,6 +1505,11 @@ class MusicService :
     override fun onPlaybackStateChanged(
         @Player.State playbackState: Int,
     ) {
+        // A broadcast never ends: reaching STATE_ENDED means the runway ran out (top-up lost a
+        // race) - re-tune to the live schedule instead of parking in silence.
+        if (playbackState == Player.STATE_ENDED) {
+            (currentQueue as? StationQueue)?.let { resyncStationPlayback(it) }
+        }
         // Save state when playback state changes
         if (dataStore.get(PersistentQueueKey, true)) {
             saveQueueToDisk()
@@ -1606,10 +1617,14 @@ class MusicService :
         }
 
         // A broadcast never stops for one bad slot: an unstreamable scheduled track (CDN 403 past
-        // the wall, region block) is skipped and the boundary handler rejoins the wall clock —
-        // handoff-settled; the zero-play-time guard already keeps it out of the play stats.
-        if (currentQueue is StationQueue) {
+        // the wall, region block) is marked unplayable (so the resync can never seek back into it),
+        // skipped, and the resync rejoins the wall clock - waiting out the gap if the next slot
+        // hasn't started, so the listener is never left permanently ahead. Handoff-settled; the
+        // zero-play-time guard already keeps the failed slot out of the play stats.
+        (currentQueue as? StationQueue)?.let { station ->
+            player.currentMediaItem?.mediaId?.let(station::markUnplayable)
             skipOnError()
+            resyncStationPlayback(station)
             return
         }
 
@@ -1994,18 +2009,70 @@ class MusicService :
 
     /**
      * Broadcast pause = stop: on resume, rejoin the LIVE position (handoff par. 5) - a station that
-     * resumes where it paused is a playlist. If the wall clock has left the paused track entirely,
-     * skip forward; the boundary handler then seeks the landing track to its live offset.
+     * resumes where it paused is a playlist.
      */
     private fun resyncStationOnResume() {
-        val station = currentQueue as? StationQueue ?: return
-        val mediaId = player.currentMediaItem?.mediaId ?: return
-        val live = station.livePositionMs(mediaId, System.currentTimeMillis()) ?: return
-        val slotLength = station.entryDurationMs(mediaId)
-        if (slotLength != null && live >= slotLength) {
-            if (player.hasNextMediaItem()) player.seekToNextMediaItem()
-        } else if (kotlin.math.abs(player.currentPosition - live) > STATION_BOUNDARY_SEEK_MS) {
-            player.seekTo(live)
+        (currentQueue as? StationQueue)?.let { resyncStationPlayback(it) }
+    }
+
+    /**
+     * THE bidirectional broadcast resync (every station drift path funnels here - boundary
+     * transitions, pause-resume, error skips, STATE_ENDED):
+     *  - finds the queued slot that is ON-AIR by wall clock (never scanning backward past the
+     *    current index into already-played slots) and seeks to its live offset when off by more
+     *    than the drift tolerance;
+     *  - if the landing slot has NOT started yet (we ran ahead: an error/blocked skip started it
+     *    early), it WAITS - pauses and resumes exactly at the slot's startMs (the addendum's
+     *    sanctioned handling), so one bad slot can never leave the listener permanently ahead;
+     *  - if NOTHING queued is on-air (paused past the runway, stale schedule), it re-tunes from
+     *    scratch - the exact flow a card tap runs, which also recovers STATE_ENDED.
+     */
+    private fun resyncStationPlayback(station: StationQueue) {
+        val nowMs = System.currentTimeMillis()
+        val startIndex = player.currentMediaItemIndex.coerceAtLeast(0)
+        for (index in startIndex until player.mediaItemCount) {
+            val mediaId = player.getMediaItemAt(index).mediaId
+            val live = station.onAirOffsetMs(mediaId, nowMs) ?: continue
+            val positionInSlot = if (index == player.currentMediaItemIndex) player.currentPosition else Long.MIN_VALUE
+            if (index != player.currentMediaItemIndex || kotlin.math.abs(positionInSlot - live) > STATION_MAX_DRIFT_MS) {
+                player.seekTo(index, live)
+            }
+            return
+        }
+        // Nothing from here on is on-air. If the CURRENT slot merely hasn't started (we're ahead
+        // after an error/blocked skip), hold playback until its startMs instead of drifting ahead.
+        val currentId = player.currentMediaItem?.mediaId
+        val untilStart = currentId?.let { station.msUntilSlotStarts(it, nowMs) }
+        if (untilStart != null && untilStart > 0) {
+            if (untilStart > STATION_MAX_DRIFT_MS) {
+                player.pause()
+                player.seekTo(0)
+                stationWaitJob?.cancel()
+                stationWaitJob = scope.launch(SilentHandler) {
+                    delay(untilStart)
+                    if (currentQueue === station && player.currentMediaItem?.mediaId == currentId) {
+                        player.play()
+                    }
+                }
+            }
+            return
+        }
+        // Past the whole runway (long pause / stale schedule): re-tune exactly like a card tap.
+        playQueue(StationQueue(station.stationId, this))
+    }
+
+    private var stationWaitJob: Job? = null
+
+    /**
+     * A queue mutation (Play next / Add to queue) is incompatible with a broadcast - it turns the
+     * player content into an ordinary list, so broadcast mode must END here: without this,
+     * currentQueue latched as the station forever (LIVE bar stuck, skips disabled everywhere, and
+     * the saveQueueToDisk guard silently disabling queue persistence for the rest of the process).
+     */
+    private fun exitStationOnQueueMutation() {
+        if (currentQueue is StationQueue) {
+            stationWaitJob?.cancel()
+            currentQueue = EmptyQueue
         }
     }
 
@@ -2124,9 +2191,13 @@ class MusicService :
             // The local skip advances the queue, whose media-item transition reloads the receiver while
             // casting. PREV uses seekToPreviousMediaItem when casting: the local clock is meaningless
             // remotely, so seekToPrevious's "restart current track if >3s in" would misfire.
-            MusicWidget.ACTION_NEXT -> player.seekToNext()
+            // A broadcast has no transport: the widget's skip taps reach the raw player and would
+            // bypass the session command mask, so they are dropped while a station plays.
+            MusicWidget.ACTION_NEXT -> if (currentQueue !is StationQueue) player.seekToNext()
             MusicWidget.ACTION_PREV ->
-                if (discoveryHandler.isConnected) player.seekToPreviousMediaItem() else player.seekToPrevious()
+                if (currentQueue !is StationQueue) {
+                    if (discoveryHandler.isConnected) player.seekToPreviousMediaItem() else player.seekToPrevious()
+                }
         }
         return super.onStartCommand(intent, flags, startId)
     }
@@ -2162,9 +2233,6 @@ class MusicService :
     }
 
     companion object {
-        /** Boundary/resume corrections only beyond this offset (the handoff's ~3s drift tolerance). */
-        private const val STATION_BOUNDARY_SEEK_MS = 3_000L
-
         const val ROOT = "root"
         const val SONG = "song"
         const val ARTIST = "artist"

--- a/app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt
@@ -97,6 +97,13 @@ class PlayerConnection(
     val error = MutableStateFlow<PlaybackException?>(null)
     val waitingForNetworkConnection = service.waitingForNetworkConnection
 
+    /**
+     * A Zemer Station broadcast is playing: play/stop only (handoff par. 5). Drives the in-app LIVE
+     * treatment and the skip/scrub gating; the notification/Auto/Bluetooth side is masked at the
+     * session player.
+     */
+    val isStationBroadcast = service.isStationBroadcast
+
     init {
         player.addListener(this)
 
@@ -304,6 +311,12 @@ class PlayerConnection(
     }
 
     private fun updateCanSkipPreviousAndNext() {
+        if (service.isStationBroadcast.value) {
+            // Broadcast transport is play/stop only - no skip in either direction.
+            canSkipPrevious.value = false
+            canSkipNext.value = false
+            return
+        }
         if (!player.currentTimeline.isEmpty) {
             val window =
                 player.currentTimeline.getWindow(player.currentMediaItemIndex, Timeline.Window())

--- a/app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt
@@ -177,6 +177,7 @@ class PlayerConnection(
     }
 
     fun seekTo(positionMs: Long) {
+        if (isStationBroadcast.value) return // a broadcast has no scrubbing (handoff par. 5)
         if (isCasting.value) {
             service.discoveryHandler.seek(CastPlayback.msToRemoteSeconds(positionMs))
         } else {
@@ -222,6 +223,7 @@ class PlayerConnection(
         else player.duration
 
     fun seekToNext() {
+        if (isStationBroadcast.value) return // a broadcast has no skip (handoff par. 5)
         if (!player.currentTimeline.isEmpty && player.isCommandAvailable(COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)) {
             try {
                 player.seekToNext()
@@ -237,6 +239,7 @@ class PlayerConnection(
     }
 
     fun seekToPrevious() {
+        if (isStationBroadcast.value) return // a broadcast has no skip (handoff par. 5)
         if (!player.currentTimeline.isEmpty && player.isCommandAvailable(COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)) {
             try {
                 // While casting the local clock is frozen at the connect position, so seekToPrevious's

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/StationQueue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/StationQueue.kt
@@ -1,0 +1,148 @@
+package com.jtech.zemer.playback.queues
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import com.jtech.zemer.di.ZemerSearchRepositoryEntryPoint
+import com.jtech.zemer.extensions.toMediaItem
+import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.search.ZemerStationEntry
+import com.jtech.zemer.search.stationJoinPositionMs
+import com.jtech.zemer.search.stationShouldSkipDyingTrack
+import com.jtech.zemer.search.stationSkewMs
+import com.jtech.zemer.search.stationStartPositionMs
+import com.jtech.zemer.utils.BlockedIdsCache
+import com.jtech.zemer.utils.ContentFilterState
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+/**
+ * A **Zemer Station** — synchronized broadcast radio (handoff `zemer-app-stations.md`): one shared,
+ * server-programmed wall-clock schedule; every listener hears the SAME track at the SAME moment.
+ * The queue's whole job is §4 of the contract: join `now` at its live offset, keep the `next`
+ * runway loaded, and let MusicService correct drift at track boundaries only.
+ *
+ * Broadcast semantics riding on this class (enforced by MusicService + the session player mask):
+ * no skip/prev/scrub, pause = stop-and-rejoin-live, never persisted to disk. The tapped-station
+ * failure path is the standard playQueue one (surfaced toast, previous queue restored).
+ *
+ * Content: pools are pre-filtered server-side to the strictest common denominator, so no flags are
+ * sent; the app's blocked-ids table still runs as the third defense layer ([entryIsBlocked] — the
+ * since-blocked race, ~10 min server-side). A same-track re-broadcast hours later is deduped away
+ * by the central append filter (the queue accumulates played items); the wall-clock resync at the
+ * following boundary absorbs that rare skipped slot.
+ *
+ * Tracking: every station play tags `station:<id>` ([playSource]); both context flags are true so
+ * the whole broadcast reports under that source (the fill-vs-context split is meaningless for a
+ * broadcast — the user chose the station, the station chose everything else).
+ */
+class StationQueue(
+    val stationId: String,
+    context: Context,
+) : Queue {
+    override val preloadItem: MediaMetadata? = null
+    override val playSource: String = "station:$stationId"
+    override val initialItemsAreContext: Boolean = true
+    override val continuationIsContext: Boolean = true
+
+    // MusicService retains currentQueue for the whole session — hold only the application context.
+    private val context = context.applicationContext
+
+    private val repository = EntryPointAccessors
+        .fromApplication(context.applicationContext, ZemerSearchRepositoryEntryPoint::class.java)
+        .zemerSearchRepository()
+
+    /** mediaId → its scheduled slot, so boundary handlers can recompute the live position. */
+    private val schedule = LinkedHashMap<String, ZemerStationEntry>()
+    private val scheduleLock = Any()
+
+    @Volatile
+    private var skewMs = 0L
+
+    var stationTitle: String? = null
+        private set
+
+    override suspend fun getInitialStatus(): Queue.Status = withContext(IO) {
+        val tuneIn = repository.stationTuneIn(stationId)
+            ?: throw IOException("Zemer station $stationId is offline")
+        val receivedAt = System.currentTimeMillis()
+        skewMs = stationSkewMs(tuneIn.serverTimeMs, receivedAt)
+        stationTitle = tuneIn.station.title
+
+        // §4: don't join a dying track — start from the first `next` entry (at/near its own start).
+        val joinNow = tuneIn.now
+            ?.takeUnless { stationShouldSkipDyingTrack(it, skewMs, receivedAt) }
+            ?.takeUnless { entryIsBlocked(it) }
+        val entries = listOfNotNull(joinNow) + tuneIn.next.filterNot { entryIsBlocked(it) }
+        if (entries.isEmpty()) throw IOException("Zemer station $stationId served no playable entries")
+        remember(entries)
+
+        Queue.Status(
+            title = tuneIn.station.title,
+            items = entries.map { it.toMediaItem() },
+            mediaItemIndex = 0,
+            // Join the on-air track at its live offset (0 for a not-yet-started addendum entry, and
+            // for a first-`next` join). Computed here, at the moment playback starts, so the fetch
+            // latency is absorbed by the seek.
+            position = if (joinNow != null) {
+                stationStartPositionMs(stationJoinPositionMs(joinNow, skewMs, System.currentTimeMillis()))
+            } else {
+                0L
+            },
+        )
+    }
+
+    // A broadcast never ends; a failed top-up throws (SilentHandler) and the next boundary retries.
+    override fun hasNextPage(): Boolean = true
+
+    override suspend fun nextPage(): List<MediaItem> = withContext(IO) {
+        val tuneIn = repository.stationTuneIn(stationId) ?: return@withContext emptyList()
+        skewMs = stationSkewMs(tuneIn.serverTimeMs, System.currentTimeMillis())
+        val entries = (listOfNotNull(tuneIn.now) + tuneIn.next).filterNot { entryIsBlocked(it) }
+        remember(entries)
+        // MusicService's central append filter drops whatever is already queued (incl. the current
+        // on-air track) — only genuinely upcoming slots are added.
+        entries.map { it.toMediaItem() }
+    }
+
+    /**
+     * Where the broadcast is right now inside the queued [mediaId], or null when it isn't a known
+     * slot. MusicService uses it for boundary drift correction and the pause→resume live rejoin.
+     */
+    fun livePositionMs(mediaId: String, localNowMs: Long): Long? {
+        val entry = synchronized(scheduleLock) { schedule[mediaId] } ?: return null
+        return stationStartPositionMs(stationJoinPositionMs(entry, skewMs, localNowMs))
+    }
+
+    /** The slot's wall-clock end (server clock, comparable via [livePositionMs]'s math). */
+    fun entryDurationMs(mediaId: String): Long? =
+        synchronized(scheduleLock) { schedule[mediaId] }?.let { it.endMs - it.startMs }
+
+    private fun remember(entries: List<ZemerStationEntry>) {
+        synchronized(scheduleLock) {
+            entries.forEach { schedule[it.videoId] = it }
+            // The schedule map only needs the runway, not the whole listening history.
+            while (schedule.size > SCHEDULE_MEMORY) {
+                val eldest = schedule.keys.firstOrNull() ?: break
+                schedule.remove(eldest)
+            }
+        }
+    }
+
+    private fun entryIsBlocked(entry: ZemerStationEntry): Boolean =
+        BlockedIdsCache.isBlocked(entry.videoId, ContentFilterState.current)
+
+    private fun ZemerStationEntry.toMediaItem(): MediaItem =
+        MediaMetadata(
+            id = videoId,
+            title = title,
+            artists = listOf(MediaMetadata.Artist(id = artistId, name = artist)),
+            duration = durationSec ?: -1,
+            thumbnailUrl = thumbnail,
+        ).toMediaItem()
+
+    private companion object {
+        const val SCHEDULE_MEMORY = 24
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/playback/queues/StationQueue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/queues/StationQueue.kt
@@ -5,11 +5,15 @@ import androidx.media3.common.MediaItem
 import com.jtech.zemer.di.ZemerSearchRepositoryEntryPoint
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.search.ZemerResultMapper.toSongItem
 import com.jtech.zemer.search.ZemerStationEntry
 import com.jtech.zemer.search.stationJoinPositionMs
+import com.jtech.zemer.search.stationOnAirOffsetMs
 import com.jtech.zemer.search.stationShouldSkipDyingTrack
 import com.jtech.zemer.search.stationSkewMs
 import com.jtech.zemer.search.stationStartPositionMs
+import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.utils.BlockedIdsCache
 import com.jtech.zemer.utils.ContentFilterState
 import dagger.hilt.android.EntryPointAccessors
@@ -42,7 +46,7 @@ class StationQueue(
     context: Context,
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
-    override val playSource: String = "station:$stationId"
+    override val playSource: String = PlaySource.station(stationId)
     override val initialItemsAreContext: Boolean = true
     override val continuationIsContext: Boolean = true
 
@@ -107,17 +111,32 @@ class StationQueue(
     }
 
     /**
-     * Where the broadcast is right now inside the queued [mediaId], or null when it isn't a known
-     * slot. MusicService uses it for boundary drift correction and the pause→resume live rejoin.
+     * The live offset inside the queued [mediaId] IF its slot is on-air right now (null when it
+     * hasn't started, already ended, is unknown, or was marked unplayable). The bidirectional
+     * resync's primitive: MusicService seeks forward when behind, waits when ahead, re-tunes when
+     * nothing queued is on-air.
      */
-    fun livePositionMs(mediaId: String, localNowMs: Long): Long? {
+    fun onAirOffsetMs(mediaId: String, localNowMs: Long): Long? {
+        if (synchronized(scheduleLock) { mediaId in unplayable }) return null
         val entry = synchronized(scheduleLock) { schedule[mediaId] } ?: return null
-        return stationStartPositionMs(stationJoinPositionMs(entry, skewMs, localNowMs))
+        return stationOnAirOffsetMs(entry, skewMs, localNowMs)
     }
 
-    /** The slot's wall-clock end (server clock, comparable via [livePositionMs]'s math). */
-    fun entryDurationMs(mediaId: String): Long? =
-        synchronized(scheduleLock) { schedule[mediaId] }?.let { it.endMs - it.startMs }
+    /** Milliseconds until the queued [mediaId]'s slot starts (negative/zero = already started). */
+    fun msUntilSlotStarts(mediaId: String, localNowMs: Long): Long? {
+        val entry = synchronized(scheduleLock) { schedule[mediaId] } ?: return null
+        return -stationJoinPositionMs(entry, skewMs, localNowMs)
+    }
+
+    /**
+     * A slot that failed to stream on THIS device (CDN 403, region block). Excluded from on-air
+     * resolution so the resync can never seek back into it and re-fail in a loop.
+     */
+    fun markUnplayable(mediaId: String) {
+        synchronized(scheduleLock) { unplayable.add(mediaId) }
+    }
+
+    private val unplayable = HashSet<String>()
 
     private fun remember(entries: List<ZemerStationEntry>) {
         synchronized(scheduleLock) {
@@ -133,14 +152,10 @@ class StationQueue(
     private fun entryIsBlocked(entry: ZemerStationEntry): Boolean =
         BlockedIdsCache.isBlocked(entry.videoId, ContentFilterState.current)
 
+    // Through the shared mapper path (SongItem -> MediaMetadata) so coverless slots get the derived
+    // thumbnail fallback and the 544x544 artwork resize like every other Zemer queue.
     private fun ZemerStationEntry.toMediaItem(): MediaItem =
-        MediaMetadata(
-            id = videoId,
-            title = title,
-            artists = listOf(MediaMetadata.Artist(id = artistId, name = artist)),
-            duration = durationSec ?: -1,
-            thumbnailUrl = thumbnail,
-        ).toMediaItem()
+        toSongItem().toMediaMetadata().toMediaItem()
 
     private companion object {
         const val SCHEDULE_MEMORY = 24

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -202,6 +202,22 @@ object ZemerResultMapper {
         songItems(tracks, hideExplicit)
 
     /**
+     * One station schedule slot as a playable [SongItem], so station items ride the SAME
+     * [SongItem.toMediaMetadata] path as every other Zemer queue: the derived-[thumbnailFor]
+     * fallback for coverless slots and the 544x544 artwork resize both come for free (a hand-built
+     * MediaMetadata lost them - blank player/notification art on coverless standalones).
+     */
+    fun ZemerStationEntry.toSongItem(): SongItem =
+        SongItem(
+            id = videoId,
+            title = title,
+            artists = listOf(Artist(name = artist, id = artistId)),
+            duration = durationSec,
+            thumbnail = thumbnail?.takeIf { it.isNotBlank() } ?: thumbnailFor(videoId),
+            explicit = false,
+        )
+
+    /**
      * A `/radio` page's tracks as playable [SongItem]s with the same defense-in-depth every other
      * Zemer surface gets — sparse-row drop, de-dup, and the surgical id-overrides ([dropBlocked]):
      * a Firestore-blocked id must not play even when the server's override sync lags the app's.

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -206,6 +206,37 @@ class ZemerSearchClient @Inject constructor() {
      * `album` / `song`, with [seed] the channelId/browseId/videoId) or `shuffle` (no seed) for Radio mode.
      * Content flags are sent explicitly (kidZone included), same as the other endpoints.
      */
+    /**
+     * The Zemer Stations catalog (`GET /stations`) — the synchronized-broadcast home row's data. NO
+     * content flags are sent: the pools are pre-filtered server-side to the strictest common
+     * denominator (handoff §6), so there is nothing left to filter. Clock-dependent — never cached.
+     */
+    suspend fun stations(): ZemerStationsResponse {
+        val response: HttpResponse = client.get("$BASE_URL/stations")
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer stations returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerStationsResponse.serializer(), response.bodyAsText())
+    }
+
+    /**
+     * One station's tune-in payload (`GET /station?id=&next=`): the on-air track with its live offset
+     * plus the next [next] scheduled entries (1..10). Null on `404` (unknown id) AND on `503`
+     * (station offline: schedule exhausted server-side) — both mean "hide the card / stop with the
+     * station-offline state; retry later". No content flags (see [stations]); never cached.
+     */
+    suspend fun station(id: String, next: Int = 5): ZemerStationTuneInResponse? {
+        val response: HttpResponse = client.get("$BASE_URL/station") {
+            parameter("id", id)
+            parameter("next", next)
+        }
+        if (response.status == HttpStatusCode.NotFound || response.status == HttpStatusCode.ServiceUnavailable) return null
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer station returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerStationTuneInResponse.serializer(), response.bodyAsText())
+    }
+
     suspend fun radio(
         kind: String,
         seed: String?,

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -210,6 +210,26 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun radioContinuation(continuation: String): ZemerRadioPage =
         client.radioContinuation(continuation).toRadioPage()
 
+    /**
+     * The live Zemer Stations for the "Zemer Radio" home row ([liveStations]: live-only cards,
+     * absolute covers, fail-soft empty). Deliberately NOT wrapped in [serverOrOffline] — a
+     * synchronized broadcast cannot be served from a snapshot, so stations are live-only like
+     * `/playlist` and `/radio`. Not cached: the responses are clock-dependent, and the row's
+     * `nowPlaying` line refreshes once per home load by contract (handoff, settled 2026-07-29).
+     */
+    suspend fun stations(): List<ZemerStation> =
+        client.stations().liveStations(::resolveZemerUrl)
+
+    /**
+     * One station's tune-in payload — the on-air entry with its live offset + the schedule runway.
+     * Null = unknown id OR station offline (hide the card / show the station-offline player state and
+     * retry later; never a silent fallback). Live-only and uncached, like [stations].
+     */
+    suspend fun stationTuneIn(id: String, next: Int = 5): ZemerStationTuneInResponse? =
+        client.station(id, next)?.let { resp ->
+            resp.copy(station = resp.station.copy(thumbnail = resolveZemerUrl(resp.station.thumbnail)))
+        }
+
     // Routed through the mapper so radio gets the same dropBlocked id-overrides pass as every other
     // Zemer surface (the server filters too; this covers its ~10-min override-sync lag).
     private fun ZemerRadioResponse.toRadioPage(): ZemerRadioPage =

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
@@ -118,12 +118,15 @@ fun stationShouldSkipDyingTrack(entry: ZemerStationEntry, skewMs: Long, localNow
     entry.endMs - (localNowMs + skewMs) <= STATION_DYING_TRACK_MS
 
 /**
- * §4 drift rule: correct only when |playback position − live position| exceeds
- * [STATION_MAX_DRIFT_MS], and then only at the NEXT track boundary — an audible mid-track jump is
- * worse than a couple of seconds of drift.
+ * The live offset inside [entry] IF it is on-air right now, else null: negative join = the slot
+ * has not started (we are ahead of the broadcast — wait, don't play), beyond the slot length = it
+ * already ended (we are behind — move on). THE primitive the bidirectional resync is built on: the
+ * caller seeks forward when behind, waits when ahead, and re-tunes when nothing queued is on-air.
  */
-fun stationDriftExceedsLimit(playbackPositionMs: Long, entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Boolean =
-    kotlin.math.abs(playbackPositionMs - stationJoinPositionMs(entry, skewMs, localNowMs)) > STATION_MAX_DRIFT_MS
+fun stationOnAirOffsetMs(entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Long? {
+    val join = stationJoinPositionMs(entry, skewMs, localNowMs)
+    return join.takeIf { it >= 0 && it < entry.endMs - entry.startMs }
+}
 
 /** Don't join a track with less than this left (handoff §4: "the last ~5s"). */
 const val STATION_DYING_TRACK_MS = 5_000L

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
@@ -1,0 +1,117 @@
+package com.jtech.zemer.search
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire models for **Zemer Stations** — synchronized broadcast radio (`GET /stations`,
+ * `GET /station?id=`), per the handoff doc `~/zemer-fix/handoff-docs/zemer-app-stations.md`. One
+ * shared, server-programmed wall-clock schedule per station: every listener hears the SAME track at
+ * the SAME moment; the client's only job is to join at the live offset and keep step (see
+ * [stationJoinPositionMs]). Field names match the JSON exactly; everything the server may omit is
+ * nullable/defaulted so a sparse row never fails deserialization (the shared lenient reader).
+ *
+ * Content policy (handoff §6): the pools are pre-filtered server-side to the strictest common
+ * denominator, so the content flags are NOT sent to these endpoints, and the row is hidden in
+ * kidZone mode. Responses are clock-dependent — never cache them. Stations are LIVE-ONLY: never
+ * served from the offline snapshot (like `/playlist` and `/radio`).
+ */
+@Serializable
+data class ZemerStationsResponse(
+    val count: Int = 0,
+    val stations: List<ZemerStation> = emptyList(),
+    /** Server clock at response time — measure local skew against it (see [stationSkewMs]). */
+    val serverTimeMs: Long = 0,
+)
+
+@Serializable
+data class ZemerStation(
+    val id: String = "",
+    val title: String = "",
+    /** Branded broadcast SVG cover; RELATIVE — resolve via `resolveZemerUrl` before rendering. */
+    val thumbnail: String? = null,
+    /** Only `live == true` stations render; a not-live station is hidden, not greyed. */
+    val live: Boolean = false,
+    val nowPlaying: ZemerStationNowPlaying? = null,
+)
+
+/** The row's "Now: ‹title› — ‹artist›" line; refreshed once per home load (settled in the handoff). */
+@Serializable
+data class ZemerStationNowPlaying(
+    val title: String = "",
+    val artist: String = "",
+    val thumbnail: String? = null,
+)
+
+/** `GET /station?id=&next=` — the tune-in payload: the on-air track + the upcoming schedule runway. */
+@Serializable
+data class ZemerStationTuneInResponse(
+    val station: ZemerStation = ZemerStation(),
+    /** Server clock at response time — the skew reference for the §4 sync math. */
+    val serverTimeMs: Long = 0,
+    /** Schedule runway remaining; an ops signal, not needed for playback. */
+    val horizonMs: Long = 0,
+    val now: ZemerStationEntry? = null,
+    val next: List<ZemerStationEntry> = emptyList(),
+)
+
+/** One scheduled slot. [offsetMs] is present on `now` only (where the broadcast is right now). */
+@Serializable
+data class ZemerStationEntry(
+    val videoId: String = "",
+    val title: String = "",
+    val artist: String = "",
+    val artistId: String? = null,
+    /** Square album art (absolute URL); null for coverless standalones. */
+    val thumbnail: String? = null,
+    val durationSec: Int? = null,
+    /** Wall-clock broadcast window (server clock). */
+    val startMs: Long = 0,
+    val endMs: Long = 0,
+    val offsetMs: Long? = null,
+)
+
+/**
+ * The renderable station cards: only `live == true` stations with a real id (a not-live or sparse
+ * row is hidden, never greyed), de-duped for the id-keyed lazy row, thumbnails resolved absolute via
+ * [resolveUrl] (the covers arrive host-relative). An empty result hides the whole row — the same
+ * fail-soft convention as `/home-rows`.
+ */
+fun ZemerStationsResponse.liveStations(resolveUrl: (String?) -> String?): List<ZemerStation> =
+    stations
+        .filter { it.live && it.id.isNotBlank() }
+        .distinctBy { it.id }
+        .map { it.copy(thumbnail = resolveUrl(it.thumbnail)) }
+
+// ── The §4 tune-in clock math (pure; unit-tested) ────────────────────────────────────────────────
+
+/** Local-to-server clock skew: add this to a local `now` to get server wall-clock time. */
+fun stationSkewMs(serverTimeMs: Long, localTimeMs: Long): Long = serverTimeMs - localTimeMs
+
+/**
+ * Where the broadcast is RIGHT NOW inside [entry], computed at [localNowMs] with the measured
+ * [skewMs]: `(local now + skew) − startMs`. Compute it at the moment playback actually starts, so
+ * fetch/prepare latency is absorbed by the seek instead of accumulating as drift.
+ */
+fun stationJoinPositionMs(entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Long =
+    (localNowMs + skewMs) - entry.startMs
+
+/**
+ * §4 join rule: joining within the last [STATION_DYING_TRACK_MS] of a track is not worth it — skip
+ * straight to the first `next` entry instead (which by then is at/near its own start).
+ */
+fun stationShouldSkipDyingTrack(entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Boolean =
+    entry.endMs - (localNowMs + skewMs) <= STATION_DYING_TRACK_MS
+
+/**
+ * §4 drift rule: correct only when |playback position − live position| exceeds
+ * [STATION_MAX_DRIFT_MS], and then only at the NEXT track boundary — an audible mid-track jump is
+ * worse than a couple of seconds of drift.
+ */
+fun stationDriftExceedsLimit(playbackPositionMs: Long, entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Boolean =
+    kotlin.math.abs(playbackPositionMs - stationJoinPositionMs(entry, skewMs, localNowMs)) > STATION_MAX_DRIFT_MS
+
+/** Don't join a track with less than this left (handoff §4: "the last ~5s"). */
+const val STATION_DYING_TRACK_MS = 5_000L
+
+/** Tolerated broadcast drift before a boundary correction (handoff §4: "~3s"). */
+const val STATION_MAX_DRIFT_MS = 3_000L

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt
@@ -67,6 +67,11 @@ data class ZemerStationEntry(
     /** Wall-clock broadcast window (server clock). */
     val startMs: Long = 0,
     val endMs: Long = 0,
+    /**
+     * Present on `now` only. MAY BE NEGATIVE (contract addendum): when the on-air entry was just
+     * taken down, the next servable entry is served as `now` and a negative offset means "this
+     * track starts in |offset| ms" — see [stationStartPositionMs].
+     */
     val offsetMs: Long? = null,
 )
 
@@ -90,10 +95,20 @@ fun stationSkewMs(serverTimeMs: Long, localTimeMs: Long): Long = serverTimeMs - 
 /**
  * Where the broadcast is RIGHT NOW inside [entry], computed at [localNowMs] with the measured
  * [skewMs]: `(local now + skew) − startMs`. Compute it at the moment playback actually starts, so
- * fetch/prepare latency is absorbed by the seek instead of accumulating as drift.
+ * fetch/prepare latency is absorbed by the seek instead of accumulating as drift. NEGATIVE when the
+ * entry has not started yet (the addendum's just-taken-down case) — feed it through
+ * [stationStartPositionMs] before seeking.
  */
 fun stationJoinPositionMs(entry: ZemerStationEntry, skewMs: Long, localNowMs: Long): Long =
     (localNowMs + skewMs) - entry.startMs
+
+/**
+ * The position to actually seek to: a negative join position means the entry starts in |value| ms
+ * (contract addendum) — of the two sanctioned handlings (wait it out vs start at 0 immediately) we
+ * take START AT 0: it is simpler, the gap is a rare sub-track-length sliver, and silence on tune-in
+ * reads as broken. The resulting few seconds of head-start decay at the next boundary correction.
+ */
+fun stationStartPositionMs(joinPositionMs: Long): Long = maxOf(0L, joinPositionMs)
 
 /**
  * §4 join rule: joining within the last [STATION_DYING_TRACK_MS] of a track is not worth it — skip

--- a/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
@@ -13,6 +13,8 @@ object PlaySource {
     const val OTHER = "other"
 
     fun artist(id: String) = "artist:$id"
+    /** A Zemer Station broadcast (the whole listen is context under it); `id` is the station slug. */
+    fun station(id: String) = "station:$id"
     fun album(id: String) = "album:$id"
     fun playlist(id: String) = "playlist:$id"
     // A discovery-sourced community playlist (the home "Community playlists" row + the search Community

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
@@ -1,23 +1,32 @@
 package com.jtech.zemer.ui.component
 
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.AsyncImage
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.search.ZemerStation
 
 /**
- * One "Zemer Radio" station card — a plain [GridItem] (the SAME geometry, typography and D-pad
- * focus treatment as every other home-row card, so the row aligns with its neighbors): the
- * station's branded broadcast SVG cover (served absolute; the shared SvgDecoder renders it), the
- * station title, and the live "Now: title — artist" line (refreshed once per home load — up to one
- * track stale by contract). Callers attach the tune-in `clickable` on [modifier], the shared grid
- * convention.
+ * One "Zemer Radio" station card - a [GridItem] (the SAME geometry, typography and D-pad focus
+ * treatment as every other home-row card, so the row aligns with its neighbors): the station's
+ * branded broadcast SVG cover (served absolute; the shared SvgDecoder renders it), the station
+ * title, and the live now-playing line. That line MARQUEES instead of truncating - a ~140dp card
+ * fits ~15 characters, so an ellipsized "Now: ..." prefix line carried no information (the cover
+ * already carries the LIVE branding, so the prefix is dropped too). Refreshed once per home load -
+ * up to one track stale by contract. Callers attach the tune-in `clickable` on [modifier], the
+ * shared grid convention.
  */
 @Composable
 fun ZemerStationCard(
@@ -26,10 +35,28 @@ fun ZemerStationCard(
     fillMaxWidth: Boolean = false,
 ) {
     GridItem(
-        title = station.title,
-        subtitle = station.nowPlaying
-            ?.let { stringResource(R.string.station_now_playing, it.title, it.artist) }
-            .orEmpty(),
+        title = {
+            Text(
+                text = station.title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        subtitle = {
+            station.nowPlaying?.let { now ->
+                Text(
+                    text = stringResource(R.string.station_now_playing, now.title, now.artist),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 1,
+                    modifier = Modifier.basicMarquee(),
+                )
+            }
+        },
         thumbnailContent = {
             AsyncImage(
                 model = station.thumbnail,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
@@ -9,24 +9,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.AsyncImage
-import com.jtech.zemer.R
 import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.search.ZemerStation
 
 /**
  * One "Zemer Radio" station card - a [GridItem] (the SAME geometry, typography and D-pad focus
- * treatment as every other home-row card, so the row aligns with its neighbors): the station's
- * branded broadcast SVG cover (served absolute; the shared SvgDecoder renders it), the station
- * title, and the live now-playing line. That line MARQUEES instead of truncating - a ~140dp card
- * fits ~15 characters, so an ellipsized "Now: ..." prefix line carried no information (the cover
- * already carries the LIVE branding, so the prefix is dropped too). Refreshed once per home load -
- * up to one track stale by contract. Callers attach the tune-in `clickable` on [modifier], the
- * shared grid convention.
+ * treatment as every other home-row card, so the row aligns with its neighbors). The branded
+ * broadcast SVG cover already carries the station name, so the text under it does NOT repeat it:
+ * it is the live now-playing SONG (bold, marqueeing - a ~140dp card truncates uselessly) over its
+ * artist, refreshed by the on-screen ticker. The station title only appears as a fallback when the
+ * server sent no nowPlaying. Callers attach the tune-in `clickable` on [modifier], the shared grid
+ * convention.
  */
 @Composable
 fun ZemerStationCard(
@@ -37,30 +34,31 @@ fun ZemerStationCard(
     GridItem(
         title = {
             Text(
-                text = station.title,
+                text = station.nowPlaying?.title ?: station.title,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.Start,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .basicMarquee(),
             )
         },
         subtitle = {
-            station.nowPlaying?.let { now ->
+            station.nowPlaying?.artist?.takeIf { it.isNotBlank() }?.let { artist ->
                 Text(
-                    text = stringResource(R.string.station_now_playing, now.title, now.artist),
+                    text = artist,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
                     maxLines = 1,
-                    modifier = Modifier.basicMarquee(),
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         },
         thumbnailContent = {
             AsyncImage(
                 model = station.thumbnail,
-                contentDescription = null,
+                contentDescription = station.title,
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(RoundedCornerShape(ThumbnailCornerRadius)),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerStationCard.kt
@@ -1,0 +1,45 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import coil3.compose.AsyncImage
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.ThumbnailCornerRadius
+import com.jtech.zemer.search.ZemerStation
+
+/**
+ * One "Zemer Radio" station card — a plain [GridItem] (the SAME geometry, typography and D-pad
+ * focus treatment as every other home-row card, so the row aligns with its neighbors): the
+ * station's branded broadcast SVG cover (served absolute; the shared SvgDecoder renders it), the
+ * station title, and the live "Now: title — artist" line (refreshed once per home load — up to one
+ * track stale by contract). Callers attach the tune-in `clickable` on [modifier], the shared grid
+ * convention.
+ */
+@Composable
+fun ZemerStationCard(
+    station: ZemerStation,
+    modifier: Modifier = Modifier,
+    fillMaxWidth: Boolean = false,
+) {
+    GridItem(
+        title = station.title,
+        subtitle = station.nowPlaying
+            ?.let { stringResource(R.string.station_now_playing, it.title, it.artist) }
+            .orEmpty(),
+        thumbnailContent = {
+            AsyncImage(
+                model = station.thumbnail,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(ThumbnailCornerRadius)),
+            )
+        },
+        fillMaxWidth = fillMaxWidth,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -88,6 +88,7 @@ fun PlayerMenu(
     val playerConnection = LocalPlayerConnection.current ?: return
     val playerVolume = playerConnection.service.playerVolume.collectAsState()
     val isCasting by playerConnection.isCasting.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val remoteVolume by playerConnection.service.discoveryHandler.remoteVolume.collectAsState()
     val activityResultLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { }
@@ -214,7 +215,9 @@ fun PlayerMenu(
     ) {
         item {
             NewActionGrid(
-                actions = listOf(
+                actions = listOfNotNull(
+                    // Hidden during a live station: the broadcast IS radio, and swapping it for a
+                    // personal /radio queue from here would be a confusing silent exit.
                     NewAction(
                         icon = {
                             Icon(
@@ -230,7 +233,7 @@ fun PlayerMenu(
                             playerConnection.startRadioSeamlessly()
                             onDismiss()
                         }
-                    ),
+                    ).takeUnless { isStationBroadcast },
                     NewAction(
                         icon = {
                             Icon(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt
@@ -119,6 +119,7 @@ fun LyricsScreen(
     val playbackState by playerConnection.playbackState.collectAsState()
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val isCasting by playerConnection.isCasting.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val repeatMode by playerConnection.repeatMode.collectAsState()
     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
     playerConnection.service.playerVolume.collectAsState()
@@ -450,7 +451,7 @@ fun LyricsScreen(
                                 }
                                 // While casting, route through the cast-aware wrapper (seekToPreviousMediaItem — a raw
                                 // seekToPrevious would rewind the paused local player without reloading the receiver).
-                                IconButton(onClick = { if (isCasting) playerConnection.seekToPrevious() else playerConnection.player.seekToPrevious() }, modifier = Modifier.size(48.dp)) {
+                                IconButton(onClick = { if (!isStationBroadcast) { if (isCasting) playerConnection.seekToPrevious() else playerConnection.player.seekToPrevious() } }, modifier = Modifier.size(48.dp)) {
                                     Icon(
                                         painter = painterResource(R.drawable.skip_previous),
                                         contentDescription = null,
@@ -481,7 +482,7 @@ fun LyricsScreen(
                                     }
                                 }
     
-                                IconButton(onClick = { playerConnection.player.seekToNext() }, modifier = Modifier.size(48.dp)) {
+                                IconButton(onClick = { if (!isStationBroadcast) playerConnection.player.seekToNext() }, modifier = Modifier.size(48.dp)) {
                                     Icon(
                                         painter = painterResource(R.drawable.skip_next),
                                         contentDescription = null,
@@ -694,7 +695,7 @@ fun LyricsScreen(
                             }
                             // While casting, route through the cast-aware wrapper (seekToPreviousMediaItem — a raw
                             // seekToPrevious would rewind the paused local player without reloading the receiver).
-                            IconButton(onClick = { if (isCasting) playerConnection.seekToPrevious() else playerConnection.player.seekToPrevious() }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { if (!isStationBroadcast) { if (isCasting) playerConnection.seekToPrevious() else playerConnection.player.seekToPrevious() } }, modifier = Modifier.size(48.dp)) {
                                 Icon(
                                     painter = painterResource(R.drawable.skip_previous),
                                     contentDescription = null,
@@ -725,7 +726,7 @@ fun LyricsScreen(
                                 }
                             }
     
-                            IconButton(onClick = { playerConnection.player.seekToNext() }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { if (!isStationBroadcast) playerConnection.player.seekToNext() }, modifier = Modifier.size(48.dp)) {
                                 Icon(
                                     painter = painterResource(R.drawable.skip_next),
                                     contentDescription = null,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -172,6 +172,7 @@ private fun NewMiniPlayer(
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val playbackState by playerConnection.playbackState.collectAsState()
     val error by playerConnection.error.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
@@ -544,19 +545,28 @@ private fun NewMiniPlayer(
                         }
 
                         if (metadata.artists.any { it.name.isNotBlank() }) {
-                            AnimatedContent(
-                                targetState = metadata.artists.joinToString { it.name },
-                                transitionSpec = { fadeIn() togetherWith fadeOut() },
-                                label = "",
-                            ) { artists ->
-                                Text(
-                                    text = artists,
-                                    color = subtitleColor,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp),
-                                )
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                // A broadcast identifies itself on the mini bar too (handoff par. 5).
+                                if (isStationBroadcast) {
+                                    StationLiveBadge(
+                                        accentColor = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(end = 6.dp),
+                                    )
+                                }
+                                AnimatedContent(
+                                    targetState = metadata.artists.joinToString { it.name },
+                                    transitionSpec = { fadeIn() togetherWith fadeOut() },
+                                    label = "",
+                                ) { artists ->
+                                    Text(
+                                        text = artists,
+                                        color = subtitleColor,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp),
+                                    )
+                                }
                             }
                         }
 
@@ -756,6 +766,7 @@ private fun LegacyMiniPlayer(
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val playbackState by playerConnection.playbackState.collectAsState()
     val error by playerConnection.error.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
@@ -910,6 +921,7 @@ private fun LegacyMiniPlayer(
                         mediaMetadata = it,
                         error = error,
                         pureBlack = pureBlack,
+                        isStationBroadcast = isStationBroadcast,
                         modifier = Modifier.padding(horizontal = 6.dp),
                     )
                 }
@@ -982,6 +994,7 @@ private fun LegacyMiniMediaInfo(
     mediaMetadata: MediaMetadata,
     error: PlaybackException?,
     pureBlack: Boolean,
+    isStationBroadcast: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -1056,18 +1069,27 @@ private fun LegacyMiniMediaInfo(
             }
 
             if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
-                AnimatedContent(
-                    targetState = mediaMetadata.artists.joinToString { it.name },
-                    transitionSpec = { fadeIn() togetherWith fadeOut() },
-                    label = "",
-                ) { artists ->
-                    Text(
-                        text = artists,
-                        color = MaterialTheme.colorScheme.secondary,
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // A broadcast identifies itself on the mini bar too (handoff par. 5).
+                    if (isStationBroadcast) {
+                        StationLiveBadge(
+                            accentColor = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(end = 6.dp),
+                        )
+                    }
+                    AnimatedContent(
+                        targetState = mediaMetadata.artists.joinToString { it.name },
+                        transitionSpec = { fadeIn() togetherWith fadeOut() },
+                        label = "",
+                    ) { artists ->
+                        Text(
+                            text = artists,
+                            color = MaterialTheme.colorScheme.secondary,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -282,8 +282,10 @@ private fun NewMiniPlayer(
                             onHorizontalDrag = { _, dragAmount ->
                                 val adjustedDragAmount =
                                     if (layoutDirection == LayoutDirection.Rtl) -dragAmount else dragAmount
-                                val canSkipPrevious = playerConnection.player.previousMediaItemIndex != -1
-                                val canSkipNext = playerConnection.player.nextMediaItemIndex != -1
+                                // A broadcast has no transport: the swipe gesture acts on the raw
+                                // player and would bypass the session command mask.
+                                val canSkipPrevious = !isStationBroadcast && playerConnection.player.previousMediaItemIndex != -1
+                                val canSkipNext = !isStationBroadcast && playerConnection.player.nextMediaItemIndex != -1
                                 val allowLeft = adjustedDragAmount < 0 && canSkipNext
                                 val allowRight = adjustedDragAmount > 0 && canSkipPrevious
                                 if (allowLeft || allowRight) {
@@ -837,8 +839,10 @@ private fun LegacyMiniPlayer(
                             onHorizontalDrag = { _, dragAmount ->
                                 val adjustedDragAmount =
                                     if (layoutDirection == LayoutDirection.Rtl) -dragAmount else dragAmount
-                                val canSkipPrevious = playerConnection.player.previousMediaItemIndex != -1
-                                val canSkipNext = playerConnection.player.nextMediaItemIndex != -1
+                                // A broadcast has no transport: the swipe gesture acts on the raw
+                                // player and would bypass the session command mask.
+                                val canSkipPrevious = !isStationBroadcast && playerConnection.player.previousMediaItemIndex != -1
+                                val canSkipNext = !isStationBroadcast && playerConnection.player.nextMediaItemIndex != -1
                                 val allowLeft = adjustedDragAmount < 0 && canSkipNext
                                 val allowRight = adjustedDragAmount > 0 && canSkipPrevious
                                 if (allowLeft || allowRight) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -217,6 +217,7 @@ fun BottomSheetPlayer(
     val repeatMode by playerConnection.repeatMode.collectAsState()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val sliderStyle by rememberEnumPreference(SliderStyleKey, SliderStyle.DEFAULT)
 
     var position by rememberSaveable(playbackState) {
@@ -852,7 +853,13 @@ fun BottomSheetPlayer(
                     .fillMaxWidth()
                     .padding(horizontal = PlayerHorizontalPadding - 8.dp)
             ) {
-                when (sliderStyle) {
+                // A broadcast has no transport: the seek slider is replaced by the read-only LIVE
+                // bar (handoff par. 5 - no scrubbing); every non-station queue is untouched.
+                if (isStationBroadcast) StationLiveBar(
+                    position = position,
+                    duration = duration,
+                    accentColor = accentColor,
+                ) else when (sliderStyle) {
                     SliderStyle.DEFAULT -> {
                         Slider(
                             value = (sliderPosition ?: position).toFloat(),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -1088,7 +1088,7 @@ fun BottomSheetPlayer(
                                 .align(Alignment.Center)
                                 .alpha(if (repeatMode == Player.REPEAT_MODE_OFF) 0.5f else 1f),
                             onClick = {
-                                playerConnection.player.toggleRepeatMode()
+                                if (!isStationBroadcast) playerConnection.player.toggleRepeatMode()
                             },
                         )
                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
@@ -144,6 +144,7 @@ fun Queue(
 
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isPlaying.collectAsState()
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
     val repeatMode by playerConnection.repeatMode.collectAsState()
 
     val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
@@ -330,7 +331,7 @@ fun Queue(
                                 )
                             )
                             .clickable {
-                                playerConnection.player.toggleRepeatMode()
+                                if (!isStationBroadcast) playerConnection.player.toggleRepeatMode()
                             },
                         contentAlignment = Alignment.Center
                     ) {
@@ -778,6 +779,9 @@ fun Queue(
                                                 } else {
                                                     if (index == currentWindowIndex) {
                                                         playerConnection.playPause()
+                                                    } else if (isStationBroadcast) {
+                                                        // A broadcast has no transport: tapping an
+                                                        // upcoming slot must not jump the schedule.
                                                     } else {
                                                         playerConnection.player.seekToDefaultPosition(
                                                             window.firstPeriodIndex,
@@ -1082,7 +1086,7 @@ fun Queue(
                                 if (playerConnection.player.shuffleModeEnabled) playerConnection.player.currentMediaItemIndex else 0,
                             )
                         }.invokeOnCompletion {
-                            playerConnection.player.shuffleModeEnabled =
+                            if (!isStationBroadcast) playerConnection.player.shuffleModeEnabled =
                                 !playerConnection.player.shuffleModeEnabled
                         }
                 },
@@ -1102,7 +1106,7 @@ fun Queue(
 
             IconButton(
                 modifier = Modifier.align(Alignment.CenterEnd),
-                onClick = playerConnection.player::toggleRepeatMode,
+                onClick = { if (!isStationBroadcast) playerConnection.player.toggleRepeatMode() },
             ) {
                 Icon(
                     painter =

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/StationLiveBar.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/StationLiveBar.kt
@@ -1,0 +1,70 @@
+package com.jtech.zemer.ui.player
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.C
+import com.jtech.zemer.R
+
+/**
+ * The station replacement for the seek slider (handoff §5: no scrubbing — a broadcast has no
+ * transport). A LIVE badge plus a read-only progress line through the current slot; progress is
+ * informational only and never accepts input.
+ */
+@Composable
+fun StationLiveBar(
+    position: Long,
+    duration: Long,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 14.dp),
+    ) {
+        StationLiveBadge(accentColor = accentColor)
+        LinearProgressIndicator(
+            progress = {
+                if (duration == C.TIME_UNSET || duration <= 0L) 0f
+                else (position.toFloat() / duration).coerceIn(0f, 1f)
+            },
+            color = accentColor,
+            trackColor = accentColor.copy(alpha = 0.24f),
+            drawStopIndicator = {},
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 10.dp),
+        )
+    }
+}
+
+/**
+ * The shared LIVE chip — the full player's [StationLiveBar] and the mini players all render this
+ * one badge, so the broadcast treatment can never drift between surfaces.
+ */
+@Composable
+fun StationLiveBadge(
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = stringResource(R.string.station_live_badge),
+        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+        color = accentColor,
+        modifier = modifier
+            .background(accentColor.copy(alpha = 0.15f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt
@@ -97,7 +97,11 @@ fun Thumbnail(
     val error by playerConnection.error.collectAsState()
     val queueTitle by playerConnection.queueTitle.collectAsState()
 
-    val swipeThumbnail by rememberPreference(SwipeThumbnailKey, true)
+    val swipeThumbnailPref by rememberPreference(SwipeThumbnailKey, true)
+    val isStationBroadcast by playerConnection.isStationBroadcast.collectAsState()
+    // A broadcast has no transport: the thumbnail swipe-to-change-song gesture acts on the raw
+    // player, so it is disabled wholesale while a station plays (no side pages, no scroll, no seek).
+    val swipeThumbnail = swipeThumbnailPref && !isStationBroadcast
     val hidePlayerThumbnail by rememberPreference(HidePlayerThumbnailKey, false)
     val cropAlbumArt by rememberPreference(CropAlbumArtKey, false)
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -95,7 +95,10 @@ import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.latestreleases.LatestReleaseCard
 import com.jtech.zemer.viewmodels.HomeViewModel
 import com.jtech.zemer.viewmodels.LatestReleasesViewModel
+import com.jtech.zemer.playback.queues.StationQueue
+import com.jtech.zemer.ui.component.ZemerStationCard
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
+import com.jtech.zemer.viewmodels.ZemerStationsViewModel
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.PlaylistItem
@@ -141,9 +144,12 @@ fun HomeScreen(
     val latestReleases by latestReleasesViewModel.releases.collectAsState()
     val zemerPlaylistsViewModel: ZemerCuratedPlaylistsViewModel = hiltViewModel()
     val zemerPlaylists by zemerPlaylistsViewModel.playlists.collectAsState()
+    val zemerStationsViewModel: ZemerStationsViewModel = hiltViewModel()
+    val zemerStations by zemerStationsViewModel.stations.collectAsState()
     // The curated endpoint's freshness contract is a plain re-fetch on screen open (single-digit-ms
     // server reads) — this also picks up a card removed by curation while a detail open 404'd.
     LaunchedEffect(Unit) { zemerPlaylistsViewModel.refresh() }
+    LaunchedEffect(Unit) { zemerStationsViewModel.refresh() }
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
     homeUiState.isNewUser
 
@@ -372,6 +378,7 @@ fun HomeScreen(
                     // The curated "Zemer Playlists" feed is separate from HomeViewModel; re-check it
                     // on every pull so newly curated playlists appear without an app restart.
                     zemerPlaylistsViewModel.refresh()
+                    zemerStationsViewModel.refresh()
                 }
             ),
         contentAlignment = Alignment.TopStart
@@ -572,6 +579,48 @@ fun HomeScreen(
                                         // '/'/'?' can never break route matching (a crash on tap).
                                         navController.navigate("zemer_playlist/${Uri.encode(playlist.id)}")
                                     }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // "Zemer Radio" - the synchronized broadcast stations (one shared wall-clock
+                // schedule per station; tap = tune in at the live position). Live cards only;
+                // empty/unreachable hides the row (the /home-rows fail-soft convention). The Home
+                // tab is never reachable from inside KidZone, satisfying the contract's
+                // hide-in-kidZone rule the same way the curated shelf does.
+                zemerStations.takeIf { it.isNotEmpty() }?.let { stations ->
+                    item(key = "zemer_stations_title", contentType = "header") {
+                        NavigationTitle(
+                            title = stringResource(R.string.zemer_radio),
+                            onClick = { navController.navigate("zemer_stations") },
+                            modifier = Modifier.animateItem()
+                        )
+                    }
+
+                    item(key = "zemer_stations_list", contentType = "grid") {
+                        LazyRow(
+                            contentPadding = WindowInsets.systemBars
+                                .only(WindowInsetsSides.Horizontal)
+                                .asPaddingValues(),
+                            modifier = Modifier.animateItem()
+                        ) {
+                            items(
+                                items = stations,
+                                key = { it.id },
+                                contentType = { "zemer_station" }
+                            ) { station ->
+                                ZemerStationCard(
+                                    station = station,
+                                    modifier = Modifier
+                                        .animateItem()
+                                        .clickable {
+                                            // Tune in at the live broadcast position.
+                                            playerConnection.playQueue(
+                                                StationQueue(station.id, playerConnection.service)
+                                            )
+                                        }
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -98,6 +98,8 @@ import com.jtech.zemer.viewmodels.LatestReleasesViewModel
 import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.ui.component.ZemerStationCard
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
+import kotlinx.coroutines.delay
+import com.jtech.zemer.viewmodels.STATION_ROW_REFRESH_MS
 import com.jtech.zemer.viewmodels.ZemerStationsViewModel
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -149,7 +151,15 @@ fun HomeScreen(
     // The curated endpoint's freshness contract is a plain re-fetch on screen open (single-digit-ms
     // server reads) — this also picks up a card removed by curation while a detail open 404'd.
     LaunchedEffect(Unit) { zemerPlaylistsViewModel.refresh() }
-    LaunchedEffect(Unit) { zemerStationsViewModel.refresh() }
+    LaunchedEffect(Unit) {
+        zemerStationsViewModel.refresh()
+        // Keep the cards' now-playing line live while Home is visible: the ticker dies with the
+        // composition, so nothing polls in the background (tracks run 3-4 min; 60s is current enough).
+        while (true) {
+            delay(STATION_ROW_REFRESH_MS)
+            zemerStationsViewModel.refresh()
+        }
+    }
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
     homeUiState.isNewUser
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -99,6 +99,9 @@ import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.ui.component.ZemerStationCard
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
 import kotlinx.coroutines.delay
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.jtech.zemer.viewmodels.STATION_ROW_REFRESH_MS
 import com.jtech.zemer.viewmodels.ZemerStationsViewModel
 import com.metrolist.innertube.models.AlbumItem
@@ -151,13 +154,17 @@ fun HomeScreen(
     // The curated endpoint's freshness contract is a plain re-fetch on screen open (single-digit-ms
     // server reads) — this also picks up a card removed by curation while a detail open 404'd.
     LaunchedEffect(Unit) { zemerPlaylistsViewModel.refresh() }
+    val stationsLifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(Unit) {
-        zemerStationsViewModel.refresh()
-        // Keep the cards' now-playing line live while Home is visible: the ticker dies with the
-        // composition, so nothing polls in the background (tracks run 3-4 min; 60s is current enough).
-        while (true) {
-            delay(STATION_ROW_REFRESH_MS)
+        // Keep the cards' now-playing line live while Home is actually VISIBLE: repeatOnLifecycle
+        // suspends the ticker the moment the app leaves RESUMED (composition alone survives
+        // backgrounding, so a bare while-loop would keep polling from the recents stack).
+        stationsLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             zemerStationsViewModel.refresh()
+            while (true) {
+                delay(STATION_ROW_REFRESH_MS)
+                zemerStationsViewModel.refresh()
+            }
         }
     }
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NavigationBuilder.kt
@@ -97,6 +97,9 @@ fun NavGraphBuilder.navigationBuilder(
     composable("zemer_playlists") {
         ZemerPlaylistsScreen(navController, scrollBehavior)
     }
+    composable("zemer_stations") {
+        ZemerStationsScreen(navController, scrollBehavior)
+    }
     composable(
         route = "home_see_all/{row}",
         arguments = listOf(navArgument("row") { type = NavType.StringType }),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
@@ -28,6 +28,9 @@ import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.ZemerStationCard
 import com.jtech.zemer.ui.utils.backToMain
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.jtech.zemer.viewmodels.STATION_ROW_REFRESH_MS
 import com.jtech.zemer.viewmodels.ZemerStationsViewModel
 import kotlinx.coroutines.delay
@@ -46,12 +49,16 @@ fun ZemerStationsScreen(
 ) {
     val playerConnection = LocalPlayerConnection.current
     val stations by viewModel.stations.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(Unit) {
-        viewModel.refresh()
-        // Same on-screen now-playing ticker as the home row (composition-scoped, no background work).
-        while (true) {
-            delay(STATION_ROW_REFRESH_MS)
+        // Same lifecycle-scoped now-playing ticker as the home row: suspended outside RESUMED, so
+        // nothing polls while the app is backgrounded.
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             viewModel.refresh()
+            while (true) {
+                delay(STATION_ROW_REFRESH_MS)
+                viewModel.refresh()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
@@ -28,7 +28,9 @@ import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.ZemerStationCard
 import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.viewmodels.STATION_ROW_REFRESH_MS
 import com.jtech.zemer.viewmodels.ZemerStationsViewModel
+import kotlinx.coroutines.delay
 
 /**
  * The "See all" screen for the Home "Zemer Radio" section: every live station as a grid (the same
@@ -44,7 +46,14 @@ fun ZemerStationsScreen(
 ) {
     val playerConnection = LocalPlayerConnection.current
     val stations by viewModel.stations.collectAsState()
-    LaunchedEffect(Unit) { viewModel.refresh() }
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+        // Same on-screen now-playing ticker as the home row (composition-scoped, no background work).
+        while (true) {
+            delay(STATION_ROW_REFRESH_MS)
+            viewModel.refresh()
+        }
+    }
 
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
@@ -1,0 +1,85 @@
+package com.jtech.zemer.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.jtech.zemer.LocalPlayerAwareWindowInsets
+import com.jtech.zemer.LocalPlayerConnection
+import com.jtech.zemer.R
+import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.playback.queues.StationQueue
+import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.ZemerStationCard
+import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.viewmodels.ZemerStationsViewModel
+
+/**
+ * The "See all" screen for the Home "Zemer Radio" section: every live station as a grid (the same
+ * card the row uses — cover, title, nowPlaying line), fresh-fetched on open like every Zemer
+ * see-all. Tapping tunes in at the live broadcast position ([StationQueue]).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ZemerStationsScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: ZemerStationsViewModel = hiltViewModel(),
+) {
+    val playerConnection = LocalPlayerConnection.current
+    val stations by viewModel.stations.collectAsState()
+    LaunchedEffect(Unit) { viewModel.refresh() }
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
+        contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+    ) {
+        items(
+            items = stations,
+            key = { it.id },
+        ) { station ->
+            ZemerStationCard(
+                station = station,
+                fillMaxWidth = true,
+                modifier = Modifier.clickable {
+                    // Tune in at the live broadcast position.
+                    playerConnection?.let { pc ->
+                        pc.playQueue(StationQueue(station.id, pc.service))
+                    }
+                },
+            )
+        }
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.zemer_radio)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
@@ -1,0 +1,42 @@
+package com.jtech.zemer.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.ZemerStation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+
+/**
+ * The "Zemer Radio" home row's own ViewModel (the LatestReleases isolation pattern): a stations
+ * fetch failure can never affect the rest of Home — the row just hides (empty list, the `/home-rows`
+ * fail-soft convention). One fetch per home load ([refresh]) is the settled freshness contract for
+ * the cards' nowPlaying line; no timers, no polling. No content flags exist for stations (pools are
+ * pre-filtered server-side), so there is no flag-change re-fetch either.
+ */
+@HiltViewModel
+class ZemerStationsViewModel @Inject constructor(
+    private val repository: ZemerSearchRepository,
+) : ViewModel() {
+    private val _stations = MutableStateFlow<List<ZemerStation>>(emptyList())
+    val stations: StateFlow<List<ZemerStation>> = _stations.asStateFlow()
+
+    private val refreshMutex = Mutex()
+
+    fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            refreshMutex.withLock {
+                // Failure keeps the previous cards (or hides a never-loaded row); a live broadcast
+                // catalog is not worth an error state on Home.
+                runCatching { repository.stations() }.onSuccess { _stations.value = it }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
@@ -19,8 +19,8 @@ import javax.inject.Inject
  * fetch failure can never affect the rest of Home — the row just hides (empty list, the `/home-rows`
  * fail-soft convention). [refresh] runs on load AND on a 60s ticker while the row is ON SCREEN
  * (an operator cadence upgrade over the handoff's once-per-load default — a stale now-playing line
- * reads as broken; the ticker is composition-scoped so nothing polls in the background, and
- * `/stations` is a single cheap read). No content flags exist for stations (pools are pre-filtered
+ * reads as broken; the ticker is LIFECYCLE-scoped via repeatOnLifecycle(RESUMED), so it suspends the
+ * moment the app is backgrounded, and `/stations` is a single cheap read). No content flags exist for stations (pools are pre-filtered
  * server-side), so there is no flag-change re-fetch.
  */
 @HiltViewModel

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt
@@ -17,9 +17,11 @@ import javax.inject.Inject
 /**
  * The "Zemer Radio" home row's own ViewModel (the LatestReleases isolation pattern): a stations
  * fetch failure can never affect the rest of Home — the row just hides (empty list, the `/home-rows`
- * fail-soft convention). One fetch per home load ([refresh]) is the settled freshness contract for
- * the cards' nowPlaying line; no timers, no polling. No content flags exist for stations (pools are
- * pre-filtered server-side), so there is no flag-change re-fetch either.
+ * fail-soft convention). [refresh] runs on load AND on a 60s ticker while the row is ON SCREEN
+ * (an operator cadence upgrade over the handoff's once-per-load default — a stale now-playing line
+ * reads as broken; the ticker is composition-scoped so nothing polls in the background, and
+ * `/stations` is a single cheap read). No content flags exist for stations (pools are pre-filtered
+ * server-side), so there is no flag-change re-fetch.
  */
 @HiltViewModel
 class ZemerStationsViewModel @Inject constructor(
@@ -40,3 +42,6 @@ class ZemerStationsViewModel @Inject constructor(
         }
     }
 }
+
+/** On-screen refresh cadence for the station cards' now-playing line (see the class KDoc). */
+const val STATION_ROW_REFRESH_MS = 60_000L

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -551,6 +551,10 @@
     <string name="offline_search_promo_body">Download a backup of the catalog once and search keeps working even when the Zemer server is unreachable</string>
     <string name="offline_search_promo_action">Set up</string>
     <string name="offline_search_promo_dismiss">Not now</string>
+    <!-- Zemer Stations (synchronized broadcast radio) -->
+    <string name="zemer_radio">Zemer Radio</string>
+    <string name="station_live_badge">LIVE</string>
+    <string name="station_now_playing">Now: %1$s — %2$s</string>
     <string name="onboarding_backup_title">Search backup</string>
     <string name="onboarding_backup_question">Should search keep working even when the Zemer server is unreachable?</string>
     <string name="onboarding_backup_enable">Download a backup</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -554,7 +554,9 @@
     <!-- Zemer Stations (synchronized broadcast radio) -->
     <string name="zemer_radio">Zemer Radio</string>
     <string name="station_live_badge">LIVE</string>
-    <string name="station_now_playing">Now: %1$s — %2$s</string>
+    <!-- The station card's live now-playing line: title, then artist. No "Now:" prefix - the card
+         is ~15 characters wide and the cover already carries the LIVE branding. -->
+    <string name="station_now_playing">%1$s • %2$s</string>
     <string name="onboarding_backup_title">Search backup</string>
     <string name="onboarding_backup_question">Should search keep working even when the Zemer server is unreachable?</string>
     <string name="onboarding_backup_enable">Download a backup</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -554,9 +554,6 @@
     <!-- Zemer Stations (synchronized broadcast radio) -->
     <string name="zemer_radio">Zemer Radio</string>
     <string name="station_live_badge">LIVE</string>
-    <!-- The station card's live now-playing line: title, then artist. No "Now:" prefix - the card
-         is ~15 characters wide and the cover already carries the LIVE branding. -->
-    <string name="station_now_playing">%1$s • %2$s</string>
     <string name="onboarding_backup_title">Search backup</string>
     <string name="onboarding_backup_question">Should search keep working even when the Zemer server is unreachable?</string>
     <string name="onboarding_backup_enable">Download a backup</string>

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
@@ -1,0 +1,112 @@
+package com.jtech.zemer.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Zemer Stations wire layer: the handoff-doc sample payloads decode field-for-field with the shared
+ * lenient reader, the card-shaping rules ([liveStations]) hold, and the §4 tune-in clock math is
+ * pinned (skew, live-offset join, the dying-track and drift rules). The playback queue itself lands
+ * in the follow-up PR — these contracts are what it builds on.
+ */
+class ZemerStationsTest {
+
+    // --- wire decode (payload shapes straight from the handoff doc) ---
+
+    @Test
+    fun `stations catalog decodes with relative covers and nowPlaying`() {
+        val json = """
+            { "count": 3,
+              "stations": [
+                { "id": "chasidish", "title": "Chassidish Radio",
+                  "thumbnail": "/stations/cover?id=chasidish",
+                  "live": true,
+                  "nowPlaying": { "title": "T", "artist": "A", "thumbnail": "https://i.ytimg.com/x.jpg" } }
+              ],
+              "serverTimeMs": 1785400000000 }
+        """.trimIndent()
+
+        val resp = zemerResponseJson.decodeFromString(ZemerStationsResponse.serializer(), json)
+        assertEquals(3, resp.count)
+        assertEquals(1785400000000, resp.serverTimeMs)
+        val s = resp.stations.single()
+        assertEquals("chasidish", s.id)
+        assertEquals("Chassidish Radio", s.title)
+        assertEquals("/stations/cover?id=chasidish", s.thumbnail)
+        assertTrue(s.live)
+        assertEquals("T", s.nowPlaying?.title)
+        assertEquals("A", s.nowPlaying?.artist)
+    }
+
+    @Test
+    fun `tune-in payload decodes - now carries offsetMs, next entries do not`() {
+        val json = """
+            { "station": { "id": "dj", "title": "DJ Radio", "thumbnail": "/stations/cover?id=dj" },
+              "serverTimeMs": 1785400000000,
+              "horizonMs": 172000000,
+              "now": { "videoId": "v1", "title": "T1", "artist": "A1", "artistId": "UCx",
+                       "thumbnail": null, "durationSec": 224,
+                       "startMs": 1785399900000, "endMs": 1785400124000, "offsetMs": 100000 },
+              "next": [ { "videoId": "v2", "title": "T2", "artist": "A2",
+                          "startMs": 1785400124000, "endMs": 1785400300000 } ] }
+        """.trimIndent()
+
+        val resp = zemerResponseJson.decodeFromString(ZemerStationTuneInResponse.serializer(), json)
+        assertEquals("dj", resp.station.id)
+        assertEquals(172000000, resp.horizonMs)
+        assertEquals("v1", resp.now?.videoId)
+        assertEquals(100000L, resp.now?.offsetMs)
+        assertNull("null thumbnail = coverless standalone", resp.now?.thumbnail)
+        assertEquals("v2", resp.next.single().videoId)
+        assertNull("next entries carry no offset", resp.next.single().offsetMs)
+    }
+
+    // --- card shaping ---
+
+    @Test
+    fun `only live stations with a real id render, deduped, covers resolved absolute`() {
+        val resp = ZemerStationsResponse(
+            stations = listOf(
+                ZemerStation(id = "chasidish", title = "C", thumbnail = "/stations/cover?id=chasidish", live = true),
+                ZemerStation(id = "offline", title = "O", live = false),
+                ZemerStation(id = "", title = "sparse", live = true),
+                ZemerStation(id = "chasidish", title = "dup", live = true),
+            ),
+        )
+
+        val cards = resp.liveStations { url -> url?.let { "https://search.zemer.io$it" } }
+
+        assertEquals(listOf("chasidish"), cards.map { it.id })
+        assertEquals("https://search.zemer.io/stations/cover?id=chasidish", cards.single().thumbnail)
+    }
+
+    // --- §4 clock math ---
+
+    private val entry = ZemerStationEntry(videoId = "v", startMs = 1_000_000, endMs = 1_224_000)
+
+    @Test
+    fun `join position is the live wall-clock offset inside the track`() {
+        // Server is 2s ahead of the local clock; 100s into the track on the server clock.
+        val skew = stationSkewMs(serverTimeMs = 1_100_000, localTimeMs = 1_098_000)
+        assertEquals(2_000L, skew)
+        assertEquals(100_000L, stationJoinPositionMs(entry, skew, localNowMs = 1_098_000))
+    }
+
+    @Test
+    fun `joining inside the last 5s skips the dying track`() {
+        assertFalse(stationShouldSkipDyingTrack(entry, skewMs = 0, localNowMs = 1_218_999))
+        assertTrue(stationShouldSkipDyingTrack(entry, skewMs = 0, localNowMs = 1_219_000))
+        assertTrue("skew counts toward the wall", stationShouldSkipDyingTrack(entry, skewMs = 2_000, localNowMs = 1_217_500))
+    }
+
+    @Test
+    fun `drift corrects only beyond 3s - and only compares against the live position`() {
+        // Live position is 100s in; 2.9s of drift is tolerated, 3.1s is not.
+        assertFalse(stationDriftExceedsLimit(playbackPositionMs = 97_100, entry = entry, skewMs = 0, localNowMs = 1_100_000))
+        assertTrue(stationDriftExceedsLimit(playbackPositionMs = 96_900, entry = entry, skewMs = 0, localNowMs = 1_100_000))
+        assertTrue("ahead drifts too", stationDriftExceedsLimit(playbackPositionMs = 103_100, entry = entry, skewMs = 0, localNowMs = 1_100_000))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
@@ -96,6 +96,16 @@ class ZemerStationsTest {
     }
 
     @Test
+    fun `a not-yet-started entry joins at 0 - the addendum's negative-offset case`() {
+        // Local+skew is 1.5s BEFORE startMs: join position is negative, seek clamps to 0.
+        val join = stationJoinPositionMs(entry, skewMs = 0, localNowMs = 998_500)
+        assertEquals(-1_500L, join)
+        assertEquals(0L, stationStartPositionMs(join))
+        // A normal mid-track join passes through unchanged.
+        assertEquals(100_000L, stationStartPositionMs(100_000L))
+    }
+
+    @Test
     fun `joining inside the last 5s skips the dying track`() {
         assertFalse(stationShouldSkipDyingTrack(entry, skewMs = 0, localNowMs = 1_218_999))
         assertTrue(stationShouldSkipDyingTrack(entry, skewMs = 0, localNowMs = 1_219_000))

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt
@@ -9,8 +9,9 @@ import org.junit.Test
 /**
  * Zemer Stations wire layer: the handoff-doc sample payloads decode field-for-field with the shared
  * lenient reader, the card-shaping rules ([liveStations]) hold, and the §4 tune-in clock math is
- * pinned (skew, live-offset join, the dying-track and drift rules). The playback queue itself lands
- * in the follow-up PR — these contracts are what it builds on.
+ * pinned (skew, live-offset join, the dying-track rule, and the on-air window the bidirectional
+ * resync is built on). [StationQueue]/MusicService wiring has no JVM seam (Hilt EntryPoint +
+ * Media3) — these pure contracts are what it builds on.
  */
 class ZemerStationsTest {
 
@@ -113,10 +114,14 @@ class ZemerStationsTest {
     }
 
     @Test
-    fun `drift corrects only beyond 3s - and only compares against the live position`() {
-        // Live position is 100s in; 2.9s of drift is tolerated, 3.1s is not.
-        assertFalse(stationDriftExceedsLimit(playbackPositionMs = 97_100, entry = entry, skewMs = 0, localNowMs = 1_100_000))
-        assertTrue(stationDriftExceedsLimit(playbackPositionMs = 96_900, entry = entry, skewMs = 0, localNowMs = 1_100_000))
-        assertTrue("ahead drifts too", stationDriftExceedsLimit(playbackPositionMs = 103_100, entry = entry, skewMs = 0, localNowMs = 1_100_000))
+    fun `on-air offset is the live position only while the slot is broadcasting`() {
+        // Mid-slot: 100s in.
+        assertEquals(100_000L, stationOnAirOffsetMs(entry, skewMs = 0, localNowMs = 1_100_000))
+        // Before startMs (we are AHEAD - wait, don't play): null.
+        assertNull(stationOnAirOffsetMs(entry, skewMs = 0, localNowMs = 999_000))
+        // At/after endMs (the slot ended - we are BEHIND, move on): null.
+        assertNull(stationOnAirOffsetMs(entry, skewMs = 0, localNowMs = 1_224_000))
+        // Exactly at startMs joins at 0.
+        assertEquals(0L, stationOnAirOffsetMs(entry, skewMs = 0, localNowMs = 1_000_000))
     }
 }


### PR DESCRIPTION
Implements the full app side of the Zemer Stations contract (`~/zemer-fix/handoff-docs/zemer-app-stations.md`, all questions + the same-day addendum settled 2026-07-29). Three stations are broadcasting live on `search.zemer.io` right now; the wire models were verified against them.

## What a station is
One shared, server-programmed wall-clock schedule per station: every listener hears the same track at the same moment, joining mid-song like FM. The server owns the program; audio still streams from YouTube exactly as everywhere else. Complementary to `/radio` (personal, seeded) - this is lean-back broadcast.

## The pieces
- **Wire layer**: `/stations` + `/station?id=&next=` clients (no content flags - pools are pre-filtered server-side; 404 AND 503 return null; never cached), `liveStations()` card shaping, and the tune-in clock math as pure functions (skew, live join position, the negative-offset start-at-0 addendum case, the 5s dying-track rule, the 3s boundary-only drift rule) - all unit-tested (`ZemerStationsTest`).
- **`StationQueue`**: joins at the live offset, keeps the runway loaded, rejoins after skipped/blocked slots, tags every play `station:<id>`. Blocked-ids run client-side as the third defense layer.
- **Broadcast semantics in `MusicService`**: boundary-only drift correction, pause = stop with resume = rejoin-live, a broadcast is never persisted to disk, an unstreamable slot skips and rejoins (the existing zero-play-time guard keeps it out of the play stats, exactly per the handoff answer).
- **Transport masking**: the session player (`CastAwarePlayer`) strips all skip/seek commands while a station plays - notification, Android Auto and Bluetooth get play/stop only; in-app, the skip flows go false, the full player swaps the seek slider for the read-only `StationLiveBar`, and both mini players show the shared `StationLiveBadge`.
- **Home "Zemer Radio" row** (under Zemer Playlists): `GridItem`-based cards (same geometry/typography/D-pad treatment as the neighboring rows), a marqueeing `title • artist` now-playing line kept live by a **60s on-screen ticker** (composition-scoped - zero background polling; an operator cadence upgrade noted in the handoff thread), a See-all arrow to the new `zemer_stations` grid, fail-soft hidden when empty/unreachable, isolated ViewModel so a stations failure can never break Home.
- **Docs**: AGENTS.md gains the stations invariants; `docs/tracking` declares `station:<id>`.

## No regressions
Every station behavior is gated on the queue type: the command mask delegates to `super` on the non-station path, and the persist guard, slider swap, badges, skip-flow gating and error handling all check the flag first - a non-station session executes byte-identical code. Full unit suite, debug + release (R8) builds, ui-audit and check-dead-resources green.

## Testing
Pure sync math + wire decode + card shaping under JVM tests; `StationQueue`/`MusicService` wiring has no JVM seam (Hilt EntryPoint + Media3), stated per the testing rule. On-device checklist:
1. Home shows the Zemer Radio row with live now-lines; the arrow opens the grid.
2. Tap a station: playback joins MID-SONG; two devices tuned to the same station play the same thing.
3. Notification/Auto/Bluetooth show play/stop only; the full player shows the LIVE bar (no scrubbing); both mini players show the LIVE badge.
4. Pause, wait a minute, resume: playback JUMPS to the live position.
5. Kill and reopen the app: the station is not restored (previous queue behavior intact).