### PR TITLE
refactor(nav): null-safe artist/album route helpers; fix banned printStackTrace

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt
@@ -3,6 +3,7 @@ package com.jtech.zemer.sync
 import com.jtech.zemer.auth.AuthState
 import com.jtech.zemer.auth.UserAuthManager
 import com.jtech.zemer.utils.ContentFilterConfig
+import com.jtech.zemer.utils.reportException
 import com.jtech.zemer.utils.ContentFilterState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -86,7 +87,7 @@ class ContentFilterSyncService @Inject constructor(
                     }
                 } catch (e: Exception) {
                     Log.d("ZemerSync", "Auto-restore exception: ${e.message}")
-                    e.printStackTrace()
+                    reportException(e)
                 }
             } else {
                 Log.d("ZemerSync", "User already signed in locally - no auto-restore")

--- a/app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jtech.zemer.auth.UserAuthManager
+import com.jtech.zemer.utils.reportException
 import com.jtech.zemer.sync.models.DevicePreferencesEntity
 import com.jtech.zemer.sync.models.DeviceContentFilters
 import com.jtech.zemer.sync.models.DeviceMetadata
@@ -213,7 +214,7 @@ class UserPreferencesRepository @Inject constructor(
             val errorClassification = classifyFirebaseError(e)
             Log.e("ZemerSync", "Auto-restore fetch failed: $errorClassification")
             Log.e("ZemerSync", "Original error: ${e.message}")
-            e.printStackTrace()
+            reportException(e)
             Result.failure(e)
         }
     }
@@ -301,7 +302,7 @@ class UserPreferencesRepository @Inject constructor(
             val errorClassification = classifyFirebaseError(e)
             Log.e("ZemerSync", "Upload failed: $errorClassification")
             Log.e("ZemerSync", "Original error: ${e.message}")
-            e.printStackTrace()
+            reportException(e)
             Result.failure(e)
         }
     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
@@ -30,6 +30,8 @@ import com.jtech.zemer.ui.menu.PlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.utils.ARTIST_AVATAR_PX
 import com.jtech.zemer.ui.utils.resize
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.WatchEndpoint
 import kotlinx.coroutines.CoroutineScope
@@ -76,7 +78,7 @@ fun LibraryArtistListItem(
         .fillMaxWidth()
 
         .clickable {
-            navController.navigate("artist/${artist.id}")
+            navController.navigateToArtist(artist.id)
         }
 )
 
@@ -125,7 +127,7 @@ fun WhitelistedArtistListItem(
         .fillMaxWidth()
 
         .clickable {
-            navController.navigate("artist/${artist.id}")
+            navController.navigateToArtist(artist.id)
         }
 )
 
@@ -145,7 +147,7 @@ fun LibraryArtistGridItem(
 
         .combinedClickable(
             onClick = {
-                navController.navigate("artist/${artist.id}")
+                navController.navigateToArtist(artist.id)
             },
             onLongClick = {
                 menuState.show {
@@ -193,7 +195,7 @@ fun WhitelistedArtistGridItem(
 
         .combinedClickable(
             onClick = {
-                navController.navigate("artist/${artist.id}")
+                navController.navigateToArtist(artist.id)
             },
             onLongClick = {
                 menuState.show {
@@ -235,7 +237,7 @@ fun LibraryAlbumListItem(
     modifier = modifier
         .fillMaxWidth()
         .clickable {
-            navController.navigate("album/${album.id}")
+            navController.navigateToAlbum(album.id)
         }
 )
 
@@ -259,7 +261,7 @@ fun LibraryAlbumGridItem(
         .fillMaxWidth()
         .combinedClickable(
             onClick = {
-                navController.navigate("album/${album.id}")
+                navController.navigateToAlbum(album.id)
             },
             onLongClick = {
                 menuState.show {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/AlbumMenu.kt
@@ -59,6 +59,7 @@ import com.jtech.zemer.ui.component.Material3MenuItemData
 import com.jtech.zemer.ui.component.NewAction
 import com.jtech.zemer.ui.component.NewActionGrid
 import com.jtech.zemer.ui.component.SongListItem
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -152,7 +153,7 @@ fun AlbumMenu(
             artists = album.artists.distinctBy { it.id }.map { ArtistChoice(it.id, it.name, it.thumbnailUrl) },
             onDismiss = { showSelectArtistDialog = false },
             onArtistClick = { artistId ->
-                navController.navigate("artist/$artistId")
+                navController.navigateToArtist(artistId)
                 onDismiss()
             },
         )
@@ -337,7 +338,7 @@ fun AlbumMenu(
                                 val valid = album.artists.filter { !it.id.isNullOrBlank() }
                                 when {
                                     valid.size == 1 -> {
-                                        navController.navigate("artist/${valid[0].id}")
+                                        navController.navigateToArtist(valid[0].id)
                                         onDismiss()
                                     }
                                     valid.size > 1 -> showSelectArtistDialog = true

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/PlayerMenu.kt
@@ -64,6 +64,8 @@ import com.jtech.zemer.ui.component.NewAction
 import com.jtech.zemer.ui.component.NewActionGrid
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.rememberPreference
 import com.metrolist.innertube.YouTube
 import kotlinx.coroutines.Dispatchers
@@ -140,7 +142,7 @@ fun PlayerMenu(
             artists = artists.map { ArtistChoice(it.id!!, it.name) },
             onDismiss = { showSelectArtistDialog = false },
             onArtistClick = { artistId ->
-                navController.navigate("artist/$artistId")
+                navController.navigateToArtist(artistId)
                 showSelectArtistDialog = false
                 playerBottomSheetState.collapseSoft()
                 onDismiss()
@@ -290,7 +292,7 @@ fun PlayerMenu(
                                 val valid = mediaMetadata.artists.filter { !it.id.isNullOrBlank() }
                                 when {
                                     valid.size == 1 -> {
-                                        navController.navigate("artist/${valid[0].id}")
+                                        navController.navigateToArtist(valid[0].id)
                                         playerBottomSheetState.collapseSoft()
                                         onDismiss()
                                     }
@@ -305,7 +307,7 @@ fun PlayerMenu(
                                 icon = { Icon(painterResource(R.drawable.album), null, Modifier.size(24.dp)) },
                                 title = { Text(stringResource(R.string.view_album)) },
                                 onClick = {
-                                    navController.navigate("album/${album.id}")
+                                    navController.navigateToAlbum(album.id)
                                     playerBottomSheetState.collapseSoft()
                                     onDismiss()
                                 },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/SongMenu.kt
@@ -72,6 +72,8 @@ import com.jtech.zemer.ui.component.SelectArtistDialog
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.TextFieldDialog
 import com.jtech.zemer.ui.utils.ShowMediaInfo
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.PermissionHelper
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.CachePlaylistViewModel
@@ -252,7 +254,7 @@ fun SongMenu(
             artists = song.artists.distinctBy { it.id }.map { ArtistChoice(it.id, it.name, it.thumbnailUrl) },
             onDismiss = { showSelectArtistDialog = false },
             onArtistClick = { artistId ->
-                navController.navigate("artist/$artistId")
+                navController.navigateToArtist(artistId)
                 onDismiss()
             },
         )
@@ -497,7 +499,7 @@ fun SongMenu(
                                 val valid = song.artists.filter { !it.id.isNullOrBlank() }
                                 when {
                                     valid.size == 1 -> {
-                                        navController.navigate("artist/${valid[0].id}")
+                                        navController.navigateToArtist(valid[0].id)
                                         onDismiss()
                                     }
                                     valid.size > 1 -> showSelectArtistDialog = true
@@ -511,7 +513,7 @@ fun SongMenu(
                             title = { Text(stringResource(R.string.view_album)) },
                             onClick = {
                                 onDismiss()
-                                navController.navigate("album/${song.song.albumId}")
+                                navController.navigateToAlbum(song.song.albumId)
                             },
                         )
                     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeAlbumMenu.kt
@@ -56,6 +56,7 @@ import com.jtech.zemer.ui.component.NewActionGrid
 import com.jtech.zemer.ui.component.SelectArtistDialog
 import com.jtech.zemer.ui.component.SongListItem
 import com.jtech.zemer.ui.component.YouTubeListItem
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.utils.reportException
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
@@ -153,7 +154,7 @@ fun YouTubeAlbumMenu(
                 .map { ArtistChoice(id = it.id, name = it.name, thumbnailUrl = it.thumbnailUrl) },
             onDismiss = { showSelectArtistDialog = false },
             onArtistClick = { artistId ->
-                navController.navigate("artist/$artistId")
+                navController.navigateToArtist(artistId)
                 onDismiss()
             },
         )
@@ -350,7 +351,7 @@ fun YouTubeAlbumMenu(
                                 title = { Text(stringResource(R.string.view_artist)) },
                                 onClick = {
                                     if (artists.size == 1) {
-                                        navController.navigate("artist/${artists[0].id}")
+                                        navController.navigateToArtist(artists[0].id)
                                         onDismiss()
                                     } else {
                                         showSelectArtistDialog = true

--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeSongMenu.kt
@@ -69,6 +69,8 @@ import com.jtech.zemer.ui.component.NewActionGrid
 import com.jtech.zemer.ui.component.SelectArtistDialog
 import com.jtech.zemer.ui.utils.ShowMediaInfo
 import com.jtech.zemer.ui.utils.resize
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.joinByBullet
 import com.jtech.zemer.utils.makeTimeString
 import com.jtech.zemer.utils.rememberPreference
@@ -153,7 +155,7 @@ fun YouTubeSongMenu(
             artists = artists.map { ArtistChoice(id = it.id!!, name = it.name) },
             onDismiss = { showSelectArtistDialog = false },
             onArtistClick = { artistId ->
-                navController.navigate("artist/$artistId")
+                navController.navigateToArtist(artistId)
                 onDismiss()
             },
         )
@@ -440,7 +442,7 @@ fun YouTubeSongMenu(
                                     val valid = artists.filter { !it.id.isNullOrBlank() }
                                     when {
                                         valid.size == 1 -> {
-                                            navController.navigate("artist/${valid[0].id}")
+                                            navController.navigateToArtist(valid[0].id)
                                             onDismiss()
                                         }
                                         valid.size > 1 -> showSelectArtistDialog = true
@@ -455,7 +457,7 @@ fun YouTubeSongMenu(
                                 icon = { Icon(painterResource(R.drawable.album), null, Modifier.size(24.dp)) },
                                 title = { Text(stringResource(R.string.view_album)) },
                                 onClick = {
-                                    navController.navigate("album/${album.id}")
+                                    navController.navigateToAlbum(album.id)
                                     onDismiss()
                                 },
                             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -135,6 +135,8 @@ import com.jtech.zemer.ui.menu.PlayerMenu
 import com.jtech.zemer.ui.screens.settings.DarkMode
 import com.jtech.zemer.ui.theme.PlayerSliderColors
 import com.jtech.zemer.ui.utils.ShowMediaInfo
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.makeTimeString
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
@@ -571,7 +573,7 @@ fun BottomSheetPlayer(
                                         interactionSource = remember { MutableInteractionSource() },
                                         onClick = {
                                             if (mediaMetadata.album != null) {
-                                                navController.navigate("album/${mediaMetadata.album.id}")
+                                                navController.navigateToAlbum(mediaMetadata.album.id)
                                                 state.collapseSoft()
                                             }
                                         },
@@ -653,7 +655,7 @@ fun BottomSheetPlayer(
                                                     ?.let { ann ->
                                                         val artistId = ann.item
                                                         if (artistId.isNotBlank()) {
-                                                            navController.navigate("artist/$artistId")
+                                                            navController.navigateToArtist(artistId)
                                                             state.collapseSoft()
                                                         }
                                                     }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AccountScreen.kt
@@ -36,6 +36,8 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.viewmodels.AccountViewModel
 import com.jtech.zemer.viewmodels.AccountContentType
 
@@ -120,7 +122,7 @@ fun AccountScreen(
                         modifier = Modifier
                             .combinedClickable(
                                 onClick = {
-                                    navController.navigate("album/${item.id}")
+                                    navController.navigateToAlbum(item.id)
                                 },
                                 onLongClick = {
                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -156,7 +158,7 @@ fun AccountScreen(
                         modifier = Modifier
                             .combinedClickable(
                                 onClick = {
-                                    navController.navigate("artist/${item.id}")
+                                    navController.navigateToArtist(item.id)
                                 },
                                 onLongClick = {
                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/AlbumScreen.kt
@@ -96,6 +96,7 @@ import com.jtech.zemer.ui.screens.playlist.PlaylistPlayShuffleButtons
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.AlbumViewModel
 import kotlinx.coroutines.launch
@@ -249,7 +250,7 @@ fun AlbumScreen(
                                     ) {
                                         albumWithSongs.artists.fastForEachIndexed { index, artist ->
                                             val link = LinkAnnotation.Clickable(artist.id) {
-                                                navController.navigate("artist/${artist.id}")
+                                                navController.navigateToArtist(artist.id)
                                             }
                                             withLink(link) {
                                                 append(artist.name)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -94,6 +94,8 @@ import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.latestreleases.LatestReleaseCard
 import com.jtech.zemer.viewmodels.HomeViewModel
@@ -295,7 +297,7 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            navController.navigate("album/${it.id}")
+                            navController.navigateToAlbum(it.id)
                         },
                         onLongClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -316,7 +318,7 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            navController.navigate("artist/${it.id}")
+                            navController.navigateToArtist(it.id)
                         },
                         onLongClick = {
                             haptic.performHapticFeedback(
@@ -358,9 +360,9 @@ fun HomeScreen(
                                 if (featuredAlbumsAreZemer) {
                                     navController.navigate(zemerAlbumRoute(item))
                                 } else {
-                                    navController.navigate("album/${item.id}")
+                                    navController.navigateToAlbum(item.id)
                                 }
-                            is ArtistItem -> navController.navigate("artist/${item.id}")
+                            is ArtistItem -> navController.navigateToArtist(item.id)
                             // Featured playlists: Zemer community playlists open via the server /playlist path
                             // and tag plays `community:<id>` (they're the discovery-sourced community row).
                             is PlaylistItem ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -56,6 +56,8 @@ import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.viewmodels.HomeSeeAllStore
 
@@ -161,8 +163,8 @@ internal fun <T : YTItem> YtItemGrid(
                             // Featured albums are Zemer-sourced: open via the server route (bot-gate-proof).
                             is AlbumItem ->
                                 if (zemerAlbums) navController.navigate(zemerAlbumRoute(item))
-                                else navController.navigate("album/${item.id}")
-                            is ArtistItem -> navController.navigate("artist/${item.id}")
+                                else navController.navigateToAlbum(item.id)
+                            is ArtistItem -> navController.navigateToArtist(item.id)
                             // Community playlists are Zemer-sourced: open via the server /playlist route and
                             // tag plays `community:<id>` (the discovery-sourced community row).
                             is PlaylistItem ->
@@ -266,7 +268,7 @@ private fun LocalItemList(items: List<LocalItem>, navController: NavController) 
                     isActive = item.id == mediaMetadata?.album?.id,
                     isPlaying = isPlaying,
                     modifier = Modifier.combinedClickable(
-                        onClick = { navController.navigate("album/${item.id}") },
+                        onClick = { navController.navigateToAlbum(item.id) },
                         onLongClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                             menuState.show { AlbumMenu(originalAlbum = item, navController = navController, onDismiss = menuState::dismiss) }
@@ -276,7 +278,7 @@ private fun LocalItemList(items: List<LocalItem>, navController: NavController) 
                 is Artist -> ArtistListItem(
                     artist = item,
                     modifier = Modifier.combinedClickable(
-                        onClick = { navController.navigate("artist/${item.id}") },
+                        onClick = { navController.navigateToArtist(item.id) },
                         onLongClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                             menuState.show { ArtistMenu(originalArtist = item, coroutineScope = scope, onDismiss = menuState::dismiss) }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/NewReleaseScreen.kt
@@ -42,6 +42,7 @@ import com.jtech.zemer.ui.component.shimmer.GridItemPlaceHolder
 import com.jtech.zemer.ui.component.shimmer.ShimmerHost
 import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.viewmodels.NewReleaseViewModel
 import com.metrolist.innertube.models.WatchEndpoint
 
@@ -209,7 +210,7 @@ fun NewReleaseScreen(
                                         .padding(horizontal = 8.dp)
                                         .combinedClickable(
                                             onClick = {
-                                                navController.navigate("album/${album.id}")
+                                                navController.navigateToAlbum(album.id)
                                             },
                                             onLongClick = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/StatsScreen.kt
@@ -50,6 +50,8 @@ import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.joinByBullet
 import com.jtech.zemer.utils.makeTimeString
 import com.jtech.zemer.viewmodels.StatsViewModel
@@ -308,7 +310,7 @@ fun StatsScreen(
                             Modifier
                                 .combinedClickable(
                                     onClick = {
-                                        navController.navigate("artist/${artist.id}")
+                                        navController.navigateToArtist(artist.id)
                                     },
                                     onLongClick = {
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -360,7 +362,7 @@ fun StatsScreen(
                                     .fillMaxWidth()
                                     .combinedClickable(
                                         onClick = {
-                                            navController.navigate("album/${album.id}")
+                                            navController.navigateToAlbum(album.id)
                                         },
                                         onLongClick = {
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
@@ -54,6 +54,8 @@ import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.viewmodels.ArtistItemsViewModel
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -188,8 +190,8 @@ fun ArtistItemsScreen(
                                         }
                                     }
 
-                                    is AlbumItem -> navController.navigate("album/${item.id}")
-                                    is ArtistItem -> navController.navigate("artist/${item.id}")
+                                    is AlbumItem -> navController.navigateToAlbum(item.id)
+                                    is ArtistItem -> navController.navigateToArtist(item.id)
                                     is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
                                 }
                             }
@@ -246,8 +248,8 @@ fun ArtistItemsScreen(
                                             )
                                         }
 
-                                        is AlbumItem -> navController.navigate("album/${item.id}")
-                                        is ArtistItem -> navController.navigate("artist/${item.id}")
+                                        is AlbumItem -> navController.navigateToAlbum(item.id)
+                                        is ArtistItem -> navController.navigateToArtist(item.id)
                                         is PlaylistItem -> navController.navigate("online_playlist/${item.id}")
                                     }
                                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -124,6 +124,8 @@ import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
 import com.jtech.zemer.ui.utils.fadingEdge
 import com.jtech.zemer.ui.utils.resize
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.ArtistViewModel
 import com.metrolist.innertube.models.AlbumItem
@@ -594,7 +596,7 @@ fun ArtistScreen(
                                         modifier = Modifier
                                             .combinedClickable(
                                                 onClick = {
-                                                    navController.navigate("album/${album.id}")
+                                                    navController.navigateToAlbum(album.id)
                                                 },
                                                 onLongClick = {
                                                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -764,7 +766,7 @@ fun ArtistScreen(
                                                                 // The artist page is corpus-sourced, so its albums/
                                                                 // playlists open via the server route (fast, bot-gate-proof).
                                                                 is AlbumItem -> navController.navigate(zemerAlbumRoute(item))
-                                                                is ArtistItem -> navController.navigate("artist/${item.id}")
+                                                                is ArtistItem -> navController.navigateToArtist(item.id)
                                                                 is PlaylistItem -> navController.navigate(zemerPlaylistRoute(item.id))
                                                             }
                                                         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt
@@ -88,6 +88,8 @@ import com.jtech.zemer.ui.component.SortHeader
 import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.PlaylistMenu
+import com.jtech.zemer.ui.utils.navigateToArtist
+import com.jtech.zemer.ui.utils.navigateToAlbum
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.LibraryAutoPlaylistViewModel
@@ -512,7 +514,7 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .combinedClickable(
                                             onClick = {
-                                                navController.navigate("artist/${item.id}")
+                                                navController.navigateToArtist(item.id)
                                             },
                                             onLongClick = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -552,7 +554,7 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .combinedClickable(
                                             onClick = {
-                                                navController.navigate("album/${item.id}")
+                                                navController.navigateToAlbum(item.id)
                                             },
                                             onLongClick = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -728,7 +730,7 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .combinedClickable(
                                             onClick = {
-                                                navController.navigate("artist/${item.id}")
+                                                navController.navigateToArtist(item.id)
                                             },
                                             onLongClick = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -757,7 +759,7 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .combinedClickable(
                                             onClick = {
-                                                navController.navigate("album/${item.id}")
+                                                navController.navigateToAlbum(item.id)
                                             },
                                             onLongClick = {
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -106,6 +106,7 @@ import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.ItemWrapper
 import com.jtech.zemer.ui.utils.backToMain
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.OnlinePlaylistViewModel
 import com.metrolist.innertube.models.SongItem
@@ -277,7 +278,7 @@ fun OnlinePlaylistScreen(
                                                         if (artist.id != null) {
                                                             val link =
                                                                 LinkAnnotation.Clickable(artist.id!!) {
-                                                                    navController.navigate("artist/${artist.id!!}")
+                                                                    navController.navigateToArtist(artist.id)
                                                                 }
                                                             withLink(link) {
                                                                 append(artist.name)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -54,6 +54,7 @@ import com.jtech.zemer.search.zemerAlbumRoute
 import com.jtech.zemer.search.zemerPlaylistRoute
 import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.ui.component.AppStateView
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.LocalMenuState
@@ -167,7 +168,7 @@ fun OnlineSearchResult(
                 }
 
                 is AlbumItem -> navController.navigate(zemerAlbumRoute(item))
-                is ArtistItem -> navController.navigate("artist/${item.id}")
+                is ArtistItem -> navController.navigateToArtist(item.id)
                 // A discovery-sourced community playlist tags its plays `community:<id>` (same source as the
                 // home Community row); featured/artist-owned stay `playlist:`. Community-ness covers the
                 // Community chip AND the Zemer summary preview, not just the chip — see [playlistIsCommunity].

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -72,6 +72,7 @@ import com.jtech.zemer.models.toMediaMetadata
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.ui.screens.Screens
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.ui.component.SearchBarIconOffsetX
@@ -299,7 +300,7 @@ fun OnlineSearchScreen(
                                     onDismiss()
                                 }
                                 is ArtistItem -> {
-                                    navController.navigate("artist/${item.id}")
+                                    navController.navigateToArtist(item.id)
                                     onDismiss()
                                 }
                                 is PlaylistItem -> {
@@ -373,7 +374,7 @@ fun OnlineSearchScreen(
                                     onDismiss()
                                 }
                                 is ArtistItem -> {
-                                    navController.navigate("artist/${item.id}")
+                                    navController.navigateToArtist(item.id)
                                     onDismiss()
                                 }
                                 is PlaylistItem -> {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/AppNavigation.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/AppNavigation.kt
@@ -1,0 +1,31 @@
+package com.jtech.zemer.ui.utils
+
+import androidx.navigation.NavController
+
+/**
+ * Null-safe navigation to the id-bearing detail routes.
+ *
+ * Building these routes by hand from an item's id (`navController.navigate("artist/$id")`) is the
+ * crash we keep hitting: a null or blank id produces the route `"artist/"` (or `"album/"`), which
+ * matches no registered destination and throws `IllegalArgumentException`. Item ids reach the UI
+ * nullable/blank in several places (corpus artists with no channel id, etc.), so instead of guarding
+ * at every call site, route every navigation through these helpers — a blank id yields a null route
+ * and the navigation is skipped, so the whole class is handled once. Prefer these over a hand-built
+ * `navigate("artist/$id")`.
+ *
+ * The route strings are built by the pure [artistRoute] / [albumRoute] so the blank-id guard is
+ * unit-tested without an Android runtime (see AppNavigationTest).
+ */
+fun artistRoute(artistId: String?): String? =
+    artistId?.takeIf { it.isNotBlank() }?.let { "artist/$it" }
+
+fun albumRoute(albumId: String?): String? =
+    albumId?.takeIf { it.isNotBlank() }?.let { "album/$it" }
+
+fun NavController.navigateToArtist(artistId: String?) {
+    artistRoute(artistId)?.let(::navigate)
+}
+
+fun NavController.navigateToAlbum(albumId: String?) {
+    albumRoute(albumId)?.let(::navigate)
+}

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt
@@ -41,7 +41,7 @@ object UrlValidator {
                 urlWithScheme.toHttpUrl()
             } catch (e: Exception) {
                 // If OkHttp fails to parse, return null
-                e.printStackTrace()
+                reportException(e)
                 return null
             }
 
@@ -54,7 +54,7 @@ object UrlValidator {
                 null
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            reportException(e)
             null
         }
     }

--- a/app/src/test/kotlin/com/jtech/zemer/ui/utils/AppNavigationTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/utils/AppNavigationTest.kt
@@ -1,0 +1,39 @@
+package com.jtech.zemer.ui.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The blank-id guard that prevents the "artist/" / "album/" crash: a real id builds the route, a
+ * null/blank/whitespace id yields null (navigation is then skipped instead of navigating to a dead
+ * route). A valid id must build the exact same string the call sites used to interpolate by hand,
+ * so the swap is behavior-identical for real ids.
+ */
+class AppNavigationTest {
+    @Test
+    fun artistRoute_realId_buildsRoute() {
+        assertEquals("artist/UC123", artistRoute("UC123"))
+        assertEquals("artist/UCabc_DEF-45", artistRoute("UCabc_DEF-45"))
+    }
+
+    @Test
+    fun artistRoute_nullOrBlank_isNull() {
+        assertNull(artistRoute(null))
+        assertNull(artistRoute(""))
+        assertNull(artistRoute("   "))
+        assertNull(artistRoute("\t"))
+    }
+
+    @Test
+    fun albumRoute_realId_buildsRoute() {
+        assertEquals("album/MPREb_abc", albumRoute("MPREb_abc"))
+    }
+
+    @Test
+    fun albumRoute_nullOrBlank_isNull() {
+        assertNull(albumRoute(null))
+        assertNull(albumRoute(""))
+        assertNull(albumRoute("  "))
+    }
+}

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -35,6 +35,12 @@ particular), so `scripts/ui-audit.sh` ratchets the known gaps down without block
   `scrolledContainerColor` is not AMOLED-aware). `BackTopAppBar` bakes both in. The only exceptions are
   the full-bleed login/onboarding bars, the video player's fixed-black bar, and ArtistScreen's
   over-header transparent state. Do not hand-roll a title `Text` or omit `colors` on a new screen bar.
+- **Never hand-build an id-bearing nav route.** `navController.navigate("artist/$id")` /
+  `navigate("album/$id")` crashes when the id is blank (an empty id builds `"artist/"`, which matches
+  no destination and throws — this was a real bug). Use the null-safe `navigateToArtist(id)` /
+  `navigateToAlbum(id)` in `ui/utils/AppNavigation.kt` — a blank id is a no-op, and the pure
+  `artistRoute`/`albumRoute` builders are unit-tested. Enforced by `R16-navroute` (baseline 0). Zemer
+  routes with query params keep their builders (`zemerAlbumRoute`, `zemerPlaylistRoute`, `ZemerRoutes.kt`).
 - Enforcement (ratcheting): `scripts/ui-audit.sh` rules `R14-backbtn` and `R15-morevert` fail CI on
   any *new* raw `R.drawable.arrow_back` / `R.drawable.more_vert` in a screen — build the back button
   and the overflow menu from the shared components instead. The existing hand-rolls are baselined in

--- a/scripts/ui-audit.sh
+++ b/scripts/ui-audit.sh
@@ -49,6 +49,9 @@
 #   R15-morevert   raw `R.drawable.more_vert` in a screen -> use the shared MoreVertMenuButton
 #                  (component/IconButton.kt) instead of a hand-rolled 3-dot overflow button.
 #                  Ratcheted.
+#   R16-navroute   hand-built single-segment id route `navigate("artist/$id")` / `navigate("album/$id")`
+#                  -> use the null-safe navigateToArtist/navigateToAlbum helpers
+#                  (ui/utils/AppNavigation.kt); a blank id would otherwise crash on "artist/". Baseline 0.
 #
 # Genuine fixed-value exceptions (AMOLED pure-black, the lyric-image *export*, color-picker
 # swatches) are allowed: they live in the baseline. Keep them minimal; --update records them.
@@ -95,6 +98,13 @@ violations() {
   grep -rnE "R\.drawable\.more_vert" "$UI" --include=*.kt 2>/dev/null \
     | grep -v "/theme/" | grep -v "component/IconButton.kt" \
     | sed -E 's/:.*//' | sed 's/$/\tR15-morevert/'
+  # R16: hand-built single-segment id nav route. navigate("artist/$id") / navigate("album/$id") built
+  # from a possibly-blank id is a crash (empty id -> "artist/" matches no destination -> throws).
+  # Route through the null-safe navigateToArtist/navigateToAlbum helpers (ui/utils/AppNavigation.kt).
+  # The regex matches ONLY the plain single-segment form (no `/sub` route, no `?query`), so the
+  # legit `artist/{id}/songs` and zemerAlbumRoute() sites are not flagged. Baselined at zero.
+  grep -rnE 'navigate\("(artist|album)/\$[^"/]*"\)' "$UI" --include=*.kt 2>/dev/null \
+    | grep -v "/theme/" | grep -v "utils/AppNavigation.kt" | sed -E 's/:.*//' | sed 's/$/\tR16-navroute/'
 }
 
 # Aggregate to "<path>\t<rule>\t<count>", sorted.
@@ -129,7 +139,7 @@ improved="$(awk -F'\t' '
 ' <(printf "%s\n" "$cur") "$BASELINE")"
 
 if [ -n "$new" ]; then
-  echo "UI audit FAILED — new Rule 5/7/8/11/12/13/14/15 violations (docs/ui/standards.md sections 1, 5, 7-8, 11, 13):"
+  echo "UI audit FAILED — new Rule 5/7/8/11/12/13/14/15/16 violations (docs/ui/standards.md sections 1, 5, 7-8, 11, 13):"
   echo "$new"
   echo
   echo "Route font sizes through MaterialTheme.typography (Type.kt), colors through"
@@ -146,7 +156,7 @@ if [ -n "$new" ]; then
 fi
 
 total="$(violations | grep -c .)"
-echo "UI audit passed — no new Rule 5/7/8/11/12/13/14/15 violations (baseline: $total known, only allowed to shrink)."
+echo "UI audit passed — no new Rule 5/7/8/11/12/13/14/15/16 violations (baseline: $total known, only allowed to shrink)."
 if [ -n "$improved" ]; then
   echo "Burned down since the baseline — tighten it with \`bash scripts/ui-audit.sh --update\`:"
   echo "$improved"


### PR DESCRIPTION
First of the codebase-cleanup passes (the componentization follow-ons). Two Tier-1 items.

## 1. Null-safe navigation (kills the "artist/" crash class for good)

Hand-built `navController.navigate("artist/$id")` / `navigate("album/$id")` crashes when the id is blank: an empty id builds the route `"artist/"`, which matches no registered destination -> `IllegalArgumentException`. That's the exact class as the View-artist crash we already fixed in the menus (#343) - but there were **97** hand-built route sites app-wide, and the guard lived only in the menus.

- New null-safe helpers in `ui/utils/AppNavigation.kt`: `navigateToArtist(id?)` / `navigateToAlbum(id?)` no-op on a null/blank id. Route strings come from pure `artistRoute` / `albumRoute` builders so the guard is **unit-tested** (`AppNavigationTest`) without an Android runtime.
- Converted all **49** plain single-segment `artist/`/`album/` navigations across 19 files to the helpers (menus, Home, search, library, artist, playlist, player, stats, account). This also removed an `!!` force-unwrap.
- New ratcheted audit rule **`R16-navroute`** (baseline 0) fails CI on any new hand-built plain-id route. Sub-routes (`artist/{id}/songs`) and the query-param Zemer routes (`zemerAlbumRoute`, `ZemerRoutes.kt`) are excluded/kept.
- Documented in `docs/ui/standards.md`.

## 2. Banned `printStackTrace`

Replaced the 5 remaining `e.printStackTrace()` calls (`ContentFilterSyncService`, `UserPreferencesRepository` x2, `UrlValidator` x2) with `reportException()`, per the docs' rule (report via reportException/Timber, never printStackTrace).

## Testing (no regressions)

- `:app:assembleDebug` + `:app:testDebugUnitTest` pass; `AppNavigationTest` covers real-id -> route and null/blank/whitespace -> null.
- `scripts/ui-audit.sh` passes (R16 = 0 after the sweep).
- Diff parity spot-checked: for a real id the helper builds the identical route; a blank id (previously a crash) is now a no-op. Zemer query-param routes untouched.

## Not in this PR (the rest of the cleanup plan)
Row-menu componentization (`rememberRowMenuOpener` + `ytItemMenu`), god-file decomposition (`MusicService`/`MainActivity`), `runBlocking` on UI paths, the repo-resolve helper, and the a11y `contentDescription` pass - each its own focused change.
