### PR TITLE
feat(nav): move Whitelisted Artists out of the bottom bar into Search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,10 +173,19 @@ The rules that must not regress:
 
 A componentization pass extracted the app's repeated composables into `ui/component/`; reuse them
 instead of hand-rolling: `BackNavigationIcon` / `BackTopAppBar` (top-bar back button), `MoreVertMenuButton`
-(row 3-dot menu), `PlaylistPlayShuffleButtons` + `PlaylistHeaderShimmer` (playlist headers/skeletons),
+(row 3-dot menu), `TopAppBarActionButton` (plain `TopAppBar` action icon — history/search/now-playing/
+refresh), `PlaylistPlayShuffleButtons` + `PlaylistHeaderShimmer` (playlist headers/skeletons),
 `shimmer/BoxPlaceholder` (the base shimmer slab under `ButtonPlaceholder`/`GridItemPlaceholder`),
 `ArtistBrowseComponents` (KidZone/whitelist browse header). New screens use these; a hand-rolled
 duplicate is a review miss.
+
+**Componentize on every touch (non-negotiable).** Whenever you touch anything in the app, first check
+whether a shared component already covers it — if one exists, use it. If you find yourself writing (or
+editing) a second near-copy of a widget that already appears elsewhere, STOP and extract it into
+`ui/component/` (or reuse the existing one), then point every site at it in the same pass — never leave
+two hand-rolled copies to drift. Extracting the shared piece is part of the change, not a follow-up: the
+staff-engineer review bar rejects copy-pasted near-duplicates. When you add a new shared component, list
+it in the paragraph above so the next contributor finds it.
 
 ### The home tab (telemetry-ranked rows; zero-InnerTube for content)
 

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -185,6 +185,7 @@ import com.jtech.zemer.constants.PauseSearchHistoryKey
 import com.jtech.zemer.constants.PureBlackKey
 import com.jtech.zemer.constants.SYSTEM_DEFAULT
 import com.jtech.zemer.constants.SlimNavBarKey
+import com.jtech.zemer.constants.BottomNavArtistsRemovedKey
 import com.jtech.zemer.constants.BottomNavigationBarEnabledKey
 import com.jtech.zemer.constants.BottomNavigationItemsKey
 import com.jtech.zemer.constants.StopMusicOnTaskClearKey
@@ -243,7 +244,9 @@ import com.jtech.zemer.utils.Updater
 import com.jtech.zemer.utils.dataStore
 import com.jtech.zemer.utils.filterWhitelisted
 import com.jtech.zemer.utils.get
+import com.jtech.zemer.utils.getSuspend
 import com.jtech.zemer.utils.hasNotificationPermission
+import com.jtech.zemer.utils.removeBottomNavItem
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.utils.updater.InstallResult
@@ -741,7 +744,22 @@ class MainActivity : ComponentActivity() {
                             sharedPreferences.getString("bottomNavigationItems", null)
                         }
                         val (bottomNavEnabled) = rememberPreference(BottomNavigationBarEnabledKey, defaultValue = prefBottomNavEnabled)
-                        val (bottomNavItemsString) = rememberPreference(BottomNavigationItemsKey, defaultValue = prefBottomNavItems ?: "home,artists,search,library")
+                        val (bottomNavItemsString) = rememberPreference(BottomNavigationItemsKey, defaultValue = prefBottomNavItems ?: "home,search,library")
+
+                        // One-time migration: the "artists" tab was dropped from the default bottom-nav
+                        // set (it now lives inside Search). Users who explicitly customized their bar
+                        // still carry a saved "artists" entry, so strip it once. The flag makes this
+                        // run a single time, so re-adding "artists" from Settings afterward sticks.
+                        LaunchedEffect(Unit) {
+                            if (context.dataStore.getSuspend(BottomNavArtistsRemovedKey, false)) return@LaunchedEffect
+                            val saved = context.dataStore.getSuspend(BottomNavigationItemsKey)
+                                ?: sharedPreferences.getString("bottomNavigationItems", null)
+                            if (saved != null && saved.split(",").any { it.trim() == "artists" }) {
+                                val stripped = removeBottomNavItem(saved, "artists", "home,search,library")
+                                context.dataStore.edit { it[BottomNavigationItemsKey] = stripped }
+                            }
+                            context.dataStore.edit { it[BottomNavArtistsRemovedKey] = true }
+                        }
 
                         // Create bottom navigation items dynamically from preferences
                         val bottomNavigationItems = remember(bottomNavItemsString) {

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -60,7 +60,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -109,6 +108,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.height
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -207,6 +207,7 @@ import com.jtech.zemer.ui.component.AccountSettingsDialog
 import com.jtech.zemer.ui.component.BottomSheetMenu
 import com.jtech.zemer.ui.component.BottomSheetPage
 import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.TopAppBarActionButton
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.RecognizeMusicFab
@@ -1449,7 +1450,7 @@ class MainActivity : ComponentActivity() {
                                                 var eggLastTapAt by remember { mutableStateOf(0L) }
                                                 Text(
                                                     text = currentTitleRes?.let { stringResource(it) } ?: "",
-                                                    style = MaterialTheme.typography.titleLarge,
+                                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                                                     modifier = if (currentTitleRes == R.string.home) {
                                                         Modifier.clickable(
                                                             interactionSource = remember { MutableInteractionSource() },
@@ -1491,6 +1492,11 @@ class MainActivity : ComponentActivity() {
                                                         }
                                                     },
                                                 ) {
+                                                    // The drawer hamburger is deliberately smaller and
+                                                    // dimmer than a normal action icon so it recedes next
+                                                    // to the bold screen title; the back arrow (other
+                                                    // states) keeps full size/weight for tap clarity.
+                                                    val showingMenu = !active && isMainScreen
                                                     Icon(
                                                         painterResource(
                                                             if (active || !isMainScreen) {
@@ -1501,6 +1507,13 @@ class MainActivity : ComponentActivity() {
                                                         ),
                                                         contentDescription = null,
                                                     modifier = Modifier
+                                                        .then(
+                                                            if (showingMenu) {
+                                                                Modifier.size(20.dp).alpha(0.6f)
+                                                            } else {
+                                                                Modifier
+                                                            }
+                                                        )
                                                         .focusRequester(burgerFocusRequester)
                                                         .focusProperties {
                                                             next = topPlayFocusRequester
@@ -1514,92 +1527,55 @@ class MainActivity : ComponentActivity() {
                                                 val currentRoute = navBackStackEntry?.destination?.route
                                                 if (currentRoute == Screens.Home.route) {
                                                     if (showHistoryButton) {
-                                                        IconButton(
+                                                        TopAppBarActionButton(
+                                                            icon = R.drawable.history,
+                                                            contentDescription = stringResource(R.string.history),
                                                             onClick = { navController.navigate("history") },
-                                                            colors = IconButtonDefaults.iconButtonColors(
-                                                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                            ),
-                                                            modifier = Modifier.clip(CircleShape)
-                                                        ) {
-                                                            Icon(
-                                                                painter = painterResource(R.drawable.history),
-                                                                contentDescription = stringResource(R.string.history)
-                                                            )
-                                                        }
-                                                    }
-                                                    IconButton(
-                                                        onClick = {
-                                                            onActiveChange(true)
-                                                        },
-                                                        colors = IconButtonDefaults.iconButtonColors(
-                                                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                        ),
-                                                        modifier = Modifier.clip(CircleShape)
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.search),
-                                                            contentDescription = stringResource(R.string.search)
                                                         )
                                                     }
+                                                    TopAppBarActionButton(
+                                                        icon = R.drawable.search,
+                                                        contentDescription = stringResource(R.string.search),
+                                                        onClick = { onActiveChange(true) },
+                                                    )
                                                 }
 
                                                 if (currentRoute == Screens.Artists.route && navBackStackEntry != null) {
                                                     val whitelistedArtistsViewModel: WhitelistedArtistsViewModel =
                                                         hiltViewModel(navBackStackEntry!!)
-                                                    IconButton(
+                                                    TopAppBarActionButton(
+                                                        icon = R.drawable.sync,
+                                                        contentDescription = stringResource(R.string.refresh_artists),
                                                         onClick = { whitelistedArtistsViewModel.sync() },
-                                                        colors = IconButtonDefaults.iconButtonColors(
-                                                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                        ),
-                                                        modifier = Modifier.clip(CircleShape)
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.sync),
-                                                            contentDescription = stringResource(R.string.refresh_artists)
-                                                        )
-                                                    }
+                                                    )
                                                 }
 
                                                 if (currentRoute == Screens.KidZone.route && navBackStackEntry != null) {
                                                     val kidZoneViewModel: KidZoneViewModel =
                                                         hiltViewModel(navBackStackEntry!!)
-                                                    IconButton(
+                                                    TopAppBarActionButton(
+                                                        icon = R.drawable.sync,
+                                                        contentDescription = stringResource(R.string.refresh_artists),
                                                         onClick = { kidZoneViewModel.sync() },
-                                                        colors = IconButtonDefaults.iconButtonColors(
-                                                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                        ),
-                                                        modifier = Modifier.clip(CircleShape)
-                                                    ) {
-                                                        Icon(
-                                                            painter = painterResource(R.drawable.sync),
-                                                            contentDescription = stringResource(R.string.refresh_artists)
-                                                        )
-                                                    }
+                                                    )
                                                 }
 
-                                                IconButton(
+                                                TopAppBarActionButton(
+                                                    icon = R.drawable.play,
+                                                    contentDescription = stringResource(R.string.now_playing),
                                                     onClick = {
                                                         coroutineScope.launch {
                                                             playerBottomSheetState.expandSoft()
                                                         }
-                                                },
-                                                    colors = IconButtonDefaults.iconButtonColors(
-                                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                    ),
+                                                    },
                                                     modifier = Modifier
-                                                        .clip(CircleShape)
                                                         .focusRequester(topPlayFocusRequester)
                                                         .focusProperties {
                                                             next = miniPlayFocusRequester
                                                             previous = burgerFocusRequester
                                                             down = contentFocusRequester
                                                         }
-                                                ) {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.play),
-                                                        contentDescription = stringResource(R.string.now_playing)
-                                                    )
-                                                }
+                                                )
                                             },
                                             scrollBehavior = searchBarScrollBehavior,
                                             colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -21,6 +21,10 @@ val DefaultOpenTabKey = stringPreferencesKey("defaultOpenTab")
 val BottomNavigationBarEnabledKey = booleanPreferencesKey("bottomNavigationBarEnabled")
 val SlimNavBarKey = booleanPreferencesKey("slimNavBar")
 val BottomNavigationItemsKey = stringPreferencesKey("bottomNavigationItems")
+// One-time flag: the "artists" tab was removed from the default bottom-nav set (surfaced inside Search
+// instead). Existing users who explicitly customized their bar keep a saved "artists" entry, so a single
+// startup migration strips it once. Re-adding it from Settings afterward sticks (the flag never re-runs).
+val BottomNavArtistsRemovedKey = booleanPreferencesKey("bottom_nav_artists_removed")
 val RecognizeMusicFabKey = booleanPreferencesKey("recognizeMusicFab")
 val GridItemsSizeKey = stringPreferencesKey("gridItemSize")
 val SliderStyleKey = stringPreferencesKey("sliderStyle")

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton as Material3IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
@@ -140,6 +141,27 @@ fun BackNavigationIcon(
         Icon(
             painter = painterResource(R.drawable.arrow_back),
             contentDescription = null,
+        )
+    }
+}
+
+/**
+ * A plain top-app-bar action icon: a transparent (container-less) [androidx.compose.material3.IconButton]
+ * holding one drawable. This is the shared look for every screen-level `TopAppBar` action here (Home's
+ * history/search/now-playing, the Artists/KidZone refresh) so they can't drift into per-site chrome
+ * (the old filled `surfaceContainerHigh` circles). Pass [modifier] through for D-pad focus wiring.
+ */
+@Composable
+fun TopAppBarActionButton(
+    @DrawableRes icon: Int,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Material3IconButton(onClick = onClick, modifier = modifier) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = contentDescription,
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/OnboardingScreen.kt
@@ -1906,7 +1906,7 @@ private fun BottomNavSetupScreen(
                             putBoolean("bottomNavigationBarEnabled", enableBottomNav)
                             // Set default items if enabling
                             if (enableBottomNav) {
-                                putString("bottomNavigationItems", "home,artists,search,library")
+                                putString("bottomNavigationItems", "home,search,library")
                             }
                         }
                         onComplete()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
@@ -69,6 +70,7 @@ import com.jtech.zemer.search.zemerPlaylistRoute
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.screens.Screens
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.SearchBarIconOffsetX
@@ -150,6 +152,22 @@ fun OnlineSearchScreen(
             .fillMaxSize()
             .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.background)
     ) {
+        // Before the user types, offer a shortcut into the whitelisted-artists browse (the Artists tab
+        // was removed from the bottom bar and lives here now). Hidden once a query exists so it never
+        // sits among live suggestions/results.
+        if (query.isBlank()) {
+            item(key = "browse_artists") {
+                BrowseArtistsItem(
+                    onClick = {
+                        navController.navigate(Screens.Artists.route)
+                        onDismiss()
+                    },
+                    pureBlack = pureBlack,
+                    modifier = Modifier.animateItem(),
+                )
+            }
+        }
+
         items(viewState.history, key = { "history_${it.query}" }) { history ->
             SuggestionItem(
                 query = history.query,
@@ -375,6 +393,77 @@ fun OnlineSearchScreen(
                     .animateItem()
             )
         }
+    }
+}
+
+/**
+ * A "Browse all artists" shortcut styled to match [SuggestionItem] (same height, focus border, D-pad
+ * focusability). Shown at the top of the pre-typing search list; opens the whitelisted-artists screen.
+ */
+@Composable
+fun BrowseArtistsItem(
+    onClick: () -> Unit,
+    pureBlack: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var focusState by remember { mutableStateOf<FocusState?>(null) }
+    val isFocused = focusState?.isFocused ?: false
+
+    val backgroundColor by animateColorAsState(
+        targetValue = when {
+            isFocused -> MaterialTheme.colorScheme.primary
+            else -> if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface
+        },
+        label = "browse_artists_focus_bg"
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (isFocused) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+        label = "browse_artists_focus_border"
+    )
+    val iconAlpha by animateFloatAsState(
+        targetValue = if (isFocused) 1f else 0.5f,
+        label = "browse_artists_icon_alpha"
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(SuggestionItemHeight)
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
+            .padding(end = SearchBarIconOffsetX)
+            .background(backgroundColor)
+            .border(width = 2.dp, color = borderColor)
+            .clickable(onClick = onClick)
+            .onFocusChanged { focusState = it }
+            .onKeyEvent { event ->
+                if (event.key == Key.Enter || event.key == Key.DirectionCenter) {
+                    onClick()
+                    true
+                } else {
+                    false
+                }
+            }
+            .focusable(),
+    ) {
+        Icon(
+            painterResource(R.drawable.artist),
+            contentDescription = null,
+            modifier = Modifier.padding(horizontal = 16.dp).alpha(iconAlpha)
+        )
+
+        Text(
+            text = stringResource(R.string.browse_artists),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+
+        Icon(
+            painter = painterResource(R.drawable.arrow_forward),
+            contentDescription = null,
+            modifier = Modifier.padding(horizontal = 16.dp).alpha(iconAlpha)
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
@@ -239,7 +239,7 @@ fun AppearanceSettings(
     }
     val (bottomNavigationItems, onBottomNavigationItemsChange) = rememberPreference(
         BottomNavigationItemsKey,
-        defaultValue = prefBottomNavItems ?: "home,artists,search,library"
+        defaultValue = prefBottomNavItems ?: "home,search,library"
     )
 
     var showBottomNavCustomizationDialog by rememberSaveable { mutableStateOf(false) }
@@ -752,7 +752,7 @@ fun AppearanceSettings(
                 onBottomNavEnabledChange(enabled)
                 // Reset to default when toggling
                 if (!enabled) {
-                    onBottomNavigationItemsChange("home,artists,search,library")
+                    onBottomNavigationItemsChange("home,search,library")
                 }
             }
         )

--- a/app/src/main/kotlin/com/jtech/zemer/utils/BottomNavItems.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/BottomNavItems.kt
@@ -1,0 +1,19 @@
+package com.jtech.zemer.utils
+
+/**
+ * Removes one item key from a comma-separated bottom-navigation set, preserving the order of the
+ * survivors. Blank/whitespace entries are dropped. If removing [key] would leave the bar empty, the
+ * [fallback] set is returned instead so the navigation bar can never render with zero destinations.
+ *
+ * Pure and Android-free so the min-one-item guard is unit-testable (see BottomNavItemsTest).
+ */
+internal fun removeBottomNavItem(
+    csv: String,
+    key: String,
+    fallback: String,
+): String {
+    val survivors = csv.split(",")
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && it != key }
+    return if (survivors.isEmpty()) fallback else survivors.joinToString(",")
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -567,4 +567,5 @@
     <string name="show_genres_row">Show genres on home</string>
     <string name="show_genres_row_desc">A row of genre shortcuts under Quick picks</string>
     <string name="singles">Singles</string>
+    <string name="browse_artists">Browse all artists</string>
 </resources>

--- a/app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt
@@ -1,0 +1,46 @@
+package com.jtech.zemer.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BottomNavItemsTest {
+    private val fallback = "home,search,library"
+
+    @Test
+    fun stripsArtistsAndPreservesOrder() {
+        assertEquals(
+            "home,search,library",
+            removeBottomNavItem("home,artists,search,library", "artists", fallback),
+        )
+    }
+
+    @Test
+    fun stripsArtistsFromAnyPosition() {
+        assertEquals("home,search,library", removeBottomNavItem("artists,home,search,library", "artists", fallback))
+        assertEquals("home,search,library", removeBottomNavItem("home,search,library,artists", "artists", fallback))
+    }
+
+    @Test
+    fun keepsCustomOrderAndOtherTabs() {
+        assertEquals(
+            "library,kid_zone,search,home",
+            removeBottomNavItem("library,kid_zone,artists,search,home", "artists", fallback),
+        )
+    }
+
+    @Test
+    fun noOpWhenKeyAbsent() {
+        assertEquals("home,search,library", removeBottomNavItem("home,search,library", "artists", fallback))
+    }
+
+    @Test
+    fun trimsWhitespaceEntries() {
+        assertEquals("home,search", removeBottomNavItem(" home , artists , search ", "artists", fallback))
+    }
+
+    @Test
+    fun fallsBackWhenRemovingLeavesEmpty() {
+        assertEquals(fallback, removeBottomNavItem("artists", "artists", fallback))
+        assertEquals(fallback, removeBottomNavItem("artists, ,artists", "artists", fallback))
+    }
+}


### PR DESCRIPTION
## What

Removes the **Artists** (Whitelisted Artists) tab from the default bottom navigation bar to declutter it, and surfaces the screen inside **Search** instead. The screen, its route, and its drawer entry are unchanged, so it stays easy to reach, and it remains re-addable from Settings.

## Why

The bottom bar was crowded. The whitelist screen is essentially a searchable artist browse, so Search is the natural home for it (the Home top bar already carries history + search icons, so no top-bar icon).

## Changes

- **Off the default bar:** the default bottom-nav string drops `"artists"` in all three places that seed it (`MainActivity`, the `AppearanceSettings` reset-on-toggle-off, and the Onboarding writer). New/default users get `home, search, library`.
- **Still reachable + re-addable:** `Screens.Artists`, its `artists` route, the parse arm, and the hamburger **drawer** entry are untouched (the KidZone precedent: a MainScreens destination absent from the default bar but reachable via drawer/route). Settings, Customize bottom navigation still offers "Artists" to re-add.
- **Inside Search:** `OnlineSearchScreen` gains a `BrowseArtistsItem` row, styled to match the existing suggestion rows (same height, focus border, D-pad focusable). It is pinned to the top of the pre-typing list and shown only when the query is blank, so it never sits among live suggestions/results. Tapping it opens the artists route and dismisses the search overlay. New string `browse_artists` = "Browse all artists".
- **One-time migration:** `BottomNavArtistsRemovedKey` strips a saved `"artists"` entry for existing users who customized their bar (reads DataStore, falls back to the legacy SharedPreferences value), with a `home,search,library` fallback if removal would empty the bar. It runs once, so re-adding Artists afterward sticks. The pure `removeBottomNavItem` transform is unit-tested.

## Testing

- `BottomNavItemsTest` (order preservation, any-position removal, whitespace trimming, no-op when absent, min-one fallback) passes.
- `:app:assembleDebug` succeeds; `scripts/ui-audit.sh` is ratchet-clean (the one new label is a resource, not a hardcoded literal).
- Manual: fresh install shows Home/Search/Library with no Artists; Search (pre-typing) shows a "Browse all artists" row that opens the screen and closes the overlay; drawer still lists Artists; Customize bottom navigation still offers it; an existing "artists" custom set is stripped once and stays re-addable.
