### PR TITLE
refactor(menu): extract the shared ytItemMenu dispatcher

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeItemMenu.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/menu/YouTubeItemMenu.kt
@@ -1,0 +1,52 @@
+package com.jtech.zemer.ui.menu
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.YTItem
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * The one YTItem -> YouTube*Menu dispatcher, shared by every discovery surface (search results, the
+ * search dropdown, Home, home see-all, artist pages) that long-presses / 3-dots a mixed list of
+ * [YTItem]s. Returns the menu content to hand to `menuState.show(...)`, collapsing the four-branch
+ * `when (item)` block that was copy-pasted at each site.
+ *
+ * [isVideo] is supplied by the caller from its OWN filter/section context (the "Videos" chip, a
+ * videos row, etc.) and is deliberately NOT re-derived here — every surface keeps exactly the
+ * video-ness it passed before, so this is a pure de-duplication with no behavior change.
+ */
+fun ytItemMenu(
+    item: YTItem,
+    navController: NavController,
+    coroutineScope: CoroutineScope,
+    onDismiss: () -> Unit,
+    isVideo: Boolean = false,
+): @Composable ColumnScope.() -> Unit = {
+    when (item) {
+        is SongItem -> YouTubeSongMenu(
+            song = item,
+            navController = navController,
+            onDismiss = onDismiss,
+            isVideo = isVideo,
+        )
+        is AlbumItem -> YouTubeAlbumMenu(
+            albumItem = item,
+            navController = navController,
+            onDismiss = onDismiss,
+        )
+        is ArtistItem -> YouTubeArtistMenu(
+            artist = item,
+            onDismiss = onDismiss,
+        )
+        is PlaylistItem -> YouTubePlaylistMenu(
+            playlist = item,
+            coroutineScope = coroutineScope,
+            onDismiss = onDismiss,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -91,6 +91,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
@@ -375,32 +376,14 @@ fun HomeScreen(
                     },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        menuState.show {
-                            when (item) {
-                                is SongItem -> YouTubeSongMenu(
-                                    song = item,
-                                    navController = navController,
-                                    onDismiss = menuState::dismiss
-                                )
-
-                                is AlbumItem -> YouTubeAlbumMenu(
-                                    albumItem = item,
-                                    navController = navController,
-                                    onDismiss = menuState::dismiss
-                                )
-
-                                is ArtistItem -> YouTubeArtistMenu(
-                                    artist = item,
-                                    onDismiss = menuState::dismiss
-                                )
-
-                                is PlaylistItem -> YouTubePlaylistMenu(
-                                    playlist = item,
-                                    coroutineScope = scope,
-                                    onDismiss = menuState::dismiss
-                                )
-                            }
-                        }
+                        menuState.show(
+                            ytItemMenu(
+                                item = item,
+                                navController = navController,
+                                coroutineScope = scope,
+                                onDismiss = menuState::dismiss,
+                            )
+                        )
                     }
                 )
         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -55,6 +55,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.ui.utils.navigateToAlbum
@@ -174,16 +175,17 @@ internal fun <T : YTItem> YtItemGrid(
                     },
                     onLongClick = {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        menuState.show {
-                            when (item) {
+                        menuState.show(
+                            ytItemMenu(
+                                item = item,
+                                navController = navController,
+                                coroutineScope = scope,
+                                onDismiss = menuState::dismiss,
                                 // Videos row: isVideo = true so the menu offers "Download video" (video),
                                 // not the audio "Download".
-                                is SongItem -> YouTubeSongMenu(song = item, navController = navController, onDismiss = menuState::dismiss, isVideo = true)
-                                is AlbumItem -> YouTubeAlbumMenu(albumItem = item, navController = navController, onDismiss = menuState::dismiss)
-                                is ArtistItem -> YouTubeArtistMenu(artist = item, onDismiss = menuState::dismiss)
-                                is PlaylistItem -> YouTubePlaylistMenu(playlist = item, coroutineScope = scope, onDismiss = menuState::dismiss)
-                            }
-                        }
+                                isVideo = true,
+                            )
+                        )
                     },
                 ),
             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistItemsScreen.kt
@@ -52,6 +52,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.navigateToArtist
@@ -129,37 +130,15 @@ fun ArtistItemsScreen(
                     trailingContent = {
                         MoreVertMenuButton(
                             onClick = {
-                                menuState.show {
-                                    when (item) {
-                                        is SongItem ->
-                                            YouTubeSongMenu(
-                                                song = item,
-                                                navController = navController,
-                                                onDismiss = menuState::dismiss,
-                                                isVideo = isVideoSection && !blockVideos,
-                                            )
-
-                                        is AlbumItem ->
-                                            YouTubeAlbumMenu(
-                                                albumItem = item,
-                                                navController = navController,
-                                                onDismiss = menuState::dismiss,
-                                            )
-
-                                        is ArtistItem ->
-                                            YouTubeArtistMenu(
-                                                artist = item,
-                                                onDismiss = menuState::dismiss,
-                                            )
-
-                                        is PlaylistItem ->
-                                            YouTubePlaylistMenu(
-                                                playlist = item,
-                                                coroutineScope = coroutineScope,
-                                                onDismiss = menuState::dismiss,
-                                            )
-                                    }
-                                }
+                                menuState.show(
+                                    ytItemMenu(
+                                        item = item,
+                                        navController = navController,
+                                        coroutineScope = coroutineScope,
+                                        onDismiss = menuState::dismiss,
+                                        isVideo = isVideoSection && !blockVideos,
+                                    )
+                                )
                             },
                         )
                     },
@@ -256,33 +235,15 @@ fun ArtistItemsScreen(
                             },
                             onLongClick = {
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                menuState.show {
-                                    when (item) {
-                                        is SongItem -> YouTubeSongMenu(
-                                            song = item,
-                                            navController = navController,
-                                            onDismiss = menuState::dismiss,
-                                            isVideo = isVideoSection && !blockVideos
-                                        )
-
-                                        is AlbumItem -> YouTubeAlbumMenu(
-                                            albumItem = item,
-                                            navController = navController,
-                                            onDismiss = menuState::dismiss
-                                        )
-
-                                        is ArtistItem -> YouTubeArtistMenu(
-                                            artist = item,
-                                            onDismiss = menuState::dismiss
-                                        )
-
-                                        is PlaylistItem -> YouTubePlaylistMenu(
-                                            playlist = item,
-                                            coroutineScope = coroutineScope,
-                                            onDismiss = menuState::dismiss
-                                        )
-                                    }
-                                }
+                                menuState.show(
+                                    ytItemMenu(
+                                        item = item,
+                                        navController = navController,
+                                        coroutineScope = coroutineScope,
+                                        onDismiss = menuState::dismiss,
+                                        isVideo = isVideoSection && !blockVideos,
+                                    )
+                                )
                             }
                         )
                         .animateItem()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/artist/ArtistScreen.kt
@@ -119,6 +119,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.backToMain
@@ -773,37 +774,15 @@ fun ArtistScreen(
                                                     },
                                                     onLongClick = {
                                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                        menuState.show {
-                                                            when (item) {
-                                                                is SongItem ->
-                                                                    YouTubeSongMenu(
-                                                                        song = item,
-                                                                        navController = navController,
-                                                                        onDismiss = menuState::dismiss,
-                                                                        isVideo = isVideoSection,
-                                                                    )
-
-                                                                is AlbumItem ->
-                                                                    YouTubeAlbumMenu(
-                                                                        albumItem = item,
-                                                                        navController = navController,
-                                                                        onDismiss = menuState::dismiss,
-                                                                    )
-
-                                                                is ArtistItem ->
-                                                                    YouTubeArtistMenu(
-                                                                        artist = item,
-                                                                        onDismiss = menuState::dismiss,
-                                                                    )
-
-                                                                is PlaylistItem ->
-                                                                    YouTubePlaylistMenu(
-                                                                        playlist = item,
-                                                                        coroutineScope = coroutineScope,
-                                                                        onDismiss = menuState::dismiss,
-                                                                    )
-                                                            }
-                                                        }
+                                                        menuState.show(
+                                                            ytItemMenu(
+                                                                item = item,
+                                                                navController = navController,
+                                                                coroutineScope = coroutineScope,
+                                                                onDismiss = menuState::dismiss,
+                                                                isVideo = isVideoSection,
+                                                            )
+                                                        )
                                                     },
                                                 )
                                                 .animateItem(),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchResult.kt
@@ -67,6 +67,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.viewmodels.OnlineSearchViewModel
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_ALBUM
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_ARTIST
@@ -182,37 +183,15 @@ fun OnlineSearchResult(
         }
         val longClick = {
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            menuState.show {
-                when (item) {
-                    is SongItem ->
-                        YouTubeSongMenu(
-                            song = item,
-                            navController = navController,
-                            onDismiss = menuState::dismiss,
-                            isVideo = !blockVideos && searchFilter?.value == FILTER_VIDEO.value,
-                        )
-
-                    is AlbumItem ->
-                        YouTubeAlbumMenu(
-                            albumItem = item,
-                            navController = navController,
-                            onDismiss = menuState::dismiss,
-                        )
-
-                    is ArtistItem ->
-                        YouTubeArtistMenu(
-                            artist = item,
-                            onDismiss = menuState::dismiss,
-                        )
-
-                    is PlaylistItem ->
-                        YouTubePlaylistMenu(
-                            playlist = item,
-                            coroutineScope = coroutineScope,
-                            onDismiss = menuState::dismiss,
-                        )
-                }
-            }
+            menuState.show(
+                ytItemMenu(
+                    item = item,
+                    navController = navController,
+                    coroutineScope = coroutineScope,
+                    onDismiss = menuState::dismiss,
+                    isVideo = !blockVideos && searchFilter?.value == FILTER_VIDEO.value,
+                )
+            )
         }
         YouTubeListItem(
             item = item,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/search/OnlineSearchScreen.kt
@@ -81,6 +81,7 @@ import com.jtech.zemer.ui.menu.YouTubeAlbumMenu
 import com.jtech.zemer.ui.menu.YouTubeArtistMenu
 import com.jtech.zemer.ui.menu.YouTubePlaylistMenu
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
+import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.viewmodels.OnlineSearchSuggestionViewModel
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -243,41 +244,17 @@ fun OnlineSearchScreen(
                 trailingContent = {
                     MoreVertMenuButton(
                         onClick = {
-                            menuState.show {
-                                when (item) {
-                                    is SongItem -> YouTubeSongMenu(
-                                        song = item,
-                                        navController = navController,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is AlbumItem -> YouTubeAlbumMenu(
-                                        albumItem = item,
-                                        navController = navController,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is ArtistItem -> YouTubeArtistMenu(
-                                        artist = item,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is PlaylistItem -> YouTubePlaylistMenu(
-                                        playlist = item,
-                                        coroutineScope = scope,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                }
-                            }
+                            menuState.show(
+                                ytItemMenu(
+                                    item = item,
+                                    navController = navController,
+                                    coroutineScope = scope,
+                                    onDismiss = {
+                                        menuState.dismiss()
+                                        onDismiss()
+                                    },
+                                )
+                            )
                         }
                     )
                 },
@@ -311,41 +288,17 @@ fun OnlineSearchScreen(
                         },
                         onLongClick = {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                            menuState.show {
-                                when (item) {
-                                    is SongItem -> YouTubeSongMenu(
-                                        song = item,
-                                        navController = navController,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is AlbumItem -> YouTubeAlbumMenu(
-                                        albumItem = item,
-                                        navController = navController,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is ArtistItem -> YouTubeArtistMenu(
-                                        artist = item,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                    is PlaylistItem -> YouTubePlaylistMenu(
-                                        playlist = item,
-                                        coroutineScope = coroutineScope,
-                                        onDismiss = {
-                                            menuState.dismiss()
-                                            onDismiss()
-                                        }
-                                    )
-                                }
-                            }
+                            menuState.show(
+                                ytItemMenu(
+                                    item = item,
+                                    navController = navController,
+                                    coroutineScope = coroutineScope,
+                                    onDismiss = {
+                                        menuState.dismiss()
+                                        onDismiss()
+                                    },
+                                )
+                            )
                         }
                     )
                     .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface)

--- a/docs/ui/standards.md
+++ b/docs/ui/standards.md
@@ -27,7 +27,9 @@ particular), so `scripts/ui-audit.sh` ratchets the known gaps down without block
   existing one) and repoint every site in the same pass — never leave two hand-rolled copies to
   drift. In particular: the top-bar back button is `BackNavigationIcon` / `BackTopAppBar`, the row
   3-dot overflow is `MoreVertMenuButton`, and a plain `TopAppBar` action icon is
-  `TopAppBarActionButton` — all in `IconButton.kt`.
+  `TopAppBarActionButton` — all in `IconButton.kt`. A discovery row that opens a menu for a mixed
+  list of InnerTube `YTItem`s uses `ytItemMenu(item, …, isVideo)` (`ui/menu/YouTubeItemMenu.kt`) —
+  the one `when (item) -> YouTube*Menu` dispatcher — instead of copy-pasting the four-branch block.
 - **Top bars are uniform via two shared sources** (`ui/component/`): the title goes through
   `AppBarTitle(text)` (bold `titleLarge`, single-line+ellipsis, matching Home) and the colors through
   `colors = zemerTopAppBarColors()` (black under AMOLED / `surfaceContainer` otherwise, with


### PR DESCRIPTION
Tier-2 cleanup (componentization round 2). **Stacked on #347** — review/merge that first; this PR's base is that branch and will retarget to `main` once #347 lands.

## What

The four-branch YTItem menu dispatcher was copy-pasted at **8 discovery surfaces**:

    menuState.show {
        when (item) {
            is SongItem -> YouTubeSongMenu(...)
            is AlbumItem -> YouTubeAlbumMenu(...)
            is ArtistItem -> YouTubeArtistMenu(...)
            is PlaylistItem -> YouTubePlaylistMenu(...)
        }
    }

(search results, search dropdown x2, Home featured grid, home see-all, artist page, artist see-all x2). Extracted to one shared `ytItemMenu(item, navController, coroutineScope, onDismiss, isVideo)` in `ui/menu/YouTubeItemMenu.kt` (returns the `@Composable ColumnScope.() -> Unit` menu content for `menuState.show`).

## No behavior change

`isVideo` is supplied by each caller from its **own** filter/section context and is deliberately NOT re-derived in the helper, so every surface keeps exactly the video-ness it had. Verified by diff that each site's `isVideo` expression carried over verbatim: `!blockVideos && searchFilter?.value == FILTER_VIDEO.value`, `isVideoSection`, `isVideoSection && !blockVideos`, `true`, or omitted (default false). The search dropdown's compound `onDismiss` (`{ menuState.dismiss(); onDismiss() }`) and each site's `coroutineScope` var were carried through too.

## Testing
`:app:assembleDebug` + `:app:testDebugUnitTest` + `scripts/ui-audit.sh` pass. (Caught + fixed one issue mid-way: `menuState.show` needs a `ColumnScope` receiver on the content lambda — the helper's return type was corrected.) Documented in `docs/ui/standards.md §1`.
