### PR TITLE
fix(theme): default the dynamic theme OFF

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -530,7 +530,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = true)
+            val enableDynamicTheme by rememberPreference(DynamicThemeKey, defaultValue = false)
             val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
             val isSystemInDarkTheme = isSystemInDarkTheme()
             val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/AppearanceSettings.kt
@@ -147,8 +147,8 @@ fun AppearanceSettings(
         appearanceScrollState.animateScrollTo(target)
     }
     val (dynamicTheme, onDynamicThemeChange) = rememberPreference(
- DynamicThemeKey,
-        defaultValue = true
+        DynamicThemeKey,
+        defaultValue = false
     )
     val (darkMode, onDarkModeChange) = rememberEnumPreference(
         DarkModeKey,


### PR DESCRIPTION
Defaults the **Enable dynamic theme** (Material You) toggle to **off**, so a fresh install uses the app's own theme instead of wallpaper-derived colors. Users can still turn it on in **Settings > Appearance**.

Flips `defaultValue` on both reads of `DynamicThemeKey` — the theme render in `MainActivity` and the Appearance switch — so they stay consistent (an existing user who already set the toggle is unaffected; only the never-touched default changes).