### PR TITLE
fix(menu): View-artist crash, content-filter bypass, and ungated writes

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/MenuDialogs.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/MenuDialogs.kt
@@ -51,7 +51,12 @@ fun SelectArtistDialog(
     onArtistClick: (artistId: String) -> Unit,
 ) {
     ListDialog(onDismiss = onDismiss) {
-        items(artists, key = { it.id }) { artist ->
+        // Drop blank ids and de-dupe: a LazyColumn hard-crashes on a duplicate or blank-collision key,
+        // and a blank id would navigate to a dead "artist/" route. (An item's artists can share/omit ids.)
+        items(
+            artists.filter { it.id.isNotBlank() }.distinctBy { it.id },
+            key = { it.id },
+        ) { artist ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
@@ -45,6 +45,7 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Album
 import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
@@ -120,10 +121,14 @@ fun AlbumMenu(
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
         onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album.album.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
+            // Remote playlist-to-playlist copy is a personal-account write; never issue it under the
+            // shared anonymous (pooled) account. The local add still happens via the dialog.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    playlist.playlist.browseId?.let { playlistId ->
+                        album.album.playlistId?.let { addPlaylistId ->
+                            YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
@@ -332,11 +332,15 @@ fun AlbumMenu(
                             icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.view_artist)) },
                             onClick = {
-                                if (album.artists.size == 1) {
-                                    navController.navigate("artist/${album.artists[0].id}")
-                                    onDismiss()
-                                } else {
-                                    showSelectArtistDialog = true
+                                // Only artists with a real id are navigable (a null/blank id would
+                                // navigate to a dead "artist/" route).
+                                val valid = album.artists.filter { !it.id.isNullOrBlank() }
+                                when {
+                                    valid.size == 1 -> {
+                                        navController.navigate("artist/${valid[0].id}")
+                                        onDismiss()
+                                    }
+                                    valid.size > 1 -> showSelectArtistDialog = true
                                 }
                             },
                         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -285,17 +285,21 @@ fun PlayerMenu(
                             icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.view_artist)) },
                             onClick = {
-                                if (mediaMetadata.artists.size == 1) {
-                                    navController.navigate("artist/${mediaMetadata.artists[0].id}")
-                                    playerBottomSheetState.collapseSoft()
-                                    onDismiss()
-                                } else {
-                                    showSelectArtistDialog = true
+                                // Only artists with a real id are navigable (a null/blank id would
+                                // navigate to a dead "artist/" route).
+                                val valid = mediaMetadata.artists.filter { !it.id.isNullOrBlank() }
+                                when {
+                                    valid.size == 1 -> {
+                                        navController.navigate("artist/${valid[0].id}")
+                                        playerBottomSheetState.collapseSoft()
+                                        onDismiss()
+                                    }
+                                    valid.size > 1 -> showSelectArtistDialog = true
                                 }
                             },
                         )
                     )
-                    mediaMetadata.album?.let { album ->
+                    mediaMetadata.album?.takeIf { !it.id.isNullOrBlank() }?.let { album ->
                         add(
                             Material3MenuItemData(
                                 icon = { Icon(painterResource(R.drawable.album), null, Modifier.size(24.dp)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -492,16 +492,20 @@ fun SongMenu(
                             icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.view_artist)) },
                             onClick = {
-                                if (song.artists.size == 1) {
-                                    navController.navigate("artist/${song.artists[0].id}")
-                                    onDismiss()
-                                } else {
-                                    showSelectArtistDialog = true
+                                // Only artists with a real id are navigable (a null/blank id would
+                                // navigate to a dead "artist/" route and crash / dead-end).
+                                val valid = song.artists.filter { !it.id.isNullOrBlank() }
+                                when {
+                                    valid.size == 1 -> {
+                                        navController.navigate("artist/${valid[0].id}")
+                                        onDismiss()
+                                    }
+                                    valid.size > 1 -> showSelectArtistDialog = true
                                 }
                             },
                         )
                     )
-                    if (song.song.albumId != null) add(
+                    if (!song.song.albumId.isNullOrBlank()) add(
                         Material3MenuItemData(
                             icon = { Icon(painterResource(R.drawable.album), null, Modifier.size(24.dp)) },
                             title = { Text(stringResource(R.string.view_album)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -332,7 +332,10 @@ fun YouTubeAlbumMenu(
                         onRetry = { songs.forEach { downloadUtil.retryMediaStoreDownload(it.id) } },
                         onRemove = { coroutineScope.launch { songs.forEach { downloadUtil.removeDownload(it.id) } } },
                     )?.let { add(it) }
-                    albumItem.artists?.let { artists ->
+                    // Only artists with a real id are navigable — a Zemer search album's artist has a
+                    // null id (channel ids aren't sent there), which would navigate to a dead
+                    // "artist/null". Filter first so "View artist" is hidden when nothing can open.
+                    albumItem.artists?.filter { !it.id.isNullOrBlank() }?.takeIf { it.isNotEmpty() }?.let { artists ->
                         add(
                             Material3MenuItemData(
                                 icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -39,6 +39,7 @@ import com.jtech.zemer.LocalDownloadUtil
 import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
@@ -111,10 +112,14 @@ fun YouTubeAlbumMenu(
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
         onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album?.album?.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
+            // Remote playlist-to-playlist copy is a personal-account write; never issue it under the
+            // shared anonymous (pooled) account. The local add still happens via the dialog.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    playlist.playlist.browseId?.let { playlistId ->
+                        album?.album?.playlistId?.let { addPlaylistId ->
+                            YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubePlaylistMenu.kt
@@ -44,8 +44,11 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.constants.ListThumbnailSize
 import com.jtech.zemer.constants.ThumbnailCornerRadius
+import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.PlaylistEntity
 import com.jtech.zemer.db.entities.PlaylistSongMap
+import com.jtech.zemer.extensions.isPersonalAccountSignedIn
+import com.jtech.zemer.utils.filterWhitelisted
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.models.toMediaMetadata
@@ -104,18 +107,24 @@ fun YouTubePlaylistMenu(
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
         onGetSong = { targetPlaylist ->
+            // Add THIS playlist's songs (filtered) to the chosen target — the fallback used
+            // targetPlaylist.id (the destination) by mistake; the source is `playlist`.
             val allSongs = songs
                 .ifEmpty {
-                    YouTube.playlist(targetPlaylist.id).completed().getOrNull()?.songs.orEmpty()
+                    fetchWhitelistedPlaylistSongs(playlist.id, database)
                 }.map {
                     it.toMediaMetadata()
                 }
             database.transaction {
                 allSongs.forEach(::insert)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                targetPlaylist.playlist.browseId?.let { playlistId ->
-                    YouTube.addPlaylistToPlaylist(playlistId, targetPlaylist.id)
+            // Remote playlist-to-playlist copy is a personal-account write; never issue it under the
+            // shared anonymous (pooled) account.
+            if (isPersonalAccountSignedIn) {
+                coroutineScope.launch(Dispatchers.IO) {
+                    targetPlaylist.playlist.browseId?.let { targetBrowseId ->
+                        YouTube.addPlaylistToPlaylist(targetBrowseId, playlist.id)
+                    }
                 }
             }
             allSongs.map { it.id }
@@ -146,8 +155,7 @@ fun YouTubePlaylistMenu(
                                 insert(playlistEntity)
                                 coroutineScope.launch(Dispatchers.IO) {
                                     songs.ifEmpty {
-                                        YouTube.playlist(playlist.id).completed()
-                                            .getOrNull()?.songs.orEmpty()
+                                        fetchWhitelistedPlaylistSongs(playlist.id, database)
                                     }.map { it.toMediaMetadata() }
                                         .onEach(::insert)
                                         .mapIndexed { index, song ->
@@ -186,7 +194,7 @@ fun YouTubePlaylistMenu(
     // songs) — fetch them so the Download row appears and downloads the whole playlist.
     val resolvedSongs by produceState(initialValue = songs, songs, playlist.id) {
         value = if (songs.isNotEmpty()) songs
-        else YouTube.playlist(playlist.id).getOrNull()?.songs.orEmpty()
+        else fetchWhitelistedPlaylistSongs(playlist.id, database)
     }
     val dbSongs by produceState(
         initialValue = emptyList<com.jtech.zemer.db.entities.Song>(),
@@ -240,7 +248,7 @@ fun YouTubePlaylistMenu(
         onGetSong = {
             val allSongs = songs
                 .ifEmpty {
-                    YouTube.playlist(playlist.id).completed().getOrNull()?.songs.orEmpty()
+                    fetchWhitelistedPlaylistSongs(playlist.id, database)
                 }.map {
                     it.toMediaMetadata()
                 }
@@ -372,12 +380,7 @@ fun YouTubePlaylistMenu(
                                     songs
                                         .ifEmpty {
                                             withContext(Dispatchers.IO) {
-                                                YouTube
-                                                    .playlist(playlist.id)
-                                                    .completed()
-                                                    .getOrNull()
-                                                    ?.songs
-                                                    .orEmpty()
+                                                fetchWhitelistedPlaylistSongs(playlist.id, database)
                                             }
                                         }.let { songs ->
                                             playerConnection.playNext(songs.map { it.copy(thumbnail = it.thumbnail.resize(544,544)).toMediaItem() })
@@ -396,12 +399,7 @@ fun YouTubePlaylistMenu(
                                     songs
                                         .ifEmpty {
                                             withContext(Dispatchers.IO) {
-                                                YouTube
-                                                    .playlist(playlist.id)
-                                                    .completed()
-                                                    .getOrNull()
-                                                    ?.songs
-                                                    .orEmpty()
+                                                fetchWhitelistedPlaylistSongs(playlist.id, database)
                                             }
                                         }.let { songs ->
                                             playerConnection.addToQueue(songs.map { it.toMediaItem() })
@@ -481,3 +479,17 @@ fun YouTubePlaylistMenu(
         }
     }
 }
+
+/**
+ * Fetches a playlist's full tracklist from InnerTube and runs it through the artist whitelist, so a
+ * menu action on an already-whitelisted playlist can NEVER pull unfiltered tracks into a local
+ * playlist, the queue, or a download. The passed-in `songs` come from surfaces that already filter,
+ * so only this empty-fallback fetch is raw and needs the gate — a whitelisted context stays
+ * whitelisted no matter which button is pressed.
+ */
+private suspend fun fetchWhitelistedPlaylistSongs(
+    playlistId: String,
+    database: MusicDatabase,
+): List<SongItem> =
+    YouTube.playlist(playlistId).completed().getOrNull()?.songs.orEmpty()
+        .filterWhitelisted(database).filterIsInstance<SongItem>()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -435,17 +435,21 @@ fun YouTubeSongMenu(
                                 icon = { Icon(painterResource(R.drawable.artist), null, Modifier.size(24.dp)) },
                                 title = { Text(stringResource(R.string.view_artist)) },
                                 onClick = {
-                                    if (artists.size == 1) {
-                                        navController.navigate("artist/${artists[0].id}")
-                                        onDismiss()
-                                    } else {
-                                        showSelectArtistDialog = true
+                                    // Only artists with a real id are navigable (a null/blank id would
+                                    // navigate to a dead "artist/" route).
+                                    val valid = artists.filter { !it.id.isNullOrBlank() }
+                                    when {
+                                        valid.size == 1 -> {
+                                            navController.navigate("artist/${valid[0].id}")
+                                            onDismiss()
+                                        }
+                                        valid.size > 1 -> showSelectArtistDialog = true
                                     }
                                 },
                             )
                         )
                     }
-                    song.album?.let { album ->
+                    song.album?.takeIf { !it.id.isNullOrBlank() }?.let { album ->
                         add(
                             Material3MenuItemData(
                                 icon = { Icon(painterResource(R.drawable.album), null, Modifier.size(24.dp)) },


### PR DESCRIPTION
Menu correctness fixes: a crash, a content-filter bypass, and ungated remote writes.

## 1. Crash: "View artist" from the search 3-dot menu

Navigating to `artist/${id}` with an **empty-string** id produces the route `"artist/"`, which matches no destination -> `IllegalArgumentException` -> crash. Search items can carry an empty (or null) artist channel id. Only `YouTubeSongMenu` filtered null ids; the album/song/player menus navigated with whatever id was present, and `SelectArtistDialog` keyed a `LazyColumn` on the raw ids (a blank or duplicate key is itself a hard crash).

- Every **View artist** now filters to artists with a non-blank id: 1 -> navigate, >1 -> picker, 0 -> nothing (no dead route). Applied in `YouTubeSongMenu`, `YouTubeAlbumMenu`, `SongMenu`, `AlbumMenu`, `PlayerMenu`.
- Every **View album** is gated on a non-blank album id.
- `SelectArtistDialog` drops blank ids and de-dupes before keying the list.
- `ArtistScreen` already renders "artist not available" for an unresolved id, so a real-but-unknown artist is unaffected.

## 2. Content-filter bypass (the whitelist guarantee)

`YouTubePlaylistMenu` reached from already-whitelisted surfaces (search, Home, artist, see-all) with `songs` omitted re-fetched the raw tracklist from InnerTube and fed it to Add-to-playlist / Play-next / Add-to-queue / Download / Save **with no `filterWhitelisted` pass** - so a whitelisted playlist could pull unfiltered tracks. Playback (`YouTubeQueue`, the Play action) already filters, so these paths were inconsistent with it.

- All five empty-fallback fetches now go through one `fetchWhitelistedPlaylistSongs()` that applies `filterWhitelisted(database)`. The whitelist is always on, so this only removes tracks a whitelisted context must never surface.
- Fixed a latent bug: the add-to-playlist fallback fetched the destination playlist's own songs (`targetPlaylist.id`) instead of the source (`playlist.id`).

## 3. Ungated remote writes

`YouTube.addPlaylistToPlaylist` (a personal-account remote copy) is now gated on `isPersonalAccountSignedIn` in `YouTubePlaylistMenu`, `AlbumMenu`, `YouTubeAlbumMenu`, matching every other write site. Anonymous (pooled) sessions no longer issue it; the local add is unchanged.

## Testing
`:app:assembleDebug` + `:app:testDebugUnitTest` pass. No behavior change for the personal-account path beyond the now-correct source playlist and the guarded ids.

## Not included (separate decisions)
- Album long-press menu still loads its tracklist via the removed InnerTube `YouTube.album()` + retired radio - real, but the fix wires the Zemer corpus repository into the menu (dedicated change).
- "Video search results treated as audio" is by-design (search folds videos into the song list), so it needs a product decision, not a blind fix.
