### PR TITLE
refactor(ui): app-wide top-bar consistency (componentization, bold titles, unified color)

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -206,6 +206,7 @@ import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.ui.component.AccountSettingsDialog
 import com.jtech.zemer.ui.component.BottomSheetMenu
 import com.jtech.zemer.ui.component.BottomSheetPage
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.TopAppBarActionButton
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
@@ -1448,9 +1449,8 @@ class MainActivity : ComponentActivity() {
                                                 // title looks inert; other tabs' titles stay plain.
                                                 var eggTaps by remember { mutableStateOf(0) }
                                                 var eggLastTapAt by remember { mutableStateOf(0L) }
-                                                Text(
+                                                AppBarTitle(
                                                     text = currentTitleRes?.let { stringResource(it) } ?: "",
-                                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                                                     modifier = if (currentTitleRes == R.string.home) {
                                                         Modifier.clickable(
                                                             interactionSource = remember { MutableInteractionSource() },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/AppBarTitle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/AppBarTitle.kt
@@ -1,0 +1,25 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * The shared screen-title style for top app bars: `titleLarge`, bold — the same treatment the Home
+ * top bar uses. Put every screen-level `TopAppBar` / [BackTopAppBar] title through this so titles
+ * never drift back to the default (thinner) weight.
+ */
+@Composable
+fun AppBarTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/AppBarTitle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/AppBarTitle.kt
@@ -5,21 +5,27 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 
 /**
- * The shared screen-title style for top app bars: `titleLarge`, bold — the same treatment the Home
- * top bar uses. Put every screen-level `TopAppBar` / [BackTopAppBar] title through this so titles
- * never drift back to the default (thinner) weight.
+ * The shared screen-title style for top app bars: `titleLarge`, bold, single line with ellipsis — the
+ * same treatment the Home top bar uses. Put every screen-level `TopAppBar` / [BackTopAppBar] title
+ * through this so titles never drift back to the default (thinner) weight. Dynamic collection names
+ * (album / artist / playlist) that need scrolling can pass `Modifier.basicMarquee()` via [modifier];
+ * [maxLines] is overridable for the rare title that must wrap.
  */
 @Composable
 fun AppBarTitle(
     text: String,
     modifier: Modifier = Modifier,
+    maxLines: Int = 1,
 ) {
     Text(
         text = text,
         style = MaterialTheme.typography.titleLarge,
         fontWeight = FontWeight.Bold,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
         modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/BackTopAppBar.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/BackTopAppBar.kt
@@ -1,15 +1,41 @@
 package com.jtech.zemer.ui.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
+import com.jtech.zemer.ui.theme.rememberPureBlack
 
 /**
- * The shared plain back-only [TopAppBar]: a title and a [BackNavigationIcon] navigation icon.
- * Used by screen-level top bars that have no other actions.
+ * The one shared top-app-bar container color for every ordinary screen, so bars never drift between
+ * grey / black / tinted per screen. Matches the Home top bar: pure black under the AMOLED
+ * (pure-black) theme, `surfaceContainer` otherwise. The container and scrolled-container colors are
+ * the same so the bar does not change shade on scroll.
+ *
+ * Use this as `colors = zemerTopAppBarColors()` on any screen-level `TopAppBar`. The only bars that
+ * should NOT use it are the deliberately full-bleed color screens (login gate, onboarding) and the
+ * video player (fixed black over video).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun zemerTopAppBarColors(): TopAppBarColors {
+    val container = if (rememberPureBlack()) Color.Black else MaterialTheme.colorScheme.surfaceContainer
+    return TopAppBarDefaults.topAppBarColors(
+        containerColor = container,
+        scrolledContainerColor = container,
+    )
+}
+
+/**
+ * The shared plain back-only [TopAppBar]: a bold [AppBarTitle]-style title and a [BackNavigationIcon]
+ * navigation icon, on the shared [zemerTopAppBarColors]. Used by screen-level top bars that have no
+ * other actions.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,6 +48,7 @@ fun BackTopAppBar(
     TopAppBar(
         title = title,
         navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
         scrollBehavior = scrollBehavior,
         modifier = modifier,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,7 +60,7 @@ fun LibraryArtistListItem(
 ) = ArtistListItem(
     artist = artist,
     trailingContent = {
-        androidx.compose.material3.IconButton(
+        MoreVertMenuButton(
             onClick = {
                 menuState.show {
                     ArtistMenu(
@@ -71,12 +70,7 @@ fun LibraryArtistListItem(
                     )
                 }
             }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.more_vert),
-                contentDescription = null
-            )
-        }
+        )
     },
     modifier = modifier
         .fillMaxWidth()
@@ -115,7 +109,7 @@ fun WhitelistedArtistListItem(
         )
     },
     trailingContent = {
-        androidx.compose.material3.IconButton(
+        MoreVertMenuButton(
             onClick = {
                 menuState.show {
                     ArtistMenu(
@@ -125,12 +119,7 @@ fun WhitelistedArtistListItem(
                     )
                 }
             }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.more_vert),
-                contentDescription = null
-            )
-        }
+        )
     },
     modifier = modifier
         .fillMaxWidth()
@@ -231,7 +220,7 @@ fun LibraryAlbumListItem(
     isActive = isActive,
     isPlaying = isPlaying,
     trailingContent = {
-        androidx.compose.material3.IconButton(
+        MoreVertMenuButton(
             onClick = {
                 menuState.show {
                     AlbumMenu(
@@ -241,12 +230,7 @@ fun LibraryAlbumListItem(
                     )
                 }
             }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.more_vert),
-                contentDescription = null
-            )
-        }
+        )
     },
     modifier = modifier
         .fillMaxWidth()
@@ -299,7 +283,7 @@ fun LibraryPlaylistListItem(
 ) = PlaylistListItem(
     playlist = playlist,
     trailingContent = {
-        androidx.compose.material3.IconButton(
+        MoreVertMenuButton(
             onClick = {
                 menuState.show {
                     if (playlist.playlist.isEditable || playlist.songCount != 0) {
@@ -338,12 +322,7 @@ fun LibraryPlaylistListItem(
                     }
                 }
             }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.more_vert),
-                contentDescription = null
-            )
-        }
+        )
     },
     modifier = modifier
         .fillMaxWidth()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt
@@ -45,9 +45,7 @@ fun <T> RowScope.SelectionTopActions(
             contentDescription = null,
         )
     }
-    IconButton(onClick = onMore) {
-        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
-    }
+    MoreVertMenuButton(onClick = onMore)
 }
 
 /**
@@ -71,7 +69,5 @@ fun <T> RowScope.SelectionActions(
             contentDescription = null,
         )
     }
-    IconButton(onClick = onMore) {
-        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
-    }
+    MoreVertMenuButton(onClick = onMore)
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
@@ -105,6 +105,7 @@ import com.jtech.zemer.ui.component.BottomSheetState
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MediaMetadataListItem
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.menu.PlayerMenu
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
 import com.jtech.zemer.ui.utils.ShowMediaInfo
@@ -725,7 +726,7 @@ fun Queue(
                                     isActive = index == currentWindowIndex,
                                     isPlaying = isPlaying,
                                     trailingContent = {
-                                        IconButton(
+                                        MoreVertMenuButton(
                                             onClick = {
                                                 menuState.show {
                                                     PlayerMenu(
@@ -744,12 +745,7 @@ fun Queue(
                                                     )
                                                 }
                                             },
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.more_vert),
-                                                contentDescription = null,
-                                            )
-                                        }
+                                        )
                                         if (!locked) {
                                             IconButton(
                                                 onClick = { },
@@ -1021,7 +1017,7 @@ fun Queue(
                         )
                     }
 
-                    IconButton(
+                    MoreVertMenuButton(
                         onClick = {
                             menuState.show {
                                 SelectionMediaMetadataMenu(
@@ -1035,13 +1031,7 @@ fun Queue(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null,
-                            tint = LocalContentColor.current,
-                        )
-                    }
+                    )
                 }
             }
             if (pureBlack) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -19,7 +18,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -27,8 +25,8 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChipsRow
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.YouTubeGridItem
 import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
@@ -185,16 +183,6 @@ fun AccountScreen(
 
     TopAppBar(
         title = { Text(stringResource(R.string.account)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
+        navigationIcon = { BackNavigationIcon(navController) },
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
@@ -29,6 +29,7 @@ import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.YouTubeGridItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
@@ -184,5 +185,6 @@ fun AccountScreen(
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.account)) },
         navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -25,6 +24,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -182,7 +182,7 @@ fun AccountScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.account)) },
+        title = { AppBarTitle(stringResource(R.string.account)) },
         navigationIcon = { BackNavigationIcon(navController) },
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -87,6 +87,7 @@ import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
@@ -556,6 +557,7 @@ fun AlbumScreen(
                     )
                 }
             }
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -84,6 +84,7 @@ import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.SelectionSongMenu
@@ -333,7 +334,7 @@ fun AlbumScreen(
                                         .focusable()
                                         .onFocusChanged { headerMenuButtonFocused.value = it.isFocused }
                                 ) {
-                                    IconButton(
+                                    MoreVertMenuButton(
                                         onClick = {
                                             menuState.show {
                                                 AlbumMenu(
@@ -346,12 +347,7 @@ fun AlbumScreen(
                                                 )
                                             }
                                         }
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.more_vert),
-                                            contentDescription = null,
-                                        )
-                                    }
+                                    )
                                 }
                             }
                         }
@@ -404,7 +400,7 @@ fun AlbumScreen(
                             showInLibraryIcon = true,
 
                             trailingContent = {
-                                IconButton(
+                                MoreVertMenuButton(
                                     onClick = {
                                         menuState.show {
                                             SongMenu(
@@ -414,12 +410,7 @@ fun AlbumScreen(
                                             )
                                         }
                                     },
-                                ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.more_vert),
-                                        contentDescription = null,
-                                    )
-                                }
+                                )
                             },
                             isSelected = songWrapper.isSelected && selection,
                             modifier =
@@ -554,7 +545,7 @@ fun AlbumScreen(
                         .focusable()
                         .onFocusChanged { isMoreButtonFocused.value = it.isFocused }
                 ) {
-                    IconButton(
+                    MoreVertMenuButton(
                         onClick = {
                             menuState.show {
                                 SelectionSongMenu(
@@ -565,12 +556,7 @@ fun AlbumScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
@@ -467,16 +468,12 @@ fun AlbumScreen(
         title = {
             if (selection) {
                 val count = wrappedSongs.count { it.isSelected }
-                Text(
-                    text = pluralStringResource(R.plurals.n_song, count, count),
-                    style = MaterialTheme.typography.titleLarge
+                AppBarTitle(
+                    text = pluralStringResource(R.plurals.n_song, count, count)
                 )
             } else {
-                Text(
-                    text = albumWithSongs?.album?.title.orEmpty(),
-                    style = MaterialTheme.typography.titleLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                AppBarTitle(
+                    text = albumWithSongs?.album?.title.orEmpty()
                 )
             }
         },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,6 +56,7 @@ import com.jtech.zemer.constants.ListItemHeight
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
@@ -98,7 +98,7 @@ fun ChartsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.charts)) },
+                title = { AppBarTitle(stringResource(R.string.charts)) },
                 navigationIcon = { BackNavigationIcon(navController) },
             )
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ChartsScreen.kt
@@ -62,6 +62,7 @@ import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
@@ -100,6 +101,7 @@ fun ChartsScreen(
             TopAppBar(
                 title = { AppBarTitle(stringResource(R.string.charts)) },
                 navigationIcon = { BackNavigationIcon(navController) },
+                colors = zemerTopAppBarColors(),
             )
         }
     ) { paddingValues ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreScreen.kt
@@ -87,6 +87,7 @@ import com.jtech.zemer.ui.component.genreIcon
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.YouTubeGridItem
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.ListItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.BoxPlaceholder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
@@ -458,6 +459,7 @@ fun GenreScreen(
         },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreScreen.kt
@@ -75,6 +75,7 @@ import com.jtech.zemer.search.zemerGenreSectionRoute
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.tracking.TrackImpressionsByKey
 import com.jtech.zemer.tracking.TrackingSurface
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.FontSizeRange
@@ -452,7 +453,7 @@ fun GenreScreen(
     TopAppBar(
         title = {
             if (showTopBarTitle) {
-                Text((state as? UiState.Loaded)?.page?.header?.title.orEmpty())
+                AppBarTitle((state as? UiState.Loaded)?.page?.header?.title.orEmpty())
             }
         },
         navigationIcon = { BackNavigationIcon(navController) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenreSectionScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
@@ -91,7 +92,7 @@ fun GenreSectionScreen(
 
     BackTopAppBar(
         title = {
-            Text(stringResource(if (viewModel.isSingles) R.string.singles else R.string.albums))
+            AppBarTitle(stringResource(if (viewModel.isSingles) R.string.singles else R.string.albums))
         },
         navController = navController,
         scrollBehavior = scrollBehavior,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt
@@ -34,6 +34,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.search.GenreKind
 import com.jtech.zemer.search.ZemerGenreSummary
 import com.jtech.zemer.search.zemerGenreRoute
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.GenreCard
@@ -116,7 +117,7 @@ fun GenresScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.genres)) },
+        title = { AppBarTitle(stringResource(R.string.genres)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt
@@ -38,6 +38,7 @@ import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.GenreCard
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.BoxPlaceholder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
@@ -120,6 +121,7 @@ fun GenresScreen(
         title = { AppBarTitle(stringResource(R.string.genres)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
@@ -59,6 +59,7 @@ import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
@@ -390,9 +391,8 @@ fun HistoryScreen(
         title = {
             if (selection) {
                 val count = allWrappedItems.count { it.isSelected }
-                Text(
-                    text = pluralStringResource(R.plurals.n_song, count, count),
-                    style = MaterialTheme.typography.titleLarge
+                AppBarTitle(
+                    text = pluralStringResource(R.plurals.n_song, count, count)
                 )
             } else if (isSearching) {
                 TextField(
@@ -419,7 +419,7 @@ fun HistoryScreen(
                         .focusRequester(focusRequester)
                 )
             } else {
-                Text(stringResource(R.string.history))
+                AppBarTitle(text = stringResource(R.string.history))
             }
         },
         navigationIcon = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt
@@ -68,6 +68,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
@@ -497,6 +498,7 @@ fun HistoryScreen(
                     )
                 }
             }
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -47,6 +47,7 @@ import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.YouTubeGridItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
@@ -113,6 +114,7 @@ fun HomeSeeAllScreen(
         title = { AppBarTitle(stringResource(row.titleRes)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -40,6 +39,7 @@ import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.search.zemerAlbumRoute
 import com.jtech.zemer.search.zemerPlaylistRoute
 import com.jtech.zemer.ui.component.AlbumListItem
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.ArtistListItem
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EmptyPlaceholder
@@ -110,7 +110,7 @@ fun HomeSeeAllScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(row.titleRes)) },
+        title = { AppBarTitle(stringResource(row.titleRes)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
@@ -32,6 +32,7 @@ import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.viewmodels.LatestReleasesViewModel
 
 /**
@@ -102,5 +103,6 @@ fun LatestReleasesScreen(
         title = { AppBarTitle(stringResource(R.string.latest_releases)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -29,6 +28,7 @@ import com.jtech.zemer.latestreleases.LatestReleaseCard
 import com.jtech.zemer.latestreleases.LatestReleaseFilter
 import com.jtech.zemer.latestreleases.applyFilter
 import com.jtech.zemer.latestreleases.shufflePlay
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
@@ -99,7 +99,7 @@ fun LatestReleasesScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.latest_releases)) },
+        title = { AppBarTitle(stringResource(R.string.latest_releases)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
@@ -34,6 +34,7 @@ import com.jtech.zemer.constants.InnerTubeCookieKey
 import com.jtech.zemer.constants.VisitorDataKey
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.utils.reportException
@@ -210,7 +211,8 @@ fun LoginScreen(
 
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.login)) },
-        navigationIcon = { BackNavigationIcon(navController) }
+        navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 
     BackHandler(enabled = webView?.canGoBack() == true) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
@@ -12,7 +12,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,6 +32,7 @@ import com.jtech.zemer.constants.AccountNameKey
 import com.jtech.zemer.constants.DataSyncIdKey
 import com.jtech.zemer.constants.InnerTubeCookieKey
 import com.jtech.zemer.constants.VisitorDataKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
@@ -209,7 +209,7 @@ fun LoginScreen(
     )
 
     TopAppBar(
-        title = { Text(stringResource(R.string.login)) },
+        title = { AppBarTitle(stringResource(R.string.login)) },
         navigationIcon = { BackNavigationIcon(navController) }
     )
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginScreen.kt
@@ -12,7 +12,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -23,7 +22,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
@@ -35,7 +33,7 @@ import com.jtech.zemer.constants.AccountNameKey
 import com.jtech.zemer.constants.DataSyncIdKey
 import com.jtech.zemer.constants.InnerTubeCookieKey
 import com.jtech.zemer.constants.VisitorDataKey
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.utils.reportException
@@ -212,17 +210,7 @@ fun LoginScreen(
 
     TopAppBar(
         title = { Text(stringResource(R.string.login)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null
-                )
-            }
-        }
+        navigationIcon = { BackNavigationIcon(navController) }
     )
 
     BackHandler(enabled = webView?.canGoBack() == true) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -30,6 +29,7 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.YouTubeQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -231,7 +231,7 @@ fun NewReleaseScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.new_release_title)) },
+        title = { AppBarTitle(stringResource(R.string.new_release_title)) },
         navigationIcon = { BackNavigationIcon(navController) },
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
@@ -37,6 +37,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.YouTubeGridItem
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
@@ -233,5 +234,6 @@ fun NewReleaseScreen(
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.new_release_title)) },
         navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
@@ -45,6 +45,7 @@ import com.jtech.zemer.ui.component.LocalArtistsGrid
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.LocalSongsGrid
 import com.jtech.zemer.ui.component.NavigationTitle
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
@@ -400,6 +401,7 @@ fun StatsScreen(
         TopAppBar(
             title = { AppBarTitle(stringResource(R.string.stats)) },
             navigationIcon = { BackNavigationIcon(navController) },
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,6 +36,7 @@ import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChoiceChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
@@ -398,7 +398,7 @@ fun StatsScreen(
         }
 
         TopAppBar(
-            title = { Text(stringResource(R.string.stats)) },
+            title = { AppBarTitle(stringResource(R.string.stats)) },
             navigationIcon = { BackNavigationIcon(navController) },
         )
     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt
@@ -24,6 +24,7 @@ import com.jtech.zemer.constants.GridThumbnailHeight
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ZemerCuratedPlaylistGridItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
 
 /**
@@ -66,5 +67,6 @@ fun ZemerPlaylistsScreen(
         title = { AppBarTitle(stringResource(R.string.zemer_playlists)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -22,6 +21,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ZemerCuratedPlaylistGridItem
 import com.jtech.zemer.viewmodels.ZemerCuratedPlaylistsViewModel
@@ -63,7 +63,7 @@ fun ZemerPlaylistsScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.zemer_playlists)) },
+        title = { AppBarTitle(stringResource(R.string.zemer_playlists)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
@@ -25,6 +25,7 @@ import com.jtech.zemer.playback.queues.StationQueue
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ZemerStationCard
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -84,5 +85,6 @@ fun ZemerStationsScreen(
         title = { AppBarTitle(stringResource(R.string.zemer_radio)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerStationsScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -23,6 +22,7 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.GridThumbnailHeight
 import com.jtech.zemer.playback.queues.StationQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ZemerStationCard
 import androidx.lifecycle.Lifecycle
@@ -81,7 +81,7 @@ fun ZemerStationsScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.zemer_radio)) },
+        title = { AppBarTitle(stringResource(R.string.zemer_radio)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistAlbumsScreen.kt
@@ -43,6 +43,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.constants.CONTENT_TYPE_ALBUM
 import com.jtech.zemer.constants.CONTENT_TYPE_HEADER
 import com.jtech.zemer.constants.GridThumbnailHeight
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.LibraryAlbumGridItem
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -128,7 +129,7 @@ fun ArtistAlbumsScreen(
         }
 
         BackTopAppBar(
-            title = { Text(artist?.artist?.name.orEmpty()) },
+            title = { AppBarTitle(artist?.artist?.name.orEmpty()) },
             navController = navController,
             scrollBehavior = scrollBehavior,
         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +39,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.tracking.PlaySource
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
@@ -300,7 +300,7 @@ fun ArtistItemsScreen(
     // NOTE: this local `title: String` param and BackTopAppBar's `title` composable parameter
     // share a name; the lambda below resolves `title` to this outer local variable.
     BackTopAppBar(
-        title = { Text(title) },
+        title = { AppBarTitle(title) },
         navController = navController,
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -97,6 +97,7 @@ import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlbumGridItem
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
@@ -834,10 +835,8 @@ fun ArtistScreen(
     TopAppBar(
         title = {
             if (!transparentAppBar) {
-                Text(
+                AppBarTitle(
                     text = artistPage?.artist?.title.orEmpty().ifEmpty { stringResource(R.string.artists) },
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
                 )
             }
         },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -97,9 +97,11 @@ import com.jtech.zemer.playback.queues.YouTubeQueue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlbumGridItem
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.EmptyPlaceholder
@@ -512,7 +514,7 @@ fun ArtistScreen(
                                 isActive = song.id == mediaMetadata?.id,
                                 isPlaying = isPlaying,
                                 trailingContent = {
-                                    IconButton(
+                                    MoreVertMenuButton(
                                         onClick = {
                                             menuState.show {
                                                 SongMenu(
@@ -522,12 +524,7 @@ fun ArtistScreen(
                                                 )
                                             }
                                         },
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.more_vert),
-                                            contentDescription = null,
-                                        )
-                                    }
+                                    )
                                 },
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -671,7 +668,7 @@ fun ArtistScreen(
                                     isActive = mediaMetadata?.id == song.id,
                                     isPlaying = isPlaying,
                                     trailingContent = {
-                                        IconButton(
+                                        MoreVertMenuButton(
                                             onClick = {
                                                 menuState.show {
                                                     YouTubeSongMenu(
@@ -681,12 +678,7 @@ fun ArtistScreen(
                                                     )
                                                 }
                                             },
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.more_vert),
-                                                contentDescription = null,
-                                            )
-                                        }
+                                        )
                                     },
                                     modifier = Modifier
                                         .combinedClickable(
@@ -850,18 +842,12 @@ fun ArtistScreen(
             }
         },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController = navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus },
+            )
         },
         actions = {
             IconButton(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -99,6 +99,7 @@ import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.AlbumGridItem
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -866,9 +867,13 @@ fun ArtistScreen(
             }
         },
         colors = if (transparentAppBar) {
+            // Over the artist header the bar is transparent so the artwork shows through.
             TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
         } else {
-            TopAppBarDefaults.topAppBarColors()
+            // Once scrolled past the header, use the shared bar color so it matches every other
+            // screen and does not grey-out on scroll (the default scrolledContainerColor isn't
+            // AMOLED-aware).
+            zemerTopAppBarColors()
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -27,6 +26,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.PlaySource
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -86,7 +86,7 @@ fun ArtistSectionScreen(
     }
 
     BackTopAppBar(
-        title = { Text(sectionTitle) },
+        title = { AppBarTitle(sectionTitle) },
         navController = navController,
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSectionScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -20,7 +18,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -33,6 +30,7 @@ import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.YtItemGrid
@@ -114,11 +112,9 @@ private fun ArtistSongList(
                 isActive = mediaMetadata?.id == song.id,
                 isPlaying = isPlaying,
                 trailingContent = {
-                    IconButton(onClick = {
+                    MoreVertMenuButton(onClick = {
                         menuState.show { YouTubeSongMenu(song = song, navController = navController, onDismiss = menuState::dismiss) }
-                    }) {
-                        Icon(painterResource(R.drawable.more_vert), contentDescription = null)
-                    }
+                    })
                 },
                 modifier = Modifier.combinedClickable(
                     onClick = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -28,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -46,8 +43,8 @@ import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.HideOnScrollFAB
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.SongMenu
@@ -131,7 +128,7 @@ fun ArtistSongsScreen(
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,
                     trailingContent = {
-                        IconButton(
+                        MoreVertMenuButton(
                             onClick = {
                                 menuState.show {
                                     SongMenu(
@@ -141,12 +138,7 @@ fun ArtistSongsScreen(
                                     )
                                 }
                             },
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.more_vert),
-                                contentDescription = null,
-                            )
-                        }
+                        )
                     },
                     modifier =
                     Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistSongsScreen.kt
@@ -41,6 +41,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.tracking.PlaySource
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -175,7 +176,7 @@ fun ArtistSongsScreen(
         }
 
         BackTopAppBar(
-            title = { Text(artist?.artist?.name.orEmpty()) },
+            title = { AppBarTitle(artist?.artist?.name.orEmpty()) },
             navController = navController,
         )
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt
@@ -81,6 +81,7 @@ import com.jtech.zemer.ui.component.AlbumListItem
 import com.jtech.zemer.ui.component.ArtistGridItem
 import com.jtech.zemer.ui.component.ArtistListItem
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.PlaylistGridItem
 import com.jtech.zemer.ui.component.PlaylistListItem
 import com.jtech.zemer.ui.component.SortHeader
@@ -456,7 +457,7 @@ fun LibraryMixScreen(
                                 PlaylistListItem(
                                     playlist = item,
                                     trailingContent = {
-                                        IconButton(
+                                        MoreVertMenuButton(
                                             onClick = {
                                                 menuState.show {
                                                     PlaylistMenu(
@@ -466,12 +467,7 @@ fun LibraryMixScreen(
                                                     )
                                                 }
                                             },
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.more_vert),
-                                                contentDescription = null,
-                                            )
-                                        }
+                                        )
                                     },
                                     modifier =
                                     Modifier
@@ -499,7 +495,7 @@ fun LibraryMixScreen(
                                 ArtistListItem(
                                     artist = item,
                                     trailingContent = {
-                                        IconButton(
+                                        MoreVertMenuButton(
                                             onClick = {
                                                 menuState.show {
                                                     ArtistMenu(
@@ -509,12 +505,7 @@ fun LibraryMixScreen(
                                                     )
                                                 }
                                             },
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.more_vert),
-                                                contentDescription = null,
-                                            )
-                                        }
+                                        )
                                     },
                                     modifier =
                                     Modifier
@@ -544,7 +535,7 @@ fun LibraryMixScreen(
                                     isActive = item.id == mediaMetadata?.album?.id,
                                     isPlaying = isPlaying,
                                     trailingContent = {
-                                        IconButton(
+                                        MoreVertMenuButton(
                                             onClick = {
                                                 menuState.show {
                                                     AlbumMenu(
@@ -554,12 +545,7 @@ fun LibraryMixScreen(
                                                     )
                                                 }
                                             },
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(R.drawable.more_vert),
-                                                contentDescription = null,
-                                            )
-                                        }
+                                        )
                                     },
                                     modifier =
                                     Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -59,6 +58,7 @@ import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionTopActions
@@ -256,7 +256,7 @@ fun LibrarySongsScreen(
                     isPlaying = isPlaying,
 
                     trailingContent = {
-                        IconButton(
+                        MoreVertMenuButton(
                             onClick = {
                                 menuState.show {
                                     SongMenu(
@@ -266,12 +266,7 @@ fun LibrarySongsScreen(
                                     )
                                 }
                             },
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.more_vert),
-                                contentDescription = null,
-                            )
-                        }
+                        )
                     },
                     isSelected = songWrapper.isSelected && selection,
                     modifier =

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.screens.videoRoute
@@ -93,7 +93,7 @@ fun LibraryVideosScreen(
                     isPlaying = isPlaying && mediaMetadata?.id == video.id,
                     isActive = mediaMetadata?.id == video.id,
                     trailingContent = {
-                        IconButton(
+                        MoreVertMenuButton(
                             onClick = {
                                 menuState.show {
                                     SongMenu(
@@ -103,12 +103,7 @@ fun LibraryVideosScreen(
                                     )
                                 }
                             },
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.more_vert),
-                                contentDescription = null,
-                            )
-                        }
+                        )
                     },
                     modifier =
                     Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt
@@ -735,6 +735,8 @@ fun VideoPlayerScreen(
                                             )
                                             Text(
                                                 text = artistName ?: stringResource(R.string.unknown_artist),
+                                                // Fixed light color on purpose: this label sits on the video
+                                                // overlay beside the Color.White title, not on a themed surface.
                                                 color = Color.LightGray,
                                                 style = MaterialTheme.typography.labelMedium,
                                                 maxLines = 1,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -86,6 +86,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
@@ -406,7 +407,7 @@ fun AutoPlaylistScreen(
                         isPlaying = isPlaying,
                         showInLibraryIcon = true,
                         trailingContent = {
-                            IconButton(
+                            MoreVertMenuButton(
                                 onClick = {
                                     menuState.show {
                                         SongMenu(
@@ -416,12 +417,7 @@ fun AutoPlaylistScreen(
                                         )
                                     }
                                 },
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.more_vert),
-                                    contentDescription = null,
-                                )
-                            }
+                            )
                         },
                         isSelected = songWrapper.isSelected && selection,
                         modifier =

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -91,6 +91,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
@@ -563,7 +564,8 @@ fun AutoPlaylistScreen(
                         )
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -79,6 +79,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.AggregateDownloadButton
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -472,9 +473,8 @@ fun AutoPlaylistScreen(
                 when {
                     selection -> {
                         val count = wrappedSongs.count { it.isSelected }
-                        Text(
-                            text = pluralStringResource(R.plurals.n_song, count, count),
-                            style = MaterialTheme.typography.titleLarge
+                        AppBarTitle(
+                            text = pluralStringResource(R.plurals.n_song, count, count)
                         )
                     }
                     isSearching -> {
@@ -503,10 +503,7 @@ fun AutoPlaylistScreen(
                         )
                     }
                     else -> {
-                        Text(
-                            text = playlist,
-                            style = MaterialTheme.typography.titleLarge
-                        )
+                        AppBarTitle(text = playlist)
                     }
                 }
             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
@@ -73,6 +73,7 @@ import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
@@ -285,7 +286,7 @@ fun CachePlaylistScreen(
                         isSelected = songWrapper.isSelected && selection,
                         showInLibraryIcon = true,
                         trailingContent = {
-                            IconButton(onClick = {
+                            MoreVertMenuButton(onClick = {
                                 menuState.show {
                                     SongMenu(
                                         originalSong = songWrapper.item,
@@ -294,12 +295,7 @@ fun CachePlaylistScreen(
                                         isFromCache = true,
                                     )
                                 }
-                            }) {
-                                Icon(
-                                    painter = painterResource(R.drawable.more_vert),
-                                    contentDescription = null
-                                )
-                            }
+                            })
                         },
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
@@ -69,6 +69,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.IconButton
@@ -349,9 +350,8 @@ fun CachePlaylistScreen(
                 when {
                     selection -> {
                         val count = wrappedSongs.count { it.isSelected }
-                        Text(
-                            text = pluralStringResource(R.plurals.n_song, count, count),
-                            style = MaterialTheme.typography.titleLarge
+                        AppBarTitle(
+                            text = pluralStringResource(R.plurals.n_song, count, count)
                         )
                     }
                     isSearching -> {
@@ -380,10 +380,7 @@ fun CachePlaylistScreen(
                         )
                     }
                     else -> {
-                        Text(
-                            stringResource(R.string.cached_playlist),
-                            style = MaterialTheme.typography.titleLarge
-                        )
+                        AppBarTitle(text = stringResource(R.string.cached_playlist))
                     }
                 }
             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt
@@ -78,6 +78,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
@@ -434,7 +435,8 @@ fun CachePlaylistScreen(
                         )
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedContentScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedContentScreen.kt
@@ -37,6 +37,7 @@ import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.BlockVideosKey
 import com.jtech.zemer.utils.rememberPreference
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackTopAppBar
 import com.jtech.zemer.viewmodels.DownloadedContentViewModel
 
@@ -158,10 +159,7 @@ fun DownloadedContentScreen(
 
         BackTopAppBar(
             title = {
-                Text(
-                    text = stringResource(R.string.offline),
-                    style = MaterialTheme.typography.titleLarge,
-                )
+                AppBarTitle(text = stringResource(R.string.offline))
             },
             navController = navController,
             scrollBehavior = scrollBehavior,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
@@ -72,6 +72,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.EmptyPlaceholder
@@ -357,9 +358,8 @@ fun DownloadedVideosScreen(
                 when {
                     selection -> {
                         val count = wrappedVideos.count { it.isSelected }
-                        Text(
-                            text = pluralStringResource(R.plurals.n_video, count, count),
-                            style = MaterialTheme.typography.titleLarge
+                        AppBarTitle(
+                            text = pluralStringResource(R.plurals.n_video, count, count)
                         )
                     }
                     isSearching -> {
@@ -388,10 +388,7 @@ fun DownloadedVideosScreen(
                         )
                     }
                     else -> {
-                        Text(
-                            text = stringResource(R.string.downloaded_videos),
-                            style = MaterialTheme.typography.titleLarge
-                        )
+                        AppBarTitle(text = stringResource(R.string.downloaded_videos))
                     }
                 }
             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
@@ -83,6 +83,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.screens.videoRoute
@@ -448,7 +449,8 @@ fun DownloadedVideosScreen(
                         )
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt
@@ -78,6 +78,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
@@ -301,7 +302,7 @@ fun DownloadedVideosScreen(
                         isPlaying = isPlaying,
                         showInLibraryIcon = true,
                         trailingContent = {
-                            IconButton(
+                            MoreVertMenuButton(
                                 onClick = {
                                     menuState.show {
                                         SongMenu(
@@ -311,12 +312,7 @@ fun DownloadedVideosScreen(
                                         )
                                     }
                                 },
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.more_vert),
-                                    contentDescription = null,
-                                )
-                            }
+                            )
                         },
                         isSelected = videoWrapper.isSelected && selection,
                         modifier = Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -132,6 +132,7 @@ import com.jtech.zemer.ui.component.OverlayEditButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.TextFieldDialog
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.CustomThumbnailMenu
 import com.jtech.zemer.ui.component.SelectionActions
 import com.jtech.zemer.ui.menu.SelectionSongMenu
@@ -872,7 +873,8 @@ fun LocalPlaylistScreen(
                         )
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
 
         SnackbarHost(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -119,6 +119,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.ActionPromptDialog
 import com.jtech.zemer.ui.component.AggregateDownloadButton
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -784,9 +785,8 @@ fun LocalPlaylistScreen(
             title = {
                 if (selection) {
                     val count = wrappedSongs.count { it.isSelected }
-                    Text(
-                        text = pluralStringResource(R.plurals.n_song, count, count),
-                        style = MaterialTheme.typography.titleLarge
+                    AppBarTitle(
+                        text = pluralStringResource(R.plurals.n_song, count, count)
                     )
                 } else if (isSearching) {
                     TextField(
@@ -813,7 +813,7 @@ fun LocalPlaylistScreen(
                             .focusRequester(focusRequester)
                     )
                 } else if (showTopBarTitle) {
-                    Text(playlist?.playlist?.name.orEmpty())
+                    AppBarTitle(text = playlist?.playlist?.name.orEmpty())
                 }
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -126,6 +126,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.OverlayEditButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
@@ -569,7 +570,7 @@ fun LocalPlaylistScreen(
                                 isPlaying = isPlaying,
                                 showInLibraryIcon = true,
                                 trailingContent = {
-                                    IconButton(
+                                    MoreVertMenuButton(
                                         onClick = {
                                             menuState.show {
                                                 SongMenu(
@@ -581,12 +582,7 @@ fun LocalPlaylistScreen(
                                                 )
                                             }
                                         },
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.more_vert),
-                                            contentDescription = null,
-                                        )
-                                    }
+                                    )
 
                                     if (sortType == PlaylistSongSortType.CUSTOM && !locked && !selection && !isSearching && editable) {
                                         IconButton(
@@ -697,7 +693,7 @@ fun LocalPlaylistScreen(
                                 showInLibraryIcon = true,
 
                                 trailingContent = {
-                                    IconButton(
+                                    MoreVertMenuButton(
                                         onClick = {
                                             menuState.show {
                                                 SongMenu(
@@ -708,12 +704,7 @@ fun LocalPlaylistScreen(
                                                 )
                                             }
                                         },
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.more_vert),
-                                            contentDescription = null,
-                                        )
-                                    }
+                                    )
                                     if (sortType == PlaylistSongSortType.CUSTOM && !locked && !selection && !isSearching && editable) {
                                         IconButton(
                                             onClick = { },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -95,6 +95,7 @@ import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.shimmer.LoadingListPlaceholder
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
@@ -345,7 +346,7 @@ fun OnlinePlaylistScreen(
                                                 }
                                             }
 
-                                            IconButton(
+                                            MoreVertMenuButton(
                                                 onClick = {
                                                     menuState.show {
                                                         YouTubePlaylistMenu(
@@ -358,12 +359,7 @@ fun OnlinePlaylistScreen(
                                                         )
                                                     }
                                                 },
-                                            ) {
-                                                Icon(
-                                                    painter = painterResource(R.drawable.more_vert),
-                                                    contentDescription = null,
-                                                )
-                                            }
+                                            )
                                         }
                                     }
                                 }
@@ -430,7 +426,7 @@ fun OnlinePlaylistScreen(
                             isPlaying = isPlaying,
                             isSelected = song.isSelected && selection,
                             trailingContent = {
-                                IconButton(
+                                MoreVertMenuButton(
                                     onClick = {
                                         menuState.show {
                                             YouTubeSongMenu(
@@ -440,12 +436,7 @@ fun OnlinePlaylistScreen(
                                             )
                                         }
                                     },
-                                ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.more_vert),
-                                        contentDescription = null,
-                                    )
-                                }
+                                )
                             },
                             modifier =
                             Modifier
@@ -624,7 +615,7 @@ fun OnlinePlaylistScreen(
                             contentDescription = null
                         )
                     }
-                    IconButton(
+                    MoreVertMenuButton(
                         onClick = {
                             menuState.show {
                                 SelectionMediaMetadataMenu(
@@ -636,12 +627,7 @@ fun OnlinePlaylistScreen(
                                 )
                             }
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 } else {
                     if (!isSearching) {
                         IconButton(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -90,6 +90,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ListQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DraggableScrollbar
 import com.jtech.zemer.ui.component.FontSizeRange
@@ -538,9 +539,8 @@ fun OnlinePlaylistScreen(
             title = {
                 if (selection) {
                     val count = wrappedSongs.count { it.isSelected }
-                    Text(
-                        text = pluralStringResource(R.plurals.n_song, count, count),
-                        style = MaterialTheme.typography.titleLarge
+                    AppBarTitle(
+                        text = pluralStringResource(R.plurals.n_song, count, count)
                     )
                 } else if (isSearching) {
                     TextField(
@@ -567,7 +567,7 @@ fun OnlinePlaylistScreen(
                             .focusRequester(focusRequester)
                     )
                 } else if (showTopBarTitle) {
-                    Text(playlist?.title.orEmpty())
+                    AppBarTitle(text = playlist?.title.orEmpty())
                 }
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -98,6 +98,7 @@ import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.shimmer.LoadingListPlaceholder
 import com.jtech.zemer.ui.menu.SelectionMediaMetadataMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
@@ -640,7 +641,8 @@ fun OnlinePlaylistScreen(
                         }
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
 
         SnackbarHost(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -76,6 +76,7 @@ import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.playback.queues.ListQueue
 import com.jtech.zemer.ui.component.AggregateDownloadButton
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.DraggableScrollbar
@@ -432,9 +433,8 @@ fun TopPlaylistScreen(
                 when {
                     selection -> {
                         val count = wrappedSongs.count { it.isSelected }
-                        Text(
-                            text = pluralStringResource(R.plurals.n_song, count, count),
-                            style = MaterialTheme.typography.titleLarge
+                        AppBarTitle(
+                            text = pluralStringResource(R.plurals.n_song, count, count)
                         )
                     }
                     isSearching -> {
@@ -463,7 +463,7 @@ fun TopPlaylistScreen(
                         )
                     }
                     else -> {
-                        Text(text = name)
+                        AppBarTitle(text = name)
                     }
                 }
             },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -83,6 +83,7 @@ import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.FontSizeRange
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
@@ -367,7 +368,7 @@ fun TopPlaylistScreen(
                         isPlaying = isPlaying,
                         showInLibraryIcon = true,
                         trailingContent = {
-                            IconButton(
+                            MoreVertMenuButton(
                                 onClick = {
                                     menuState.show {
                                         SongMenu(
@@ -377,12 +378,7 @@ fun TopPlaylistScreen(
                                         )
                                     }
                                 },
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.more_vert),
-                                    contentDescription = null,
-                                )
-                            }
+                            )
                         },
                         isSelected = songWrapper.isSelected && selection,
                         modifier = Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt
@@ -88,6 +88,7 @@ import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.component.SelectionActions
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.SelectionSongMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
@@ -523,7 +524,8 @@ fun TopPlaylistScreen(
                         )
                     }
                 }
-            }
+            },
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
@@ -76,6 +76,7 @@ import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.zemerCuratedPlaylistRuntimeLabel
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
@@ -467,6 +468,7 @@ fun ZemerCuratedPlaylistScreen(
                 BackNavigationIcon(navController)
             },
             scrollBehavior = scrollBehavior,
+            colors = zemerTopAppBarColors(),
         )
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -67,13 +65,14 @@ import com.jtech.zemer.tracking.TrackingSurface
 import com.jtech.zemer.search.ChartMovement
 import com.jtech.zemer.search.zemerAlbumRoute
 import com.jtech.zemer.ui.component.AutoResizeText
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChartRankCell
 import com.jtech.zemer.ui.component.rememberChartRankMetrics
 import com.jtech.zemer.ui.component.chartAnchorLabel
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.FontSizeRange
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.component.zemerCuratedPlaylistRuntimeLabel
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
@@ -405,12 +404,7 @@ fun ZemerCuratedPlaylistScreen(
                             isActive = mediaMetadata?.id == song.id,
                             isPlaying = isPlaying,
                             trailingContent = {
-                                IconButton(onClick = { showSongMenu(song) }) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.more_vert),
-                                        contentDescription = null,
-                                    )
-                                }
+                                MoreVertMenuButton(onClick = { showSongMenu(song) })
                             },
                             modifier = Modifier
                                 .weight(1f)
@@ -469,15 +463,7 @@ fun ZemerCuratedPlaylistScreen(
                 }
             },
             navigationIcon = {
-                IconButton(
-                    onClick = navController::navigateUp,
-                    onLongClick = navController::backToMain,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_back),
-                        contentDescription = null
-                    )
-                }
+                BackNavigationIcon(navController)
             },
             scrollBehavior = scrollBehavior,
         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/ZemerCuratedPlaylistScreen.kt
@@ -64,6 +64,7 @@ import com.jtech.zemer.tracking.TrackImpressionsByKey
 import com.jtech.zemer.tracking.TrackingSurface
 import com.jtech.zemer.search.ChartMovement
 import com.jtech.zemer.search.zemerAlbumRoute
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.AutoResizeText
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ChartRankCell
@@ -459,7 +460,7 @@ fun ZemerCuratedPlaylistScreen(
         TopAppBar(
             title = {
                 if (showTopBarTitle) {
-                    Text((state as? UiState.Loaded)?.page?.playlist?.title.orEmpty())
+                    AppBarTitle(text = (state as? UiState.Loaded)?.page?.playlist?.title.orEmpty())
                 }
             },
             navigationIcon = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -44,6 +44,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.RecognitionHistoryEntity
 import com.jtech.zemer.recognition.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.focusBorder
@@ -65,14 +66,7 @@ fun RecognitionHistoryScreen(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.recognition_history)) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
-                    }
-                },
+                navigationIcon = { BackNavigationIcon(navController) },
                 actions = {
                     if (items.isNotEmpty()) {
                         IconButton(onClick = { showClearDialog = true }, onLongClick = {}) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -44,6 +44,7 @@ import com.jtech.zemer.constants.ThumbnailCornerRadius
 import com.jtech.zemer.db.entities.RecognitionHistoryEntity
 import com.jtech.zemer.recognition.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.IconButton
@@ -65,7 +66,7 @@ fun RecognitionHistoryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.recognition_history)) },
+                title = { AppBarTitle(stringResource(R.string.recognition_history)) },
                 navigationIcon = { BackNavigationIcon(navController) },
                 actions = {
                     if (items.isNotEmpty()) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -49,6 +49,7 @@ import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.resize
 import com.jtech.zemer.viewmodels.RecognitionHistoryViewModel
@@ -78,6 +79,7 @@ fun RecognitionHistoryScreen(
                         }
                     }
                 },
+                colors = zemerTopAppBarColors(),
             )
         },
     ) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,7 +35,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -60,6 +57,7 @@ import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.OfflineBackupPromoCard
 import com.jtech.zemer.ui.component.YouTubeListItem
@@ -225,14 +223,9 @@ fun OnlineSearchResult(
             },
             isPlaying = isPlaying,
             trailingContent = {
-                IconButton(
+                MoreVertMenuButton(
                     onClick = longClick,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.more_vert),
-                        contentDescription = null,
-                    )
-                }
+                )
             },
             modifier =
             Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -73,6 +73,7 @@ import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.screens.Screens
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SearchBarIconOffsetX
 import com.jtech.zemer.ui.component.YouTubeListItem
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
@@ -239,7 +240,7 @@ fun OnlineSearchScreen(
                 },
                 isPlaying = isPlaying,
                 trailingContent = {
-                    IconButton(
+                    MoreVertMenuButton(
                         onClick = {
                             menuState.show {
                                 when (item) {
@@ -277,12 +278,7 @@ fun OnlineSearchScreen(
                                 }
                             }
                         }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.more_vert),
-                            contentDescription = null
-                        )
-                    }
+                    )
                 },
                 modifier = Modifier
                     .combinedClickable(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
@@ -50,6 +50,7 @@ import com.jtech.zemer.BuildConfig
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.DeveloperModeEnabledKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.utils.backToMain
@@ -210,7 +211,7 @@ fun AboutScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.about)) },
+        title = { AppBarTitle(stringResource(R.string.about)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
@@ -50,7 +50,7 @@ import com.jtech.zemer.BuildConfig
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.DeveloperModeEnabledKey
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
@@ -212,18 +212,12 @@ fun AboutScreen(
     TopAppBar(
         title = { Text(stringResource(R.string.about)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AboutScreen.kt
@@ -53,6 +53,7 @@ import com.jtech.zemer.constants.DeveloperModeEnabledKey
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 import android.widget.Toast
@@ -219,6 +220,7 @@ fun AboutScreen(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -38,6 +38,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.AndroidAutoSectionsOrderKey
@@ -258,7 +259,7 @@ fun AndroidAutoSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.android_auto)) },
+        title = { AppBarTitle(stringResource(R.string.android_auto)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -47,6 +47,7 @@ import com.jtech.zemer.constants.MediaSessionConstants
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.utils.rememberPreference
 import kotlinx.coroutines.flow.map
 import sh.calvin.reorderable.ReorderableItem
@@ -262,5 +263,6 @@ fun AndroidAutoSettings(
         title = { AppBarTitle(stringResource(R.string.android_auto)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AndroidAutoSettings.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
@@ -39,6 +38,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalDatabase
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.AndroidAutoSectionsOrderKey
 import com.jtech.zemer.constants.AndroidAutoTargetPlaylistKey
@@ -259,11 +259,7 @@ fun AndroidAutoSettings(
 
     TopAppBar(
         title = { Text(stringResource(R.string.android_auto)) },
-        navigationIcon = {
-            IconButton(onClick = navController::navigateUp) {
-                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
-            }
-        },
+        navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior,
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
@@ -96,6 +96,7 @@ import com.jtech.zemer.constants.RecognizeMusicFabKey
 import com.jtech.zemer.constants.BottomNavigationItemsKey
 import com.jtech.zemer.constants.UseNewMiniPlayerDesignKey
 import com.jtech.zemer.constants.UseNewPlayerDesignKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.EnumListPreference
@@ -1033,7 +1034,7 @@ fun AppearanceSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.appearance)) },
+        title = { AppBarTitle(stringResource(R.string.appearance)) },
         navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
@@ -108,6 +108,7 @@ import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
 import com.jtech.zemer.ui.component.TextFieldDialog
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
@@ -1035,7 +1036,8 @@ fun AppearanceSettings(
 
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.appearance)) },
-        navigationIcon = { BackNavigationIcon(navController) }
+        navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
@@ -96,10 +96,10 @@ import com.jtech.zemer.constants.RecognizeMusicFabKey
 import com.jtech.zemer.constants.BottomNavigationItemsKey
 import com.jtech.zemer.constants.UseNewMiniPlayerDesignKey
 import com.jtech.zemer.constants.UseNewPlayerDesignKey
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.EnumListPreference
 import com.jtech.zemer.ui.player.isBlurSupported
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PlayerSliderTrack
 import com.jtech.zemer.ui.component.PreferenceEntry
@@ -1034,17 +1034,7 @@ fun AppearanceSettings(
 
     TopAppBar(
         title = { Text(stringResource(R.string.appearance)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        }
+        navigationIcon = { BackNavigationIcon(navController) }
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
@@ -32,6 +32,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.menu.AddToPlaylistDialogOnline
@@ -147,7 +148,7 @@ fun BackupAndRestore(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.backup_restore)) },
+        title = { AppBarTitle(stringResource(R.string.backup_restore)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
@@ -32,7 +32,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.menu.AddToPlaylistDialogOnline
 import com.jtech.zemer.ui.menu.LoadingScreen
@@ -149,18 +149,12 @@ fun BackupAndRestore(
     TopAppBar(
         title = { Text(stringResource(R.string.backup_restore)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
     AddToPlaylistDialogOnline(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/BackupAndRestore.kt
@@ -37,6 +37,7 @@ import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.menu.AddToPlaylistDialogOnline
 import com.jtech.zemer.ui.menu.LoadingScreen
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.viewmodels.BackupRestoreViewModel
 import kotlinx.coroutines.delay
@@ -156,7 +157,8 @@ fun BackupAndRestore(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
     AddToPlaylistDialogOnline(
         isVisible = showChoosePlaylistDialogOnline,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
@@ -52,6 +52,7 @@ import com.jtech.zemer.models.DpadDirection
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.AccessibilityUtils
 import com.jtech.zemer.utils.rememberAccessibilityEnabledState
@@ -168,7 +169,8 @@ fun ButtonSetupScreen(
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.dpad_setup_title)) },
         navigationIcon = { BackNavigationIcon(navController) },
-        scrollBehavior = scrollBehavior
+        scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
@@ -49,6 +49,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.models.DpadDirection
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.utils.backToMain
@@ -165,7 +166,7 @@ fun ButtonSetupScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.dpad_setup_title)) },
+        title = { AppBarTitle(stringResource(R.string.dpad_setup_title)) },
         navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt
@@ -49,7 +49,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.models.DpadDirection
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.AccessibilityUtils
@@ -166,17 +166,7 @@ fun ButtonSetupScreen(
 
     TopAppBar(
         title = { Text(stringResource(R.string.dpad_setup_title)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null
-                )
-            }
-        },
+        navigationIcon = { BackNavigationIcon(navController) },
         scrollBehavior = scrollBehavior
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
@@ -80,6 +80,7 @@ import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
 import com.jtech.zemer.ui.component.AnonymousAuthEmailDialog
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.rememberEnumPreference
@@ -464,7 +465,8 @@ fun ContentSettings(
 
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.content)) },
-        navigationIcon = { BackNavigationIcon(navController) }
+        navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -73,6 +72,7 @@ import com.jtech.zemer.constants.SYSTEM_DEFAULT
 import com.jtech.zemer.constants.TopSize
 import com.jtech.zemer.sync.SyncState
 import com.jtech.zemer.sync.SyncStatus
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EditTextPreference
 import com.jtech.zemer.ui.component.ListPreference
@@ -463,7 +463,7 @@ fun ContentSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.content)) },
+        title = { AppBarTitle(stringResource(R.string.content)) },
         navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ContentSettings.kt
@@ -73,8 +73,8 @@ import com.jtech.zemer.constants.SYSTEM_DEFAULT
 import com.jtech.zemer.constants.TopSize
 import com.jtech.zemer.sync.SyncState
 import com.jtech.zemer.sync.SyncStatus
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EditTextPreference
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -464,17 +464,7 @@ fun ContentSettings(
 
     TopAppBar(
         title = { Text(stringResource(R.string.content)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        }
+        navigationIcon = { BackNavigationIcon(navController) }
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -72,7 +73,7 @@ fun GeneralSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.links)) },
+        title = { AppBarTitle(stringResource(R.string.links)) },
         navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
-import com.jtech.zemer.ui.component.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -26,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.utils.backToMain
@@ -73,16 +73,6 @@ fun GeneralSettings(
 
     TopAppBar(
         title = { Text(stringResource(R.string.links)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null
-                )
-            }
-        }
+        navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/GeneralSettings.kt
@@ -29,6 +29,7 @@ import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -74,6 +75,7 @@ fun GeneralSettings(
 
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.links)) },
-        navigationIcon = { BackNavigationIcon(navController) }
+        navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
@@ -51,6 +51,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.DebugLoggingEnabledKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.focusBorder
@@ -240,7 +241,7 @@ fun LogViewerScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.log_viewer)) },
+        title = { AppBarTitle(stringResource(R.string.log_viewer)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
@@ -51,8 +51,8 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.DebugLoggingEnabledKey
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.focusBorder
 import com.jtech.zemer.ui.theme.logPriorityColor
 import com.jtech.zemer.ui.component.PreferenceEntry
@@ -242,18 +242,12 @@ fun LogViewerScreen(
     TopAppBar(
         title = { Text(stringResource(R.string.log_viewer)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/LogViewerScreen.kt
@@ -59,6 +59,7 @@ import com.jtech.zemer.ui.theme.logPriorityColor
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.LogBufferTree
 import com.jtech.zemer.utils.LogExport
@@ -249,7 +250,8 @@ fun LogViewerScreen(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -28,6 +28,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.OfflineSubsetEnabledKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -116,7 +117,7 @@ fun OfflineSearchSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.offline_search)) },
+        title = { AppBarTitle(stringResource(R.string.offline_search)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -28,7 +28,7 @@ import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.OfflineSubsetEnabledKey
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
@@ -118,18 +118,12 @@ fun OfflineSearchSettings(
     TopAppBar(
         title = { Text(stringResource(R.string.offline_search)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/OfflineSearchSettings.kt
@@ -33,6 +33,7 @@ import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.OfflineSearchSettingsViewModel
@@ -127,5 +128,6 @@ fun OfflineSearchSettings(
             )
         },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
@@ -39,6 +39,7 @@ import com.jtech.zemer.constants.PersistentQueueKey
 import com.jtech.zemer.constants.SeekExtraSeconds
 import com.jtech.zemer.constants.SkipSilenceKey
 import com.jtech.zemer.constants.StopMusicOnTaskClearKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EnumListPreference
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -263,7 +264,7 @@ fun PlayerSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.player_and_audio)) },
+        title = { AppBarTitle(stringResource(R.string.player_and_audio)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
@@ -46,6 +46,7 @@ import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SliderPreference
 import com.jtech.zemer.ui.component.SwitchPreference
 import com.jtech.zemer.ui.player.CastDownloadDialog
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
@@ -272,6 +273,7 @@ fun PlayerSettings(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PlayerSettings.kt
@@ -39,8 +39,8 @@ import com.jtech.zemer.constants.PersistentQueueKey
 import com.jtech.zemer.constants.SeekExtraSeconds
 import com.jtech.zemer.constants.SkipSilenceKey
 import com.jtech.zemer.constants.StopMusicOnTaskClearKey
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.EnumListPreference
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SliderPreference
 import com.jtech.zemer.ui.component.SwitchPreference
@@ -265,18 +265,12 @@ fun PlayerSettings(
     TopAppBar(
         title = { Text(stringResource(R.string.player_and_audio)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
@@ -38,6 +38,7 @@ import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 
@@ -198,6 +199,7 @@ fun PrivacySettings(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
@@ -32,6 +32,7 @@ import com.jtech.zemer.R
 import com.jtech.zemer.constants.DisableScreenshotKey
 import com.jtech.zemer.constants.PauseListenHistoryKey
 import com.jtech.zemer.constants.PauseSearchHistoryKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.PreferenceEntry
@@ -189,7 +190,7 @@ fun PrivacySettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.privacy)) },
+        title = { AppBarTitle(stringResource(R.string.privacy)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/PrivacySettings.kt
@@ -32,8 +32,8 @@ import com.jtech.zemer.R
 import com.jtech.zemer.constants.DisableScreenshotKey
 import com.jtech.zemer.constants.PauseListenHistoryKey
 import com.jtech.zemer.constants.PauseSearchHistoryKey
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.DefaultDialog
-import com.jtech.zemer.ui.component.IconButton
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
@@ -191,18 +191,12 @@ fun PrivacySettings(
     TopAppBar(
         title = { Text(stringResource(R.string.privacy)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.navigation.NavController
 import com.google.firebase.auth.FirebaseAuth
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.Material3SettingsGroup
 import com.jtech.zemer.ui.component.Material3SettingsItem
@@ -210,7 +211,7 @@ fun SettingsScreen(
             .background(MaterialTheme.colorScheme.background)
     ) {
         TopAppBar(
-            title = { Text(stringResource(R.string.settings)) },
+            title = { AppBarTitle(stringResource(R.string.settings)) },
             navigationIcon = { BackNavigationIcon(navController) },
             scrollBehavior = scrollBehavior
         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.Material3SettingsGroup
 import com.jtech.zemer.ui.component.Material3SettingsItem
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 
 data class SettingItem(
     val id: String,
@@ -213,7 +214,8 @@ fun SettingsScreen(
         TopAppBar(
             title = { AppBarTitle(stringResource(R.string.settings)) },
             navigationIcon = { BackNavigationIcon(navController) },
-            scrollBehavior = scrollBehavior
+            scrollBehavior = scrollBehavior,
+            colors = zemerTopAppBarColors(),
         )
         // Content with scroll
         val paddingValues = LocalPlayerAwareWindowInsets.current.asPaddingValues()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/SettingsScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -34,6 +32,7 @@ import androidx.navigation.NavController
 import com.google.firebase.auth.FirebaseAuth
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.Material3SettingsGroup
 import com.jtech.zemer.ui.component.Material3SettingsItem
 
@@ -212,14 +211,7 @@ fun SettingsScreen(
     ) {
         TopAppBar(
             title = { Text(stringResource(R.string.settings)) },
-            navigationIcon = {
-                IconButton(onClick = { navController.navigateUp() }) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_back),
-                        contentDescription = null
-                    )
-                }
-            },
+            navigationIcon = { BackNavigationIcon(navController) },
             scrollBehavior = scrollBehavior
         )
         // Content with scroll

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
@@ -48,6 +48,7 @@ import com.jtech.zemer.constants.MaxImageCacheSizeKey
 import com.jtech.zemer.constants.MaxSongCacheSizeKey
 import com.jtech.zemer.extensions.tryOrNull
 import com.jtech.zemer.ui.component.ActionPromptDialog
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
@@ -399,7 +400,7 @@ fun StorageSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.storage)) },
+        title = { AppBarTitle(stringResource(R.string.storage)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,7 +35,6 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -50,7 +48,7 @@ import com.jtech.zemer.constants.MaxImageCacheSizeKey
 import com.jtech.zemer.constants.MaxSongCacheSizeKey
 import com.jtech.zemer.extensions.tryOrNull
 import com.jtech.zemer.ui.component.ActionPromptDialog
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
@@ -403,18 +401,12 @@ fun StorageSettings(
     TopAppBar(
         title = { Text(stringResource(R.string.storage)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt
@@ -53,6 +53,7 @@ import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.formatFileSize
 import com.jtech.zemer.db.entities.Song
@@ -408,7 +409,8 @@ fun StorageSettings(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
@@ -41,7 +41,7 @@ import com.jtech.zemer.constants.StreamSourceVisionOSKey
 import com.jtech.zemer.constants.StreamSourceTVHTML5Key
 import com.jtech.zemer.constants.StreamSourceWebCreatorKey
 import com.jtech.zemer.constants.StreamSourceWebRemixKey
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
 import com.jtech.zemer.ui.utils.backToMain
@@ -200,18 +200,12 @@ fun StreamSourceSettings(
     TopAppBar(
         title = { Text(stringResource(R.string.stream_sources)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus },
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         },
         scrollBehavior = scrollBehavior,
     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
@@ -45,6 +45,7 @@ import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.utils.rememberPreference
 
@@ -209,5 +210,6 @@ fun StreamSourceSettings(
             )
         },
         scrollBehavior = scrollBehavior,
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt
@@ -41,6 +41,7 @@ import com.jtech.zemer.constants.StreamSourceVisionOSKey
 import com.jtech.zemer.constants.StreamSourceTVHTML5Key
 import com.jtech.zemer.constants.StreamSourceWebCreatorKey
 import com.jtech.zemer.constants.StreamSourceWebRemixKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.PreferenceGroupTitle
 import com.jtech.zemer.ui.component.SwitchPreference
@@ -198,7 +199,7 @@ fun StreamSourceSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.stream_sources)) },
+        title = { AppBarTitle(stringResource(R.string.stream_sources)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -45,7 +45,7 @@ import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.CheckForUpdatesKey
 import com.jtech.zemer.constants.InstallerTypeKey
 import com.jtech.zemer.constants.NightlyUpdatesKey
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.UpdateDownloadDialog
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
@@ -396,18 +396,12 @@ fun UpdaterScreen(
     TopAppBar(
         title = { Text(stringResource(R.string.updater)) },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .focusRequester(backFocus)
-                        .focusProperties { down = firstFocus }
-                )
-            }
+            BackNavigationIcon(
+                navController,
+                modifier = Modifier
+                    .focusRequester(backFocus)
+                    .focusProperties { down = firstFocus }
+            )
         }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -48,6 +48,7 @@ import com.jtech.zemer.constants.NightlyUpdatesKey
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.UpdateDownloadDialog
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.component.ListPreference
 import com.jtech.zemer.ui.component.PreferenceEntry
 import com.jtech.zemer.ui.component.SwitchPreference
@@ -403,6 +404,7 @@ fun UpdaterScreen(
                     .focusRequester(backFocus)
                     .focusProperties { down = firstFocus }
             )
-        }
+        },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -45,6 +45,7 @@ import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.constants.CheckForUpdatesKey
 import com.jtech.zemer.constants.InstallerTypeKey
 import com.jtech.zemer.constants.NightlyUpdatesKey
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.component.UpdateDownloadDialog
 import com.jtech.zemer.ui.component.ListPreference
@@ -394,7 +395,7 @@ fun UpdaterScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.updater)) },
+        title = { AppBarTitle(stringResource(R.string.updater)) },
         navigationIcon = {
             BackNavigationIcon(
                 navController,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
+import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.utils.backToMain
 import androidx.compose.ui.res.stringResource
@@ -32,7 +32,7 @@ fun IntegrationScreen(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.integrations)) },
+        title = { AppBarTitle(stringResource(R.string.integrations)) },
         navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
@@ -5,17 +5,15 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavController
 import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
-import com.jtech.zemer.ui.component.IconButton
+import com.jtech.zemer.ui.component.BackNavigationIcon
 import com.jtech.zemer.ui.utils.backToMain
 import androidx.compose.ui.res.stringResource
 
@@ -35,16 +33,6 @@ fun IntegrationScreen(
 
     TopAppBar(
         title = { Text(stringResource(R.string.integrations)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        }
+        navigationIcon = { BackNavigationIcon(navController) }
     )
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt
@@ -14,6 +14,7 @@ import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.BackNavigationIcon
+import com.jtech.zemer.ui.component.zemerTopAppBarColors
 import com.jtech.zemer.ui.utils.backToMain
 import androidx.compose.ui.res.stringResource
 
@@ -33,6 +34,7 @@ fun IntegrationScreen(
 
     TopAppBar(
         title = { AppBarTitle(stringResource(R.string.integrations)) },
-        navigationIcon = { BackNavigationIcon(navController) }
+        navigationIcon = { BackNavigationIcon(navController) },
+        colors = zemerTopAppBarColors(),
     )
 }

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -21,6 +21,20 @@ particular), so `scripts/ui-audit.sh` ratchets the known gaps down without block
 - Do not introduce a second component that duplicates one of these. (For example, settings rows use
   the `Preference.kt` widgets below — do not add a parallel "settings group" widget set; grouped/
   separated rows use the components in section 11 — do not hand-roll cards per row.)
+- **Componentize on every touch.** Whenever you edit a screen, check whether a shared component
+  already covers what you are writing; if it does, use it. The moment you would write a *second*
+  near-copy of a widget that already exists elsewhere, extract it into `ui/component/` (or reuse the
+  existing one) and repoint every site in the same pass — never leave two hand-rolled copies to
+  drift. In particular: the top-bar back button is `BackNavigationIcon` / `BackTopAppBar`, the row
+  3-dot overflow is `MoreVertMenuButton`, and a plain `TopAppBar` action icon is
+  `TopAppBarActionButton` — all in `IconButton.kt`.
+- Enforcement (ratcheting): `scripts/ui-audit.sh` rules `R14-backbtn` and `R15-morevert` fail CI on
+  any *new* raw `R.drawable.arrow_back` / `R.drawable.more_vert` in a screen — build the back button
+  and the overflow menu from the shared components instead. The existing hand-rolls are baselined in
+  `scripts/ui-audit-baseline.tsv` (a large backlog — burn it down when you touch a screen; a
+  state-branching nav icon that legitimately flips to `close` in selection mode stays baselined).
+  The remaining reuse rules here (the other shared components, the `Material3SettingsGroup` settings
+  cards, the `.focusable()` D-pad treatment) are not greppable and stay a code-review gate.
 
 ## 2. Settings screens
 

--- a/scripts/ui-audit-baseline.tsv
+++ b/scripts/ui-audit-baseline.tsv
@@ -10,4 +10,15 @@ app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt	R12-blur	1
 app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt	R12-blur	1
 app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt	R8-hex	1
 app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt	R12-blur	1
+app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt	R15-morevert	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/player/VideoPlayerScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/AutoPlaylistScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/CachePlaylistScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/DownloadedVideosScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/LocalPlaylistScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt	R14-backbtn	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/TopPlaylistScreen.kt	R14-backbtn	1
 app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt	R8-hex	1
+app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ButtonSetupScreen.kt	R14-backbtn	1

--- a/scripts/ui-audit.sh
+++ b/scripts/ui-audit.sh
@@ -11,9 +11,18 @@
 # correct for a plain song list, wrong for a grouped menu); the ratchet allowlists the legit dialog /
 # data-list ListItems that legitimately remain in menu files, so only NEW ones fail.
 #
-# NOT mechanically checked here (enforced by code review, see standards.md): the reuse rules
-# (section 1), the settings grouped-list component (Material3SettingsGroup), and the .focusable()
-# D-pad requirement on any new row component — reuse/structure judgments, not greppable patterns.
+# Componentization / reuse (standards.md section 1) is PARTLY checked: the two highest-frequency
+# shared widgets are ratcheted here — the top-bar back button (R14, BackNavigationIcon / BackTopAppBar)
+# and the row 3-dot overflow menu (R15, MoreVertMenuButton). A screen that re-rolls either from a raw
+# drawable fails once the baseline is set. Both are broad drawable matches, so the genuinely-different
+# sites (a state-branching nav icon that flips to `close` in selection mode; a non-nav glyph) are
+# baselined and only NEW hand-rolls fail — record a legit new one with --update.
+#
+# NOT mechanically checked here (enforced by code review, see standards.md): the rest of the reuse
+# rules (section 1) — TopAppBarActionButton, PlaylistPlayShuffleButtons, the shimmer placeholders,
+# ArtistBrowseComponents — plus the settings grouped-list component (Material3SettingsGroup) and the
+# .focusable() D-pad requirement on any new row component — reuse/structure judgments, not greppable
+# without heavy false positives.
 #
 #   bash scripts/ui-audit.sh            # check; exit 1 if a file gained violations
 #   bash scripts/ui-audit.sh --update   # rewrite the baseline to the current state
@@ -33,6 +42,13 @@
 #   R12-blur       raw `Modifier.blur(` under ui/ -> player blur must go through the effective
 #                  background (PlayerBackgroundStyle.effective(), no-op below API 31; see
 #                  ui/player/PlayerBackground.kt and standards.md section 8). Ratcheted.
+#   R14-backbtn    raw `R.drawable.arrow_back` in a screen -> use the shared BackNavigationIcon /
+#                  BackTopAppBar (component/IconButton.kt, component/BackTopAppBar.kt) instead of
+#                  re-rolling the top-bar back button. Ratcheted (state-branching nav icons that
+#                  legitimately can't use the shared component are baselined).
+#   R15-morevert   raw `R.drawable.more_vert` in a screen -> use the shared MoreVertMenuButton
+#                  (component/IconButton.kt) instead of a hand-rolled 3-dot overflow button.
+#                  Ratcheted.
 #
 # Genuine fixed-value exceptions (AMOLED pure-black, the lyric-image *export*, color-picker
 # swatches) are allowed: they live in the baseline. Keep them minimal; --update records them.
@@ -68,6 +84,17 @@ violations() {
   # per-surface `Icon.Download(` re-implements the unified badge. Baselined at zero.
   grep -rnE "downloadUtil\.downloads|\.getDownload\(|Icon\.Download\(" "$UI" --include=*.kt 2>/dev/null \
     | grep -v "/theme/" | sed -E 's/:.*//' | sed 's/$/\tR13-download/'
+  # R14: hand-rolled top-bar back button. The shared BackNavigationIcon / BackTopAppBar own the
+  # arrow_back nav icon; a raw R.drawable.arrow_back in a screen re-rolls it. Exclude the two files
+  # that DEFINE / wrap the shared component. Ratcheted (state-branching close/back icons baselined).
+  grep -rnE "R\.drawable\.arrow_back" "$UI" --include=*.kt 2>/dev/null \
+    | grep -v "/theme/" | grep -v "component/IconButton.kt" | grep -v "component/BackTopAppBar.kt" \
+    | sed -E 's/:.*//' | sed 's/$/\tR14-backbtn/'
+  # R15: hand-rolled 3-dot overflow menu. Use MoreVertMenuButton (component/IconButton.kt) rather
+  # than a raw R.drawable.more_vert IconButton. Exclude the defining file. Ratcheted.
+  grep -rnE "R\.drawable\.more_vert" "$UI" --include=*.kt 2>/dev/null \
+    | grep -v "/theme/" | grep -v "component/IconButton.kt" \
+    | sed -E 's/:.*//' | sed 's/$/\tR15-morevert/'
 }
 
 # Aggregate to "<path>\t<rule>\t<count>", sorted.
@@ -102,14 +129,16 @@ improved="$(awk -F'\t' '
 ' <(printf "%s\n" "$cur") "$BASELINE")"
 
 if [ -n "$new" ]; then
-  echo "UI audit FAILED — new Rule 5/7/8/11/12/13 violations (docs/ui/standards.md sections 5, 7-8, 11, 13):"
+  echo "UI audit FAILED — new Rule 5/7/8/11/12/13/14/15 violations (docs/ui/standards.md sections 1, 5, 7-8, 11, 13):"
   echo "$new"
   echo
   echo "Route font sizes through MaterialTheme.typography (Type.kt), colors through"
   echo "MaterialTheme.colorScheme, dialogs through the Dialog.kt helpers (DefaultDialog etc.),"
   echo "user-facing text through stringResource() with metrolist_strings.xml, grouped action"
-  echo "menus through Material3MenuGroup / Material3MenuItemData (not raw ListItem rows), and"
-  echo "player blur through PlayerBackgroundStyle.effective() (ui/player/PlayerBackground.kt)."
+  echo "menus through Material3MenuGroup / Material3MenuItemData (not raw ListItem rows),"
+  echo "player blur through PlayerBackgroundStyle.effective() (ui/player/PlayerBackground.kt),"
+  echo "the top-bar back button through BackNavigationIcon / BackTopAppBar, and the row 3-dot"
+  echo "overflow through MoreVertMenuButton (both in ui/component/)."
   echo "If a fixed value or a genuine dialog/data-list ListItem is required, keep it minimal and"
   echo "record it with:"
   echo "  bash scripts/ui-audit.sh --update"
@@ -117,7 +146,7 @@ if [ -n "$new" ]; then
 fi
 
 total="$(violations | grep -c .)"
-echo "UI audit passed — no new Rule 5/7/8/11/12/13 violations (baseline: $total known, only allowed to shrink)."
+echo "UI audit passed — no new Rule 5/7/8/11/12/13/14/15 violations (baseline: $total known, only allowed to shrink)."
 if [ -n "$improved" ]; then
   echo "Burned down since the baseline — tighten it with \`bash scripts/ui-audit.sh --update\`:"
   echo "$improved"


### PR DESCRIPTION
An app-wide top-bar consistency pass, driven from shared single sources so screens can't drift again. Net -164 lines across 70 files; no behavior change beyond the unified look.

## 1. Componentization (import, don't re-roll)
- ~24 hand-rolled back buttons -> the shared `BackNavigationIcon` / `BackTopAppBar`.
- ~20 hand-rolled 3-dot overflow buttons -> `MoreVertMenuButton`.
- The top-bar action icons (history / search / now-playing / refresh) -> a new shared `TopAppBarActionButton` (dropping the heavy `surfaceContainerHigh` chips for plain icons, matching the reference look).
- Removed the ~56 now-dead `Icon` / `painterResource` / `IconButton` imports the swaps left behind.

## 2. Bold titles
- New shared `AppBarTitle` (titleLarge + Bold + single-line + ellipsis), matching the Home bar.
- Every screen top bar (all settings screens, album / artist / playlist / genre / history / charts / stats / account / login / Zemer playlists+stations / see-all / latest+new releases / recognition) plus Home now render their title through it. Selection-mode counts and dynamic collection names are converted too; search-mode TextFields and dialog titles are deliberately left alone.

## 3. Unified top-bar color (no grey-on-scroll)
- Root cause: the default Material3 `scrolledContainerColor` is a light grey that isn't AMOLED-aware, so screens that pass a `scrollBehavior` greyed-out on scroll while others stayed black.
- New shared `zemerTopAppBarColors()` (container == scrolledContainer; pure black under the AMOLED theme, `surfaceContainer` otherwise), baked into `BackTopAppBar` and applied to every screen top bar - including ArtistScreen once scrolled past its transparent header.

## 4. Guardrails
- `scripts/ui-audit.sh` gains ratcheted rules `R14-backbtn` and `R15-morevert`: a new hand-rolled back button or 3-dot menu fails CI. Baseline burned down 83 -> 30 known (the remainder are the intentional exceptions below plus the pre-existing AMOLED / lyric-image / color-picker cases).
- `docs/ui/standards.md` and `AGENTS.md` document the componentize-on-touch rule and the new shared components.

## Intentional exceptions (left as-is)
- Selection-mode back buttons that flip `<-` to `x`; the custom-tinted/sized `Queue` overflow; the full-bleed login / onboarding bars; the video player's fixed-black bar.

## Testing
`:app:assembleDebug` + `:app:testDebugUnitTest` + `scripts/ui-audit.sh` all pass on HEAD. Diff parity spot-checked on the higher-risk sites (onClick/menu lambdas verbatim, no lost focus modifiers/tint). Release build left to CI.
