### PR TITLE
fix(menu): load the album long-press menu from the Zemer corpus, not InnerTube

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -41,10 +41,13 @@ import com.jtech.zemer.R
 import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.extensions.isPersonalAccountSignedIn
 import com.jtech.zemer.extensions.toMediaItem
+import com.jtech.zemer.di.ZemerSearchRepositoryEntryPoint
 import com.jtech.zemer.playback.DownloadMenuLogic
 import com.jtech.zemer.playback.DownloadStateResolver
-import com.jtech.zemer.playback.queues.YouTubeAlbumRadio
+import com.jtech.zemer.playback.queues.LocalAlbumRadio
+import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.ui.component.AlreadyInPlaylistDialog
+import dagger.hilt.android.EntryPointAccessors
 import com.jtech.zemer.ui.component.ArtistChoice
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
@@ -76,19 +79,23 @@ fun YouTubeAlbumMenu(
     val playerConnection = LocalPlayerConnection.current ?: return
     val album by database.albumWithSongs(albumItem.id).collectAsState(initial = null)
     val coroutineScope = rememberCoroutineScope()
+    // Corpus-native: resolve the album (browseId + playlistId) from the Zemer server, mirroring
+    // AlbumViewModel. No InnerTube YouTube.album() - a non-corpus album is non-whitelisted and its
+    // tracks would bypass the filter; a failed corpus load just leaves the actions empty rather than
+    // silently no-op-ing on a bot-gated InnerTube call.
+    val zemerRepository = remember(context) {
+        EntryPointAccessors
+            .fromApplication(context.applicationContext, ZemerSearchRepositoryEntryPoint::class.java)
+            .zemerSearchRepository()
+    }
 
     LaunchedEffect(Unit) {
-        database.album(albumItem.id).collect { album ->
-            if (album == null) {
-                YouTube
-                    .album(albumItem.id)
-                    .onSuccess { albumPage ->
-                        database.transaction {
-                            insert(albumPage)
-                        }
-                    }.onFailure {
-                        reportException(it)
-                    }
+        database.album(albumItem.id).collect { dbAlbum ->
+            if (dbAlbum == null) {
+                val options = zemerSearchOptions(context)
+                runCatching { zemerRepository.album(albumItem.id, albumItem.playlistId, options) }
+                    .onSuccess { page -> page?.let { database.transaction { insert(it) } } }
+                    .onFailure { reportException(it) }
             }
         }
     }
@@ -211,10 +218,11 @@ fun YouTubeAlbumMenu(
                         text = stringResource(R.string.play),
                         onClick = {
                             onDismiss()
-                            album?.songs?.let { songs ->
-                                if (songs.isNotEmpty()) {
-                                    playerConnection.playQueue(YouTubeAlbumRadio(albumItem.playlistId, database))
-                                }
+                            // Corpus-native: play the album's whitelisted tracks, then continue on the
+                            // Zemer /radio?kind=album fill (LocalAlbumRadio) - not the retired
+                            // YouTube.next()-based YouTubeAlbumRadio.
+                            album?.takeIf { it.songs.isNotEmpty() }?.let { aws ->
+                                playerConnection.playQueue(LocalAlbumRadio(aws, context = context))
                             }
                         }
                     ),
@@ -230,10 +238,10 @@ fun YouTubeAlbumMenu(
                         text = stringResource(R.string.shuffle),
                         onClick = {
                             onDismiss()
-                            album?.songs?.let { songs ->
-                                if (songs.isNotEmpty()) {
-                                    playerConnection.playQueue(YouTubeAlbumRadio(albumItem.playlistId, database))
-                                }
+                            album?.takeIf { it.songs.isNotEmpty() }?.let { aws ->
+                                playerConnection.playQueue(
+                                    LocalAlbumRadio(aws.copy(songs = aws.songs.shuffled()), context = context),
+                                )
                             }
                         }
                     ),
@@ -320,8 +328,9 @@ fun YouTubeAlbumMenu(
                             coroutineScope.launch(Dispatchers.IO) {
                                 var toDownload = database.albumWithSongs(albumItem.id).first()?.songs.orEmpty()
                                 if (toDownload.isEmpty()) {
-                                    YouTube.album(albumItem.id)
-                                        .onSuccess { page -> database.transaction { insert(page) } }
+                                    val options = zemerSearchOptions(context)
+                                    runCatching { zemerRepository.album(albumItem.id, albumItem.playlistId, options) }
+                                        .onSuccess { page -> page?.let { database.transaction { insert(it) } } }
                                         .onFailure { reportException(it) }
                                     toDownload = database.albumWithSongs(albumItem.id).first()?.songs.orEmpty()
                                 }


### PR DESCRIPTION
The album long-press menu (`YouTubeAlbumMenu`) was the last app surface still reaching InnerTube for content.

## The bug

- It populated the local DB by calling `YouTube.album(albumItem.id)` (the InnerTube path the rest of the app removed). If that call was bot-gated/failed, `album?.songs` stayed empty and **every** action - Play, Shuffle, Play next, Add to queue, Download - silently no-op'd.
- Play / Shuffle used `YouTubeAlbumRadio`, a retired `YouTube.next()`-based queue.
- Neither ran through the whitelist that `AlbumScreen`/`AlbumViewModel` already enforce, so a bot-gated/non-corpus album could surface unfiltered tracks.

## The fix (mirror AlbumViewModel / AlbumScreen)

- Resolve the album from the Zemer server: `zemerRepository.album(browseId, playlistId, zemerSearchOptions(context))` -> `insert(page)`, for both the initial populate (`LaunchedEffect`) and the Download fetch-if-empty fallback. No InnerTube album fetch. A non-corpus album loads nothing (it is non-whitelisted - the deliberate no-fallback design the album screen already uses).
- Play / Shuffle -> `LocalAlbumRadio(albumWithSongs[, shuffled])` (the album's whitelisted tracks, then the `/radio?kind=album` fill), exactly as `AlbumScreen`.
- The repository is resolved from the application context via `ZemerSearchRepositoryEntryPoint`, the same entry point `LocalAlbumRadio`/`ZemerRadioQueue` use.

## Testing

`:app:assembleDebug` + `:app:testDebugUnitTest` + `scripts/ui-audit.sh` pass. Control flow of the DB-populate `LaunchedEffect` is unchanged (fetch only when the row is absent); only the source (corpus vs InnerTube) and the radio queue changed. The one remaining `YouTube.` call is the gated `addPlaylistToPlaylist` personal-account write.
