### PR TITLE
fix(playlists): drop the redundant curated-card title

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -927,6 +927,8 @@ fun YouTubeGridItem(
     // Suppress the text title when the thumbnail already carries it (the curated Zemer-playlist
     // covers bake the title into the SVG, so the label below would just repeat it).
     showTitle: Boolean = true,
+    // Suppress the sub-label entirely (the compact Home curated card is just the cover).
+    showSubtitle: Boolean = true,
 ) = GridItem(
     title = {
         if (showTitle) {
@@ -942,7 +944,7 @@ fun YouTubeGridItem(
         }
     },
     subtitle = {
-        val subtitle = subtitleOverride ?: when (item) {
+        val subtitle = if (!showSubtitle) null else subtitleOverride ?: when (item) {
             is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
             is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
             is ArtistItem -> null

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -924,17 +924,22 @@ fun YouTubeGridItem(
     fillMaxWidth: Boolean = false,
     subtitleOverride: String? = null,
     centeredPlayButton: Boolean = false,
+    // Suppress the text title when the thumbnail already carries it (the curated Zemer-playlist
+    // covers bake the title into the SVG, so the label below would just repeat it).
+    showTitle: Boolean = true,
 ) = GridItem(
     title = {
-        Text(
-            text = item.title,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = if (item is ArtistItem) TextAlign.Center else TextAlign.Start,
-            modifier = Modifier.basicMarquee().fillMaxWidth()
-        )
+        if (showTitle) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = if (item is ArtistItem) TextAlign.Center else TextAlign.Start,
+                modifier = Modifier.basicMarquee().fillMaxWidth()
+            )
+        }
     },
     subtitle = {
         val subtitle = subtitleOverride ?: when (item) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt
@@ -68,6 +68,9 @@ fun ZemerCuratedPlaylistGridItem(
             pluralStringResource(R.plurals.n_song, playlist.trackCount, playlist.trackCount),
             if (showRuntime) zemerCuratedPlaylistRuntimeLabel(playlist.totalDurationSec) else null,
         ),
+        // The generated cover SVG already renders the playlist name, so the text title below would
+        // be a duplicate — show only the count/runtime sub-label.
+        showTitle = false,
         thumbnailRatio = 1f,
         fillMaxWidth = fillMaxWidth,
         modifier = modifier,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt
@@ -52,6 +52,9 @@ fun ZemerCuratedPlaylistGridItem(
     modifier: Modifier = Modifier,
     fillMaxWidth: Boolean = false,
     showRuntime: Boolean = true,
+    // The compact Home row is just the cover (no sub-label at all); the wider See-all grid keeps
+    // the count/runtime.
+    showSubtitle: Boolean = true,
 ) {
     YouTubeGridItem(
         item = PlaylistItem(
@@ -69,8 +72,9 @@ fun ZemerCuratedPlaylistGridItem(
             if (showRuntime) zemerCuratedPlaylistRuntimeLabel(playlist.totalDurationSec) else null,
         ),
         // The generated cover SVG already renders the playlist name, so the text title below would
-        // be a duplicate — show only the count/runtime sub-label.
+        // be a duplicate — show only the count/runtime sub-label (and nothing at all on Home).
         showTitle = false,
+        showSubtitle = showSubtitle,
         thumbnailRatio = 1f,
         fillMaxWidth = fillMaxWidth,
         modifier = modifier,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -634,9 +634,9 @@ fun HomeScreen(
                             ) { playlist ->
                                 ZemerCuratedPlaylistGridItem(
                                     playlist = playlist,
-                                    // The compact 128dp row card: runtime overflows its two subtitle
-                                    // lines, so it shows the song count alone (full label on See all).
-                                    showRuntime = false,
+                                    // Home row: just the cover card, no sub-label at all (the count
+                                    // + runtime stay on the wider See all grid).
+                                    showSubtitle = false,
                                     modifier = Modifier.clickable {
                                         // The slug is server-controlled: encode so an unexpected
                                         // '/'/'?' can never break route matching (a crash on tap).


### PR DESCRIPTION
The generated Zemer-playlist cover SVG renders the playlist name as artwork (e.g. the `auto-top-50` cover shows "Top 50"), so the text title printed below the card was a duplicate.

Adds a `showTitle` flag to the shared `YouTubeGridItem` (default `true`, so every other caller is unchanged) and has `ZemerCuratedPlaylistGridItem` pass `false`, leaving just the "N songs" (and runtime, on the wide see-all card) sub-label under the cover.

Scope: the curated Home shelf card and the see-all grid card. No behavior change elsewhere.

Verified: `compileDebugKotlin`, `assembleDebug`, `scripts/ui-audit.sh` all pass.

Separately noted (not fixed here): the card's count uses the server `trackCount` while the detail header counts the client-deduped list, so they can differ by one when a playlist carries a duplicate videoId. A verification question is filed in the curated-playlists handoff doc to decide whether that is fixed server-side (post-dedupe `trackCount`) or client-side.
