### PR TITLE
fix(status): the story ring respects the hide-text/hide-image filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,12 @@ Releases are. Feature package `statuses/`; UI under `ui/screens/statuses/`; full
   next date; only the creator's newest status advances to the next creator; back is floored at the
   entry date (jump-to-date sheet goes earlier). The per-segment ring in `StatusCreatorCircle` colors
   seen vs unseen (accent unseen / `outlineVariant` seen).
+- **The ring respects the content filter.** `StatusCreator.recentPostKinds` carries the kind of each
+  recent status (YidStatus from the feed; JewishStatus via a batched `public_posts?id=in.(...)&select=
+  id,kind` fetch in `fetchStatusCreators`), so `visibleRecentIds(filter)` drops hidden-kind statuses.
+  The ring, `caughtUpOnLatest` and `sortedByUnseenFirst` all key off the VISIBLE ids, and a creator with
+  nothing viewable drops from the row/see-all. Unknown kinds (fetch failed / size mismatch) show all -
+  never hide more than we can prove.
 - **The viewer's no-flash invariants** (`StoryScreen`, all hard-won): creators live in a cube
   `HorizontalPager`; the active face renders only when `postsCreatorIdx == creatorIdx` (else the stale
   previous-creator content flashes on settle); both neighbors are prefetched (posts AND the thumbnail

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt
@@ -42,6 +42,10 @@ data class StatusCreator(
     // YidStatus) — drives the segmented story ring (one segment each) and the WhatsApp "read" state
     // (newest seen => caught up), oldest-first so the newest is the LAST id.
     val recentPostIds: List<String> = emptyList(),
+    // The kind of each recent status, aligned 1:1 with [recentPostIds], so the ring can respect the
+    // hide-text/hide-image content filter. Empty (or a size mismatch) means "unknown" -> show all, so
+    // nothing regresses when kinds could not be resolved.
+    val recentPostKinds: List<String> = emptyList(),
     val source: StatusSource = StatusSource.JEWISH_STATUS,
 )
 
@@ -76,21 +80,37 @@ fun List<StatusPost>.applyStatusFilter(filter: StatusContentFilter): List<Status
     filter { (!filter.hideText || it.kind != "text") && (!filter.hideImage || it.kind != "image") }
 
 /**
- * Whether the user is "caught up" on a creator (WhatsApp read state): their NEWEST status has been
- * viewed. `recent_post_ids` is oldest-first (verified against posted_at), so the newest is the LAST id.
- * Older days left unopened do NOT keep a creator marked unread - a user who watched today's auto-play is
- * caught up even if earlier days are still openable via the jump-to-date sheet. Empty => not caught up.
+ * The recent status ids the user can actually VIEW under their content filter (hide-text/hide-image).
+ * Drives the ring segment count and the read state, so hidden-kind statuses never show as ring segments.
+ * When kinds are unknown (no [recentPostKinds], or a size mismatch), every id is returned - never hides
+ * more than we can prove, so nothing regresses.
  */
-fun StatusCreator.caughtUpOnLatest(seenPostIds: Set<String>): Boolean =
-    recentPostIds.lastOrNull()?.let { it in seenPostIds } ?: false
+fun StatusCreator.visibleRecentIds(filter: StatusContentFilter): List<String> {
+    if (recentPostKinds.size != recentPostIds.size) return recentPostIds
+    return recentPostIds.filterIndexed { i, _ ->
+        val kind = recentPostKinds[i]
+        (!filter.hideText || kind != "text") && (!filter.hideImage || kind != "image")
+    }
+}
+
+/**
+ * Whether the user is "caught up" on a creator (WhatsApp read state): their NEWEST VISIBLE status has
+ * been viewed. `recent_post_ids` is oldest-first (verified against posted_at), so the newest is the LAST
+ * id. Older days left unopened do NOT keep a creator marked unread - a user who watched today's auto-play
+ * is caught up even if earlier days are still openable via the jump-to-date sheet. Empty => not caught up.
+ */
+fun StatusCreator.caughtUpOnLatest(seenPostIds: Set<String>, filter: StatusContentFilter): Boolean =
+    visibleRecentIds(filter).lastOrNull()?.let { it in seenPostIds } ?: false
 
 /**
  * Creators ordered for the Home row AND the See-all grid (one definition so the two can't drift):
- * creators the user is caught up on (newest seen) sink to the end (WhatsApp), preserving recency order
- * within each group.
+ * creators the user is caught up on (newest VISIBLE status seen) sink to the end (WhatsApp), preserving
+ * recency order within each group.
  */
-fun List<StatusCreator>.sortedByUnseenFirst(seenPostIds: Set<String>): List<StatusCreator> =
-    sortedBy { it.caughtUpOnLatest(seenPostIds) }
+fun List<StatusCreator>.sortedByUnseenFirst(
+    seenPostIds: Set<String>,
+    filter: StatusContentFilter,
+): List<StatusCreator> = sortedBy { it.caughtUpOnLatest(seenPostIds, filter) }
 
 /**
  * Merge two platforms' creators, dropping cross-platform DUPLICATES (the same real creator appears on
@@ -137,7 +157,28 @@ suspend fun fetchStatusCreators(): List<StatusCreator> = coroutineScope {
         // empty ring and open to nothing. YidStatus already only keeps creators that have posts.
         .filter { it.recentPostIds.isNotEmpty() }
 
-    base
+    // Resolve the KIND of each recent status (one batched query over all ids) so the ring can respect
+    // the hide-text/hide-image filter. Fail-soft: an unresolved id stays "" (unknown -> shown).
+    val kinds = async(Dispatchers.IO) { fetchPostKinds(base.flatMap { it.recentPostIds }) }.await()
+    base.map { c -> c.copy(recentPostKinds = c.recentPostIds.map { kinds[it].orEmpty() }) }
+}
+
+/** Batch-resolve `id -> kind` for the given post ids (chunked to keep the URL bounded). Fail-soft. */
+private fun fetchPostKinds(ids: List<String>): Map<String, String> {
+    if (ids.isEmpty()) return emptyMap()
+    val out = HashMap<String, String>(ids.size)
+    ids.distinct().chunked(100).forEach { chunk ->
+        // Post ids are Supabase UUIDs (URL-safe), so no encoding is needed for the `in.(...)` list.
+        val url = "$BASE/public_posts?id=in.(${chunk.joinToString(",")})&select=id,kind"
+        runCatching {
+            val arr = JSONArray(getJson(url))
+            for (i in 0 until arr.length()) {
+                val o = arr.getJSONObject(i)
+                out[o.getString("id")] = o.optString("kind")
+            }
+        }
+    }
+    return out
 }
 
 /**

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt
@@ -59,7 +59,7 @@ fun fetchYidStatusFeed(days: Int = YID_FEED_DAYS): YidFeed {
     // Keep only creators that actually have a status in the window; attach their status ids as the ring.
     val creators = musicCreators.mapNotNull { c ->
         val posts = byCreator[c.id]?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-        c.copy(recentPostIds = posts.map { it.id })
+        c.copy(recentPostIds = posts.map { it.id }, recentPostKinds = posts.map { it.kind })
     }
     return YidFeed(creators, byCreator)
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt
@@ -30,8 +30,11 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import androidx.compose.runtime.remember
+import com.jtech.zemer.statuses.StatusContentFilter
 import com.jtech.zemer.statuses.StatusCreator
 import com.jtech.zemer.statuses.statusAvatarUrl
+import com.jtech.zemer.statuses.visibleRecentIds
 import com.jtech.zemer.ui.theme.HeaderFontFamily
 
 /**
@@ -45,12 +48,16 @@ import com.jtech.zemer.ui.theme.HeaderFontFamily
 fun StatusCreatorCircle(
     creator: StatusCreator,
     seenPostIds: Set<String>,
+    contentFilter: StatusContentFilter,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val colorScheme = MaterialTheme.colorScheme
-    val segments = creator.recentPostIds.size.coerceAtLeast(1)
+    // Ring over the statuses the user can actually VIEW under their content filter, so hidden-kind
+    // statuses never show as segments.
+    val visibleIds = remember(creator, contentFilter) { creator.visibleRecentIds(contentFilter) }
+    val segments = visibleIds.size.coerceAtLeast(1)
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -75,7 +82,7 @@ fun StatusCreatorCircle(
                 repeat(segments) { i ->
                     // Per-segment read state: an arc mutes to the subtle outline once ITS status is
                     // seen, so the accent arcs that remain show how many are left to view.
-                    val postId = creator.recentPostIds.getOrNull(i)
+                    val postId = visibleIds.getOrNull(i)
                     val seen = postId != null && postId in seenPostIds
                     drawArc(
                         color = if (seen) colorScheme.outlineVariant else colorScheme.primary,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -95,6 +95,7 @@ import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.menu.ytItemMenu
 import com.jtech.zemer.ui.screens.videoRoute
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
+import com.jtech.zemer.statuses.visibleRecentIds
 import com.jtech.zemer.ui.utils.storyRoute
 import com.jtech.zemer.ui.utils.SnapLayoutInfoProvider
 import com.jtech.zemer.ui.utils.navigateToArtist
@@ -168,6 +169,12 @@ fun HomeScreen(
     val zemerStatusesViewModel: ZemerStatusesViewModel = hiltViewModel()
     val statusCreators by zemerStatusesViewModel.creators.collectAsState()
     val statusSeenPostIds by zemerStatusesViewModel.seenPostIds.collectAsState()
+    val statusContentFilter by zemerStatusesViewModel.contentFilter.collectAsState()
+    // Only creators with a status the user can actually view under their content filter (a fully
+    // hidden creator drops from the row, and its ring never over-counts).
+    val visibleStatusCreators = remember(statusCreators, statusContentFilter) {
+        statusCreators.filter { it.visibleRecentIds(statusContentFilter).isNotEmpty() }
+    }
     // Settings → Appearance owns these toggles (there is deliberately no in-row hide affordance).
     val (showHomeGenres, _) = rememberPreference(ShowHomeGenresKey, defaultValue = true)
     val (showHomeStatuses, _) = rememberPreference(ShowHomeStatusesKey, defaultValue = true)
@@ -575,7 +582,7 @@ fun HomeScreen(
                 // blocked by content filters: statuses are mostly video/media, so the same gate as the
                 // Featured Videos row applies. The tap carries the creator's stable id (storyRoute).
                 if (showHomeStatuses && !blockVideos) {
-                    statusCreators.takeIf { it.isNotEmpty() }?.let { creators ->
+                    visibleStatusCreators.takeIf { it.isNotEmpty() }?.let { creators ->
                         item(key = "statuses_title", contentType = "header") {
                             NavigationTitle(
                                 title = stringResource(R.string.statuses),
@@ -587,6 +594,7 @@ fun HomeScreen(
                             HomeStatusesRow(
                                 creators = creators,
                                 seenPostIds = statusSeenPostIds,
+                                contentFilter = statusContentFilter,
                                 onCreatorClick = { creatorId -> navController.navigate(storyRoute(creatorId)) },
                                 modifier = Modifier.animateItem(),
                             )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.jtech.zemer.statuses.StatusContentFilter
 import com.jtech.zemer.statuses.StatusCreator
 import com.jtech.zemer.statuses.sortedByUnseenFirst
 import com.jtech.zemer.ui.component.StatusCreatorCircle
@@ -28,10 +29,13 @@ import com.jtech.zemer.ui.component.StatusCreatorCircle
 fun HomeStatusesRow(
     creators: List<StatusCreator>,
     seenPostIds: Set<String>,
+    contentFilter: StatusContentFilter,
     onCreatorClick: (creatorId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val ordered = remember(creators, seenPostIds) { creators.sortedByUnseenFirst(seenPostIds) }
+    val ordered = remember(creators, seenPostIds, contentFilter) {
+        creators.sortedByUnseenFirst(seenPostIds, contentFilter)
+    }
     LazyRow(
         contentPadding = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
             .add(WindowInsets(left = 12.dp, right = 12.dp))
@@ -46,6 +50,7 @@ fun HomeStatusesRow(
             StatusCreatorCircle(
                 creator = creator,
                 seenPostIds = seenPostIds,
+                contentFilter = contentFilter,
                 onClick = { onCreatorClick(creator.id) },
             )
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt
@@ -32,7 +32,9 @@ import com.jtech.zemer.LocalPlayerAwareWindowInsets
 import com.jtech.zemer.R
 import com.jtech.zemer.statuses.StatusCreator
 import com.jtech.zemer.statuses.StatusSource
+import com.jtech.zemer.statuses.StatusContentFilter
 import com.jtech.zemer.statuses.sortedByUnseenFirst
+import com.jtech.zemer.statuses.visibleRecentIds
 import com.jtech.zemer.ui.component.AppBarTitle
 import com.jtech.zemer.ui.component.ArtistSearchField
 import com.jtech.zemer.ui.component.BackNavigationIcon
@@ -59,14 +61,15 @@ fun StatusesScreen(
 ) {
     val creators by viewModel.creators.collectAsState()
     val seenPostIds by viewModel.seenPostIds.collectAsState()
+    val contentFilter by viewModel.contentFilter.collectAsState()
     var query by rememberSaveable { mutableStateOf("") }
     val searchFocus = remember { FocusRequester() }
 
-    val jewish = remember(creators, seenPostIds, query) {
-        creators.filterSourceAndQuery(StatusSource.JEWISH_STATUS, query).sortedByUnseenFirst(seenPostIds)
+    val jewish = remember(creators, seenPostIds, query, contentFilter) {
+        creators.filterSourceAndQuery(StatusSource.JEWISH_STATUS, query).visibleUnseenFirst(seenPostIds, contentFilter)
     }
-    val yid = remember(creators, seenPostIds, query) {
-        creators.filterSourceAndQuery(StatusSource.YID_STATUS, query).sortedByUnseenFirst(seenPostIds)
+    val yid = remember(creators, seenPostIds, query, contentFilter) {
+        creators.filterSourceAndQuery(StatusSource.YID_STATUS, query).visibleUnseenFirst(seenPostIds, contentFilter)
     }
 
     LaunchedEffect(Unit) { viewModel.refresh() }
@@ -88,8 +91,8 @@ fun StatusesScreen(
                     modifier = Modifier.padding(top = 8.dp), // sit a bit lower under the app bar
                 )
             }
-            statusSection(R.string.status_source_jewishstatus, jewish, seenPostIds, ::open)
-            statusSection(R.string.status_source_yidstatus, yid, seenPostIds, ::open)
+            statusSection(R.string.status_source_jewishstatus, jewish, seenPostIds, contentFilter, ::open)
+            statusSection(R.string.status_source_yidstatus, yid, seenPostIds, contentFilter, ::open)
         }
     }
 
@@ -112,11 +115,16 @@ fun StatusesScreen(
 private fun List<StatusCreator>.filterSourceAndQuery(source: StatusSource, query: String) =
     filter { it.source == source && (query.isBlank() || it.displayName.contains(query.trim(), ignoreCase = true)) }
 
+// Drop creators with nothing viewable under the filter, then sink caught-up creators to the end.
+private fun List<StatusCreator>.visibleUnseenFirst(seenPostIds: Set<String>, filter: StatusContentFilter) =
+    filter { it.visibleRecentIds(filter).isNotEmpty() }.sortedByUnseenFirst(seenPostIds, filter)
+
 /** One platform section: the shared Home-row section title (only when it has matches) then its circles. */
 private fun androidx.compose.foundation.lazy.grid.LazyGridScope.statusSection(
     titleRes: Int,
     creators: List<StatusCreator>,
     seenPostIds: Set<String>,
+    contentFilter: StatusContentFilter,
     onOpen: (StatusCreator) -> Unit,
 ) {
     if (creators.isEmpty()) return
@@ -128,6 +136,7 @@ private fun androidx.compose.foundation.lazy.grid.LazyGridScope.statusSection(
             StatusCreatorCircle(
                 creator = creator,
                 seenPostIds = seenPostIds,
+                contentFilter = contentFilter,
                 onClick = { onOpen(creator) },
                 modifier = Modifier.padding(vertical = 4.dp),
             )

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt
@@ -1,13 +1,20 @@
 package com.jtech.zemer.viewmodels
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jtech.zemer.constants.HideImageStatusKey
+import com.jtech.zemer.constants.HideTextStatusKey
+import com.jtech.zemer.statuses.StatusContentFilter
 import com.jtech.zemer.statuses.StatusCreator
 import com.jtech.zemer.statuses.StatusesRepository
+import com.jtech.zemer.utils.dataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,6 +27,7 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class ZemerStatusesViewModel @Inject constructor(
+    @ApplicationContext context: Context,
     private val repository: StatusesRepository,
 ) : ViewModel() {
     val creators: StateFlow<List<StatusCreator>> = repository.creators
@@ -28,6 +36,22 @@ class ZemerStatusesViewModel @Inject constructor(
     // viewed and returned from.
     val seenPostIds: StateFlow<Set<String>> =
         repository.seen.stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
+
+    // The hide-text/hide-image content filter (Settings -> Appearance), so the ring only counts statuses
+    // the user can actually view (a fully-hidden creator drops from the row).
+    val contentFilter: StateFlow<StatusContentFilter> =
+        context.dataStore.data
+            .map {
+                StatusContentFilter(
+                    hideText = it[HideTextStatusKey] ?: true,
+                    hideImage = it[HideImageStatusKey] ?: false,
+                )
+            }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.Lazily,
+                StatusContentFilter(hideText = true, hideImage = false),
+            )
 
     /**
      * Refresh the row. [force] (pull-to-refresh) always re-fetches; a plain call (screen open) re-fetches

--- a/app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt
@@ -109,6 +109,8 @@ class StatusesApiTest {
         assertTrue(statusMediaUrl("c1/v.mp4")!!.endsWith("/status-media/c1/v.mp4"))
     }
 
+    private val showAll = StatusContentFilter(hideText = false, hideImage = false)
+
     @Test
     fun `caughtUpOnLatest keys off the newest (last) recent id, not older ones`() {
         // recent_post_ids is oldest-first, so p2 is the newest.
@@ -116,13 +118,33 @@ class StatusesApiTest {
             id = "c1", slug = "s", displayName = "S", avatarPath = null,
             recentPostIds = listOf("p1", "p2"),
         )
-        assertFalse(creator.caughtUpOnLatest(emptySet()))
+        assertFalse(creator.caughtUpOnLatest(emptySet(), showAll))
         // Seeing only the OLDER status does not count as caught up.
-        assertFalse(creator.caughtUpOnLatest(setOf("p1")))
+        assertFalse(creator.caughtUpOnLatest(setOf("p1"), showAll))
         // Seeing the newest (last) status => caught up, even if an older one is still unseen.
-        assertTrue(creator.caughtUpOnLatest(setOf("p2")))
+        assertTrue(creator.caughtUpOnLatest(setOf("p2"), showAll))
         // A creator with no known statuses is never caught up (so it never sinks on an empty ring).
-        assertFalse(creator.copy(recentPostIds = emptyList()).caughtUpOnLatest(setOf("p2")))
+        assertFalse(creator.copy(recentPostIds = emptyList()).caughtUpOnLatest(setOf("p2"), showAll))
+    }
+
+    @Test
+    fun `visibleRecentIds drops hidden kinds, keys off newest visible for caught-up`() {
+        // v(video) t(text) i(image), oldest-first; kinds aligned 1:1.
+        val creator = StatusCreator(
+            id = "c1", slug = "s", displayName = "S", avatarPath = null,
+            recentPostIds = listOf("v", "i", "t"),
+            recentPostKinds = listOf("video", "image", "text"),
+        )
+        // Default filter (hide text): text drops, ring shows v + i.
+        val hideText = StatusContentFilter(hideText = true, hideImage = false)
+        assertEquals(listOf("v", "i"), creator.visibleRecentIds(hideText))
+        // Caught up is now keyed off the newest VISIBLE (i), not the hidden newest (t).
+        assertTrue(creator.caughtUpOnLatest(setOf("i"), hideText))
+        assertFalse(creator.caughtUpOnLatest(setOf("t"), hideText))
+        // Hide both text and image -> only the video remains.
+        assertEquals(listOf("v"), creator.visibleRecentIds(StatusContentFilter(hideText = true, hideImage = true)))
+        // Unknown kinds (no recentPostKinds) -> show everything, never hide more than we can prove.
+        assertEquals(listOf("v", "i", "t"), creator.copy(recentPostKinds = emptyList()).visibleRecentIds(hideText))
     }
 
     @Test
@@ -180,7 +202,7 @@ class StatusesApiTest {
         val a = c("a", "a1", "a2")   // newest a2 unseen -> stays
         val b = c("b", "b1", "b2")   // newest b2 seen   -> sinks
         val d = c("d", "d1", "d2")   // newest d2 unseen -> stays
-        val ordered = listOf(a, b, d).sortedByUnseenFirst(setOf("b2", "a1"))
+        val ordered = listOf(a, b, d).sortedByUnseenFirst(setOf("b2", "a1"), showAll)
         assertEquals(listOf("a", "d", "b"), ordered.map { it.id })
     }
 }

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -166,7 +166,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 | `com.jtech.zemer.search` | no | 1 | 39 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSeenStore.kt` | 31 | `com.jtech.zemer.statuses` | no | 9 | 5 | android.content, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 | `com.jtech.zemer.statuses` | no | 4 | 20 | java.time, java.util |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 247 | `com.jtech.zemer.statuses` | no | 8 | 65 | java.net, kotlinx.coroutines, org.json |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 288 | `com.jtech.zemer.statuses` | no | 8 | 74 | java.net, kotlinx.coroutines, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 139 | `com.jtech.zemer.statuses` | no | 15 | 25 | android.os, java.util, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 153 | `com.jtech.zemer.statuses` | no | 8 | 32 | java.io, java.util, okhttp3.MediaType, okhttp3.OkHttpClient, okhttp3.Request, okhttp3.RequestBody, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 | `com.jtech.zemer.sync` | no | 18 | 42 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
@@ -228,7 +228,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 | `com.jtech.zemer.ui.component` | yes | 79 | 32 | androidx.activity, androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 73 | `com.jtech.zemer.ui.component` | yes | 9 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 | `com.jtech.zemer.ui.component` | yes | 25 | 1 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt` | 122 | `com.jtech.zemer.ui.component` | yes | 33 | 13 | androidx.compose, coil3.compose, coil3.request |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 36 | 14 | androidx.compose, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 20 | 7 | androidx.compose, java.io |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 | `com.jtech.zemer.ui.component` | yes | 8 | 7 | androidx.compose, kotlin.math |
@@ -277,9 +277,9 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt` | 208 | `com.jtech.zemer.ui.screens` | yes | 44 | 6 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 504 | `com.jtech.zemer.ui.screens` | yes | 78 | 30 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 84 | `com.jtech.zemer.ui.screens` | yes | 27 | 5 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1045 | `com.jtech.zemer.ui.screens` | yes | 122 | 74 | android.net, androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1053 | `com.jtech.zemer.ui.screens` | yes | 123 | 76 | android.net, androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 294 | `com.jtech.zemer.ui.screens` | yes | 61 | 25 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 53 | `com.jtech.zemer.ui.screens` | yes | 17 | 2 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 | `com.jtech.zemer.ui.screens` | yes | 18 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 | `com.jtech.zemer.ui.screens` | yes | 43 | 18 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 | `com.jtech.zemer.ui.screens` | yes | 34 | 9 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginCapture.kt` | 39 | `com.jtech.zemer.ui.screens` | no | 0 | 7 |  |
@@ -341,7 +341,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 215 | `com.jtech.zemer.ui.screens.settings` | yes | 48 | 20 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 410 | `com.jtech.zemer.ui.screens.settings` | yes | 66 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 40 | `com.jtech.zemer.ui.screens.settings.integrations` | yes | 17 | 1 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 136 | `com.jtech.zemer.ui.screens.statuses` | yes | 42 | 10 | androidx.compose, androidx.hilt, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 145 | `com.jtech.zemer.ui.screens.statuses` | yes | 44 | 12 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StoryScreen.kt` | 831 | `com.jtech.zemer.ui.screens.statuses` | yes | 97 | 86 | android.view, androidx.activity, androidx.compose, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, java.time, java.util, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/ChartColors.kt` | 30 | `com.jtech.zemer.ui.theme` | yes | 4 | 3 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/LogColors.kt` | 26 | `com.jtech.zemer.ui.theme` | yes | 5 | 2 | android.util, androidx.compose |
@@ -452,7 +452,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenreViewModel.kt` | 168 | `com.jtech.zemer.viewmodels` | no | 21 | 28 | android.content, androidx.lifecycle, coil3.imageLoader, coil3.request, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenresViewModel.kt` | 59 | `com.jtech.zemer.viewmodels` | no | 18 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 13 | 7 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 39 | `com.jtech.zemer.viewmodels` | no | 11 | 5 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 | `com.jtech.zemer.viewmodels` | no | 18 | 6 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 | `com.jtech.zemer.constants` | no | 4 | 3 | androidx.datastore, java.lang, org.junit |
@@ -499,7 +499,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt` | 81 | `com.jtech.zemer.search` | no | 8 | 8 | java.io, java.nio, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt` | 127 | `com.jtech.zemer.search` | no | 5 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 | `com.jtech.zemer.statuses` | no | 5 | 8 | java.time, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 186 | `com.jtech.zemer.statuses` | no | 6 | 25 | org.json, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 | `com.jtech.zemer.statuses` | no | 6 | 28 | org.json, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 78 | `com.jtech.zemer.statuses` | no | 5 | 10 | org.json, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/FlushScheduleTest.kt` | 57 | `com.jtech.zemer.tracking` | no | 2 | 8 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 680 lines | text `.md` |
+| `AGENTS.md` | 686 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 680 lines | `.md` |
+| `AGENTS.md` | 686 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -325,7 +325,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSeenStore.kt` | 31 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 247 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 288 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 139 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 153 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 lines | `.kt` |
@@ -387,7 +387,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SearchBar.kt` | 369 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SelectionTopActions.kt` | 73 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SortHeader.kt` | 108 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt` | 122 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusCreatorCircle.kt` | 129 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 129 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 lines | `.kt` |
@@ -436,9 +436,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/GenresScreen.kt` | 208 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HistoryScreen.kt` | 504 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 84 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1045 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1053 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 294 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 53 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginCapture.kt` | 39 lines | `.kt` |
@@ -500,7 +500,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 215 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 410 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/integrations/IntegrationScreen.kt` | 40 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 136 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 145 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StoryScreen.kt` | 831 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/ChartColors.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/theme/LogColors.kt` | 26 lines | `.kt` |
@@ -611,7 +611,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenreViewModel.kt` | 168 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenresViewModel.kt` | 59 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt` | 47 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 39 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 lines | `.kt` |
 | `app/src/main/res/drawable-night/widget_background.xml` | 6 lines | `.xml` |
@@ -853,7 +853,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchRoutingTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerStationsTest.kt` | 127 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 186 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 78 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/FlushScheduleTest.kt` | 57 lines | `.kt` |


### PR DESCRIPTION
The Music Status creator ring drew one segment per recent status regardless of the content filter, so **hidden-kind statuses still showed as ring segments** (and over-counted "unseen"). Reported on-device: with "hide text-only" on (the default), a creator's ring still counted its text statuses.

## Fix
- `StatusCreator` now carries `recentPostKinds` (aligned 1:1 with `recentPostIds`):
  - **YidStatus**: kinds come straight from the grouped feed.
  - **JewishStatus**: `recent_post_ids` carry no kind, so `fetchStatusCreators` resolves them in one batched `public_posts?id=in.(...)&select=id,kind` query (chunked, fail-soft).
- `visibleRecentIds(filter)` drops hidden-kind statuses; the ring segment count/coloring, `caughtUpOnLatest`, and `sortedByUnseenFirst` all key off the visible ids.
- A creator with **nothing viewable** under the filter drops from the Home row and See-all.
- **Unknown kinds** (fetch failed / size mismatch) show everything, so nothing regresses when kinds can't be resolved.

## Tests
- New `visibleRecentIds` + filter-aware `caughtUpOnLatest` coverage in `StatusesApiTest`; existing sort/caught-up tests updated for the new signatures.
- `assembleDebug` + status JVM tests + ui-audit green. `AGENTS.md` Music Status section updated; docs regenerated.