### PR TITLE
feat(ui): 5-tap Home-title easter egg

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -23,6 +23,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -228,7 +230,10 @@ import com.jtech.zemer.ui.theme.DefaultThemeColor
 import com.jtech.zemer.ui.theme.ZemerTheme
 import com.jtech.zemer.ui.theme.extractThemeColor
 import com.jtech.zemer.ui.theme.rememberPureBlack
+import com.jtech.zemer.ui.utils.HOME_EASTER_EGG_TAPS
 import com.jtech.zemer.ui.utils.appBarScrollBehavior
+import com.jtech.zemer.ui.utils.easterEggTapCount
+import com.jtech.zemer.ui.utils.playHomeEasterEgg
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.resetHeightOffset
 import com.jtech.zemer.utils.ButtonInputCapture
@@ -1418,9 +1423,35 @@ class MainActivity : ComponentActivity() {
                                     Row {
                                         TopAppBar(
                                             title = {
+                                                // 5 quick taps on the Home title play the easter-egg
+                                                // song (the counter + playback live in
+                                                // ui/utils/HomeTitleEasterEgg.kt). Ripple-free so the
+                                                // title looks inert; other tabs' titles stay plain.
+                                                var eggTaps by remember { mutableStateOf(0) }
+                                                var eggLastTapAt by remember { mutableStateOf(0L) }
                                                 Text(
                                                     text = currentTitleRes?.let { stringResource(it) } ?: "",
                                                     style = MaterialTheme.typography.titleLarge,
+                                                    modifier = if (currentTitleRes == R.string.home) {
+                                                        Modifier.clickable(
+                                                            interactionSource = remember { MutableInteractionSource() },
+                                                            indication = null,
+                                                        ) {
+                                                            val now = System.currentTimeMillis()
+                                                            eggTaps = easterEggTapCount(eggTaps, eggLastTapAt, now)
+                                                            eggLastTapAt = now
+                                                            if (eggTaps >= HOME_EASTER_EGG_TAPS) {
+                                                                eggTaps = 0
+                                                                playerConnection?.let { pc ->
+                                                                    coroutineScope.launch(Dispatchers.IO) {
+                                                                        playHomeEasterEgg(pc, database)
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    } else {
+                                                        Modifier
+                                                    },
                                                 )
                                             },
                                             navigationIcon = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/HomeTitleEasterEgg.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/HomeTitleEasterEgg.kt
@@ -1,0 +1,51 @@
+package com.jtech.zemer.ui.utils
+
+import com.jtech.zemer.db.MusicDatabase
+import com.jtech.zemer.models.toMediaMetadata
+import com.jtech.zemer.playback.PlayerConnection
+import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.utils.filterWhitelisted
+import com.jtech.zemer.utils.reportException
+import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.WatchEndpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** The song behind the 5-tap Home-title easter egg (`music.zemer.io/watch?v=<this>`). */
+const val HOME_EASTER_EGG_VIDEO_ID = "84mNcwGCIUE"
+
+/** Taps required to trigger the easter egg. */
+const val HOME_EASTER_EGG_TAPS = 5
+
+/** A gap longer than this between taps resets the count (an idle tap is not a sequence). */
+const val HOME_EASTER_EGG_TAP_WINDOW_MS = 1_500L
+
+/**
+ * Pure tap-sequence counter (unit-tested): the new count after a tap at [nowMs], resetting to 1
+ * when the gap since [lastTapAtMs] exceeds the window. The caller fires at [HOME_EASTER_EGG_TAPS].
+ */
+fun easterEggTapCount(previousCount: Int, lastTapAtMs: Long, nowMs: Long): Int =
+    if (nowMs - lastTapAtMs > HOME_EASTER_EGG_TAP_WINDOW_MS) 1 else previousCount + 1
+
+/**
+ * Plays the easter-egg song EXACTLY like an incoming `music.zemer.io/watch` deep link
+ * (MainActivity's handler): resolve via `YouTube.queue`, run the whitelist filter (the kosher
+ * guarantee applies to easter eggs too - a non-whitelisted egg is silently ignored), then start the
+ * standard watch-endpoint queue. Failures are reported, never surfaced - it's an egg.
+ */
+suspend fun playHomeEasterEgg(playerConnection: PlayerConnection, database: MusicDatabase) {
+    YouTube.queue(listOf(HOME_EASTER_EGG_VIDEO_ID)).onSuccess { queue ->
+        val filtered = queue.filterWhitelisted(database).filterIsInstance<SongItem>()
+        val song = filtered.firstOrNull() ?: return
+        withContext(Dispatchers.Main) {
+            playerConnection.playQueue(
+                YouTubeQueue(
+                    WatchEndpoint(videoId = song.id),
+                    song.toMediaMetadata(),
+                    database,
+                ),
+            )
+        }
+    }.onFailure(::reportException)
+}

--- a/app/src/test/kotlin/com/jtech/zemer/ui/HomeTitleEasterEggTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/HomeTitleEasterEggTest.kt
@@ -1,0 +1,36 @@
+package com.jtech.zemer.ui
+
+import com.jtech.zemer.ui.utils.HOME_EASTER_EGG_TAPS
+import com.jtech.zemer.ui.utils.HOME_EASTER_EGG_TAP_WINDOW_MS
+import com.jtech.zemer.ui.utils.easterEggTapCount
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** The Home-title easter egg's tap-sequence rule: quick taps accumulate, an idle gap resets. */
+class HomeTitleEasterEggTest {
+
+    @Test
+    fun `quick taps accumulate to the trigger count`() {
+        var count = 0
+        var lastAt = 0L
+        var now = 10_000L
+        repeat(HOME_EASTER_EGG_TAPS) {
+            count = easterEggTapCount(count, lastAt, now)
+            lastAt = now
+            now += 300
+        }
+        assertEquals(HOME_EASTER_EGG_TAPS, count)
+    }
+
+    @Test
+    fun `an idle gap resets the sequence to one`() {
+        val count = easterEggTapCount(previousCount = 4, lastTapAtMs = 10_000, nowMs = 10_000 + HOME_EASTER_EGG_TAP_WINDOW_MS + 1)
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `a tap exactly at the window edge still counts`() {
+        val count = easterEggTapCount(previousCount = 2, lastTapAtMs = 10_000, nowMs = 10_000 + HOME_EASTER_EGG_TAP_WINDOW_MS)
+        assertEquals(3, count)
+    }
+}


### PR DESCRIPTION
Five quick taps on the **Home** top-bar title (a 1.5s idle gap resets the sequence) play the easter-egg song (`music.zemer.io/watch?v=84mNcwGCIUE`).

- Playback reuses the deep-link semantics exactly: `YouTube.queue` resolve, the **whitelist filter still applies** (a non-whitelisted egg is silently ignored - the kosher guarantee has no exceptions), then the standard watch-endpoint queue.
- Ripple-free tap target so the title looks inert; other tabs' titles are untouched.
- Modular per the engineering rules: counter + playback helper in `ui/utils/HomeTitleEasterEgg.kt`, not grown into MainActivity; the pure tap-sequence rule is unit-tested (accumulate, idle reset, window edge). The playback wiring itself has no JVM seam, stated per the testing rule.

Full unit suite, debug + release (R8) builds, and ui-audit green.