### PR TITLE
fix(stations): row tap on the playing song restarts it during a broadcast

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -95,6 +95,7 @@ import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
@@ -459,7 +460,7 @@ fun AlbumScreen(
                                 .combinedClickable(
                                     onClick = {
                                         if (!selection) {
-                                            if (songWrapper.item.id == mediaMetadata?.id) {
+                                            if (activeRowTapTogglesPlayPause(songWrapper.item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                 playerConnection.playPause()
                                             } else {
                                                 playerConnection.service.getAutomix(playlistId)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
@@ -68,6 +68,7 @@ import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.ChartsViewModel
@@ -268,7 +269,7 @@ fun ChartsScreen(
                                                 .width(horizontalLazyGridItemWidth)
                                                 .combinedClickable(
                                                     onClick = {
-                                                        if (song.id == mediaMetadata?.id) {
+                                                        if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                             playerConnection.playPause()
                                                         } else {
                                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
@@ -69,6 +69,7 @@ import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.DateAgo
@@ -256,7 +257,7 @@ fun HistoryScreen(
                                 .fillMaxWidth()
                                 .combinedClickable(
                                     onClick = {
-                                        if (song.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(
@@ -332,7 +333,7 @@ fun HistoryScreen(
                                 .combinedClickable(
                                     onClick = {
                                         if (!selection) {
-                                            if (event.song.id == mediaMetadata?.id) {
+                                            if (activeRowTapTogglesPlayPause(event.song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                 playerConnection.playPause()
                                             } else {
                                                 playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -90,6 +90,7 @@ import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.videoRoute
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.latestreleases.LatestReleaseCard
@@ -233,7 +234,7 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            if (it.id == mediaMetadata?.id) {
+                            if (activeRowTapTogglesPlayPause(it.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                 playerConnection.playPause()
                             } else {
                                 playerConnection.playQueue(
@@ -501,7 +502,7 @@ fun HomeScreen(
                                         .width(horizontalLazyGridItemWidth)
                                         .combinedClickable(
                                             onClick = {
-                                                if (song!!.id == mediaMetadata?.id) {
+                                                if (activeRowTapTogglesPlayPause(song!!.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(
@@ -785,7 +786,7 @@ fun HomeScreen(
                                         .width(horizontalLazyGridItemWidth)
                                         .combinedClickable(
                                             onClick = {
-                                                if (song!!.id == mediaMetadata?.id) {
+                                                if (activeRowTapTogglesPlayPause(song!!.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -55,6 +55,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.viewmodels.HomeSeeAllStore
@@ -224,7 +225,7 @@ private fun SongList(songs: List<Song>, navController: NavController) {
                 },
                 modifier = Modifier.combinedClickable(
                     onClick = {
-                        if (shown.id == mediaMetadata?.id) playerConnection.playPause()
+                        if (activeRowTapTogglesPlayPause(shown.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) playerConnection.playPause()
                         else playerConnection.playQueue(ZemerRadioQueue.song(shown.toMediaMetadata(), playerConnection.service))
                     },
                     onLongClick = {
@@ -261,7 +262,7 @@ private fun LocalItemList(items: List<LocalItem>, navController: NavController) 
                     },
                     modifier = Modifier.combinedClickable(
                         onClick = {
-                            if (item.id == mediaMetadata?.id) playerConnection.playPause()
+                            if (activeRowTapTogglesPlayPause(item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) playerConnection.playPause()
                             else playerConnection.playQueue(ZemerRadioQueue.song(item.toMediaMetadata(), playerConnection.service))
                         },
                         onLongClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
@@ -50,6 +50,7 @@ import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.joinByBullet
 import com.jtech.zemer.utils.makeTimeString
@@ -255,7 +256,7 @@ fun StatsScreen(
                                 .fillMaxWidth()
                                 .combinedClickable(
                                     onClick = {
-                                        if (song.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/YouTubeBrowseScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/YouTubeBrowseScreen.kt
@@ -62,6 +62,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.YouTubeBrowseViewModel
@@ -175,7 +176,7 @@ fun YouTubeBrowseScreen(
                                             modifier =
                                             Modifier
                                                 .clickable {
-                                                    if (song.id == mediaMetadata?.id) {
+                                                    if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                         playerConnection.playPause()
                                                     } else {
                                                         playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
@@ -56,6 +56,7 @@ import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.videoRoute
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.ArtistItemsViewModel
 import com.metrolist.innertube.models.AlbumItem
@@ -184,7 +185,7 @@ fun ArtistItemsScreen(
                             } else if (!isVideoSection) {
                                 when (item) {
                                     is SongItem -> {
-                                        if (item.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             // Mark as video if from video section

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -116,6 +116,7 @@ import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.videoRoute
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.fadingEdge
 import com.jtech.zemer.ui.utils.resize
@@ -532,7 +533,7 @@ fun ArtistScreen(
                                     .fillMaxWidth()
                                     .combinedClickable(
                                         onClick = {
-                                            if (song.id == mediaMetadata?.id) {
+                                            if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                 playerConnection.playPause()
                                             } else {
                                                 playerConnection.playQueue(
@@ -694,7 +695,7 @@ fun ArtistScreen(
                                                     val artistDisplay = song.artists.joinToString(" • ") { it.name }
                                                     navController.navigate(videoRoute(song.id, song.title, artistDisplay))
                                                 } else if (!isVideoSection) {
-                                                    if (song.id == mediaMetadata?.id) {
+                                                    if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                         playerConnection.playPause()
                                                     } else {
                                                         playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
@@ -36,6 +36,7 @@ import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.YtItemGrid
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.ArtistViewModel
 import com.metrolist.innertube.models.SongItem
@@ -130,7 +131,7 @@ private fun ArtistSongList(
                 },
                 modifier = Modifier.combinedClickable(
                     onClick = {
-                        if (song.id == mediaMetadata?.id) {
+                        if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                             playerConnection.playPause()
                         } else {
                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
@@ -51,6 +51,7 @@ import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
@@ -153,7 +154,7 @@ fun ArtistSongsScreen(
                         .fillMaxWidth()
                         .combinedClickable(
                             onClick = {
-                                if (song.id == mediaMetadata?.id) {
+                                if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                     playerConnection.playPause()
                                 } else {
                                     playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
@@ -64,6 +64,7 @@ import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionTopActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.utils.PermissionHelper
 import com.jtech.zemer.utils.rememberEnumPreference
@@ -279,7 +280,7 @@ fun LibrarySongsScreen(
                         .combinedClickable(
                             onClick = {
                                 if (!selection) {
-                                    if (songWrapper.item.id == mediaMetadata?.id) {
+                                    if (activeRowTapTogglesPlayPause(songWrapper.item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                         playerConnection.playPause()
                                     } else {
                                         playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -94,6 +94,7 @@ import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.makeTimeString
@@ -457,7 +458,7 @@ fun AutoPlaylistScreen(
                             .combinedClickable(
                                 onClick = {
                                     if (!selection) {
-                                        if (songWrapper.item.song.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(songWrapper.item.song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
@@ -81,6 +81,7 @@ import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberEnumPreference
@@ -334,7 +335,7 @@ fun CachePlaylistScreen(
                             .combinedClickable(
                                 onClick = {
                                     if (!selection) {
-                                        if (songWrapper.item.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(songWrapper.item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -138,6 +138,7 @@ import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.screens.settings.DarkMode
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.filterWhitelisted
@@ -607,7 +608,7 @@ fun LocalPlaylistScreen(
                                     .fillMaxWidth()
                                     .combinedClickable(
                                         onClick = {
-                                            if (song.song.id == mediaMetadata?.id) {
+                                            if (activeRowTapTogglesPlayPause(song.song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                 playerConnection.playPause()
                                             } else {
                                                 playerConnection.playQueue(
@@ -735,7 +736,7 @@ fun LocalPlaylistScreen(
                                     .combinedClickable(
                                         onClick = {
                                             if (!selection) {
-                                                if (songWrapper.item.song.id == mediaMetadata?.id) {
+                                                if (activeRowTapTogglesPlayPause(songWrapper.item.song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -101,6 +101,7 @@ import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
@@ -453,7 +454,7 @@ fun OnlinePlaylistScreen(
                                     enabled = !hideExplicit || !song.item.second.explicit,
                                     onClick = {
                                         if (!selection) {
-                                            if (song.item.second.id == mediaMetadata?.id) {
+                                            if (activeRowTapTogglesPlayPause(song.item.second.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                 playerConnection.playPause()
                                             } else {
                                                 playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -91,6 +91,7 @@ import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.makeTimeString
@@ -417,7 +418,7 @@ fun TopPlaylistScreen(
                             .combinedClickable(
                                 onClick = {
                                     if (!selection) {
-                                        if (songWrapper.item.song.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(songWrapper.item.song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
@@ -78,6 +78,7 @@ import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.zemerCuratedPlaylistRuntimeLabel
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.joinByBullet
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistViewModel
@@ -415,7 +416,7 @@ fun ZemerCuratedPlaylistScreen(
                                 .weight(1f)
                                 .combinedClickable(
                                     onClick = {
-                                        if (song.id == mediaMetadata?.id) {
+                                        if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                             playerConnection.playPause()
                                         } else {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -56,6 +56,7 @@ import com.jtech.zemer.constants.BlockVideosKey
 import com.jtech.zemer.search.zemerAlbumRoute
 import com.jtech.zemer.search.zemerPlaylistRoute
 import com.jtech.zemer.utils.rememberPreference
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -159,7 +160,7 @@ fun OnlineSearchResult(
                     if (isVideoFilter) {
                         val artistDisplay = item.artists.joinToString(" • ") { it.name }
                         navController.navigate(videoRoute(item.id, item.title, artistDisplay))
-                    } else if (item.id == mediaMetadata?.id) {
+                    } else if (activeRowTapTogglesPlayPause(item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                         playerConnection.playPause()
                     } else {
                         playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -69,6 +69,7 @@ import com.jtech.zemer.search.zemerPlaylistRoute
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SearchBarIconOffsetX
 import com.jtech.zemer.ui.component.YouTubeListItem
@@ -270,7 +271,7 @@ fun OnlineSearchScreen(
                         onClick = {
                             when (item) {
                                 is SongItem -> {
-                                    if (item.id == mediaMetadata?.id) {
+                                    if (activeRowTapTogglesPlayPause(item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                         playerConnection.playPause()
                                     } else {
                                         playerConnection.playQueue(
@@ -344,7 +345,7 @@ fun OnlineSearchScreen(
                         if (event.key == Key.Enter || event.key == Key.DirectionCenter) {
                             when (item) {
                                 is SongItem -> {
-                                    if (item.id == mediaMetadata?.id) {
+                                    if (activeRowTapTogglesPlayPause(item.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                         playerConnection.playPause()
                                     } else {
                                         playerConnection.playQueue(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/ActiveRowTap.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/ActiveRowTap.kt
@@ -1,0 +1,17 @@
+package com.jtech.zemer.ui.utils
+
+/**
+ * Whether tapping a list row for the CURRENTLY-PLAYING song should toggle play/pause (the
+ * app-wide convention) or fall through to the row's normal "play this" path.
+ *
+ * During a station broadcast the toggle arm is a dead end (issue #324): the listener joined the
+ * song mid-broadcast, and every restart affordance - seek, skip, previous - is deliberately
+ * masked, so a liked song heard on the radio could never be replayed from the beginning. Falling
+ * through starts the song as a fresh play from 0, which also exits broadcast mode through the
+ * same machinery as any queue swap. Off-station behavior is unchanged.
+ *
+ * Every active-row tap site routes its condition through this ONE predicate; never inline the
+ * `&& !isStationBroadcast` per screen (drift between surfaces is how conventions rot).
+ */
+fun activeRowTapTogglesPlayPause(isActiveSong: Boolean, isStationBroadcast: Boolean): Boolean =
+    isActiveSong && !isStationBroadcast

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/ActiveRowTap.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/ActiveRowTap.kt
@@ -10,8 +10,12 @@ package com.jtech.zemer.ui.utils
  * through starts the song as a fresh play from 0, which also exits broadcast mode through the
  * same machinery as any queue swap. Off-station behavior is unchanged.
  *
- * Every active-row tap site routes its condition through this ONE predicate; never inline the
- * `&& !isStationBroadcast` per screen (drift between surfaces is how conventions rot).
+ * Every active-row tap site in `ui/screens/` routes its condition through this ONE predicate;
+ * never inline the `&& !isStationBroadcast` per screen (drift between surfaces is how conventions
+ * rot). The queue sheet (`ui/player/Queue.kt`) is deliberately NOT converted: its fall-through is
+ * a seek to the tapped window - a broadcast-forbidden mid-schedule jump - not a fresh play, its
+ * taps are already station-gated at the site, and pause is the one legitimate broadcast transport
+ * there.
  */
 fun activeRowTapTogglesPlayPause(isActiveSong: Boolean, isStationBroadcast: Boolean): Boolean =
     isActiveSong && !isStationBroadcast

--- a/app/src/test/kotlin/com/jtech/zemer/ui/ActiveRowTapTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/ActiveRowTapTest.kt
@@ -1,0 +1,31 @@
+package com.jtech.zemer.ui
+
+import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The active-row tap rule (issue #324): tapping the currently-playing song in a list toggles
+ * play/pause EXCEPT during a station broadcast, where it must fall through to a fresh play from 0
+ * - the broadcast masks seek/skip, so the row tap is the only way to replay a song heard
+ * mid-broadcast (e.g. like it on the radio, open Liked songs, tap it).
+ */
+class ActiveRowTapTest {
+
+    @Test
+    fun `active song toggles play-pause in normal playback`() {
+        assertTrue(activeRowTapTogglesPlayPause(isActiveSong = true, isStationBroadcast = false))
+    }
+
+    @Test
+    fun `active song falls through to a fresh play during a station broadcast`() {
+        assertFalse(activeRowTapTogglesPlayPause(isActiveSong = true, isStationBroadcast = true))
+    }
+
+    @Test
+    fun `a different song never toggles, station or not`() {
+        assertFalse(activeRowTapTogglesPlayPause(isActiveSong = false, isStationBroadcast = false))
+        assertFalse(activeRowTapTogglesPlayPause(isActiveSong = false, isStationBroadcast = true))
+    }
+}


### PR DESCRIPTION
Fixes #324

A song heard mid-broadcast on a Zemer station could never be replayed from the beginning: tapping it in any list (e.g. Liked songs) toggled play/pause, and seek/skip/previous are deliberately masked during a broadcast, so there was no restart affordance at all.

All active-row tap sites (27 sites across 21 screens) now route their condition through one pure, unit-tested predicate (`activeRowTapTogglesPlayPause`): during a station broadcast the tap falls through to the row's normal play path, starting the song fresh from 0 and exiting the broadcast via the standard queue-swap machinery. Off-station behavior is byte-identical - the predicate is exactly the old condition AND not-broadcast.

Scope decision (owner-confirmed): station-only. During regular playback the active-row play/pause convention is unchanged.

Note: the new `UserPlaylistScreen` on PR #323 has one more tap site; it gets the same one-line treatment there once this merges (the helper has to exist on main first).