### PR TITLE
feat(status): server-driven Music Status source config (server-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,21 @@ Releases are. Feature package `statuses/`; UI under `ui/screens/statuses/`; full
   header) -> 403. YidStatus is filtered to music categories (no comedy). `mergeStatusCreators` drops
   cross-platform duplicates by a normalized name (`statusNameKey`); the Home row is uniform over the
   merge, the See-all groups by `source`. Creators with empty `recentPostIds` are dropped (no ring).
+- **The source filter is server-driven, SERVER-ONLY** (`statuses/StatusSourcesConfig.kt`, contract
+  `handoff-docs/zemer-status-sources-config-request.md`): which JewishStatus category UUIDs + YidStatus
+  keywords count as "music" sync (version-gated) from `content.zemer.io/status-sources`, so they retune
+  without an APK. Typed descriptors with **one handler per `type`** (`supabase-category` / `keyword-feed`);
+  the two clients take `baseUrl`/`apiKey`/filter as params, but each `type`'s PROTOCOL details (the R2 CDN
+  host, the YidStatus feed path + `Origin` header) stay baked into its handler, never in a descriptor.
+  **There is NO baked-in fallback config** - the mirror is the single source of truth; the app persists the
+  last-good config (reloaded at startup) and is simply hidden until the first successful sync (fail-soft,
+  never wrong content). Fail-soft parse: null ONLY when a valid config can't be obtained (unreachable /
+  `503` / non-JSON / no `providers` array) -> caller keeps its last-good (or stays hidden); a VALID config
+  is honored as-is even when its usable set is empty (all `enabled:false` / unknown-type / empty-filter = an
+  intentional dark, row hidden); unknown `type` / disabled / empty-filter providers are skipped non-fatally.
+  Config synced by `StatusesRepository.syncStatusSources()` (non-blocking, on the refresh path; applies next
+  load), persisted (`StatusSourcesConfigKey`/`StatusSourcesVersionKey`) + reloaded at startup. Adding a
+  provider of an existing type is config-only; a new `type` is the one thing that needs an app change.
 - **Fail-soft + isolated.** `ZemerStatusesViewModel` (Stations pattern): a fetch failure keeps the row
   empty and `HomeScreen` hides it; nothing about Home depends on it. Gated by `ShowHomeStatusesKey`.
   If only one source fails the other still populates the row (progressive `republish`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,8 +414,14 @@ Releases are. Feature package `statuses/`; UI under `ui/screens/statuses/`; full
   `503` / non-JSON / no `providers` array) -> caller keeps its last-good (or stays hidden); a VALID config
   is honored as-is even when its usable set is empty (all `enabled:false` / unknown-type / empty-filter = an
   intentional dark, row hidden); unknown `type` / disabled / empty-filter providers are skipped non-fatally.
-  Config synced by `StatusesRepository.syncStatusSources()` (non-blocking, on the refresh path; applies next
-  load), persisted (`StatusSourcesConfigKey`/`StatusSourcesVersionKey`) + reloaded at startup. Adding a
+  Config synced by `StatusesRepository.syncStatusSources()` on the refresh path - AWAITED only for the
+  first-ever sync (so a fresh install's first load runs with a real config), non-blocking after; throttled
+  to one poll per `STALE_MS` window and QUIET on network failure (no `reportException` - matches the other
+  mirror syncs); the installed version is endpoint-capped (`minOf(body, endpoint)`) so a stale CDN body
+  can't suppress future syncs; family caches are version-stamped so a config change invalidates them
+  immediately; per-provider fail-soft keeps a failed provider's previous creators while siblings refresh;
+  persisted (`StatusSourcesConfigKey`/`StatusSourcesVersionKey`) + reloaded at startup, and
+  `StatusSourcesCache.update()` never rolls back to an older version (restore/sync race safe). Adding a
   provider of an existing type is config-only; a new `type` is the one thing that needs an app change.
 - **Fail-soft + isolated.** `ZemerStatusesViewModel` (Stations pattern): a fetch failure keeps the row
   empty and `HomeScreen` hides it; nothing about Home depends on it. Gated by `ShowHomeStatusesKey`.
@@ -480,8 +486,10 @@ Releases are. Feature package `statuses/`; UI under `ui/screens/statuses/`; full
   `BringIntoViewRequester`), not the top.
 - **Media URLs are source-agnostic** (`statusMediaUrl`/`statusAvatarUrl`): a full `https` path passes
   through unchanged (YidStatus), a relative path gets the R2 prefix (JewishStatus).
-- **Third-party, so NO handoff doc** (these are not Zemer services). API shape, the OkHttp/Origin
-  gotcha, and the feed cost caps are recorded in `docs/status/` instead.
+- **Third-party platforms have no handoff doc** (they are not Zemer services): API shape, the
+  OkHttp/Origin gotcha, and the feed cost caps are recorded in `docs/status/` instead. The ONE Zemer-side
+  piece - the server-driven source config on the content mirror - IS covered by a handoff contract
+  (`handoff-docs/zemer-status-sources-config-request.md`, see the server-driven bullet above).
 
 **Status downloads (save a status to the device gallery).** A save FAB in the story viewer writes the
 current status to the gallery, and a "Status" card in Library -> Downloaded opens a browser of saved

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -167,10 +167,14 @@ class App : Application(), SingletonImageLoader.Factory {
         // Load the persisted Music Status source config so the last-good (server-driven) categories/keywords
         // are live at startup / offline, before the feature's first version-gated sync. There is no baked-in
         // fallback: an unparseable / absent value leaves the feature with no config, so it stays hidden until
-        // the first successful sync.
+        // the first successful sync. The persisted EFFECTIVE version (endpoint-capped at sync time) overrides
+        // the body's, and update() itself never rolls back a concurrently-synced newer config.
         applicationScope.launch(Dispatchers.IO) {
             runCatching {
-                parseStatusSourcesConfig(dataStore.get(StatusSourcesConfigKey, ""))?.let { StatusSourcesCache.update(it) }
+                parseStatusSourcesConfig(dataStore.get(StatusSourcesConfigKey, ""))?.let { parsed ->
+                    val persistedVersion = dataStore.get(StatusSourcesVersionKey, parsed.version)
+                    StatusSourcesCache.update(parsed.copy(version = minOf(parsed.version, persistedVersion)))
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -34,6 +34,8 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.jtech.zemer.utils.ContentFilterConfig
 import com.jtech.zemer.utils.CrashReportingTree
 import com.jtech.zemer.utils.BlockedIdsCache
+import com.jtech.zemer.statuses.StatusSourcesCache
+import com.jtech.zemer.statuses.parseStatusSourcesConfig
 import com.jtech.zemer.utils.ContentFilterState
 import com.jtech.zemer.utils.IsraeliArtistRegistry
 import com.jtech.zemer.utils.LogBufferTree
@@ -159,6 +161,16 @@ class App : Application(), SingletonImageLoader.Factory {
             runCatching {
                 val persisted = BlockedIdsCache.parse(dataStore.get(BlockedContentIdsKey, ""))
                 if (persisted.isNotEmpty()) BlockedIdsCache.updateAll(persisted)
+            }
+        }
+
+        // Load the persisted Music Status source config so the last-good (server-driven) categories/keywords
+        // are live at startup / offline, before the feature's first version-gated sync. There is no baked-in
+        // fallback: an unparseable / absent value leaves the feature with no config, so it stays hidden until
+        // the first successful sync.
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching {
+                parseStatusSourcesConfig(dataStore.get(StatusSourcesConfigKey, ""))?.let { StatusSourcesCache.update(it) }
             }
         }
 

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -77,9 +77,10 @@ val YtmSyncKey = booleanPreferencesKey("ytmSync")
 // Persisted snapshot of the server's blockedContentIds list (newline-joined), loaded at startup so the
 // blocklist is active before the first sync of the session and survives offline launches.
 val BlockedContentIdsKey = stringPreferencesKey("blockedContentIds")
-// Persisted Music Status source config: the raw /status-sources JSON + the last-synced integer version
-// gate. Loaded at startup so the last-good (server-driven) filter config survives restarts / offline,
-// falling back to the baked-in default only when neither a persisted nor a fresh config is usable.
+// Persisted Music Status source config: the raw /status-sources JSON + the last-synced EFFECTIVE integer
+// version (endpoint-capped). Loaded at startup so the last-good (server-driven) filter config survives
+// restarts / offline. There is NO baked-in fallback (server-only design): with neither a persisted nor a
+// fresh config the feature simply stays hidden until the first successful sync.
 val StatusSourcesConfigKey = stringPreferencesKey("statusSourcesConfig")
 val StatusSourcesVersionKey = longPreferencesKey("statusSourcesVersion")
 val CheckForUpdatesKey = booleanPreferencesKey("checkForUpdates")

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -77,6 +77,11 @@ val YtmSyncKey = booleanPreferencesKey("ytmSync")
 // Persisted snapshot of the server's blockedContentIds list (newline-joined), loaded at startup so the
 // blocklist is active before the first sync of the session and survives offline launches.
 val BlockedContentIdsKey = stringPreferencesKey("blockedContentIds")
+// Persisted Music Status source config: the raw /status-sources JSON + the last-synced integer version
+// gate. Loaded at startup so the last-good (server-driven) filter config survives restarts / offline,
+// falling back to the baked-in default only when neither a persisted nor a fresh config is usable.
+val StatusSourcesConfigKey = stringPreferencesKey("statusSourcesConfig")
+val StatusSourcesVersionKey = longPreferencesKey("statusSourcesVersion")
 val CheckForUpdatesKey = booleanPreferencesKey("checkForUpdates")
 val NightlyUpdatesKey = booleanPreferencesKey("nightlyUpdates") // opt-in nightly update channel
 // Last nightly build announced via the startup snackbar, so each nightly is announced only once.

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt
@@ -1,0 +1,148 @@
+package com.jtech.zemer.statuses
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Server-driven config for the Music Status sources: which categories / keywords each third-party
+ * platform is filtered down to. Synced (version-gated) from the PRIVATE content mirror
+ * (`content.zemer.io/status-sources`); the status DATA still comes straight from JewishStatus /
+ * YidStatus - only the *filter* config is centralized so it can change without an APK release.
+ * Contract: `ZemerTeam/handoff-docs/zemer-status-sources-config-request.md`.
+ *
+ * SERVER-ONLY: there is NO baked-in fallback config - the mirror is the single source of truth. The app
+ * caches the last-good config (persisted to DataStore, reloaded at startup) so it survives restarts /
+ * offline. Until a device's first successful sync it has NO config and the feature is simply hidden
+ * (fail-soft) - the same graceful state as the third-party sources being down. Nothing wrong is ever
+ * shown; the worst case is an absent row.
+ *
+ * Fail-soft rules (agreed with the mirror maintainer, and the reason parse returns config-or-null):
+ *  - CANNOT obtain a VALID config (unreachable, 503, non-JSON, `providers` not an array) -> parse returns
+ *    null and the caller KEEPS its last-good config (or stays hidden if it has none). A transient failure
+ *    never blanks a working feature.
+ *  - A VALID config is HONORED as-is, even when its usable set is empty (every provider disabled /
+ *    unknown-type / empty-filter). That is an intentional dark - the row shows nothing.
+ *  - An unknown `type`, a disabled provider, or an enabled provider with an empty filter list is SKIPPED
+ *    non-fatally; the others still load. A new-`type` descriptor can be added to the config before its
+ *    handler ships; old installs ignore it while still running the types they know.
+ *
+ * A descriptor carries only the tunable DATA (baseUrl, apiKey, category ids / keywords, enabled).
+ * Protocol details welded to a handler - the JewishStatus R2 CDN host, the YidStatus feed edge path and
+ * its required `Origin` header - stay baked into the handler for that `type`, never in the config.
+ */
+
+/** The handler family a provider descriptor maps to. Unknown slugs resolve to null (-> skipped). */
+enum class StatusProviderType(val slug: String) {
+    /** JewishStatus shape: Supabase PostgREST, per-category browse, per-creator post fetch. */
+    SUPABASE_CATEGORY("supabase-category"),
+
+    /** YidStatus shape: one global feed for a rolling window, client-side keyword filter. */
+    KEYWORD_FEED("keyword-feed");
+
+    companion object {
+        fun fromSlug(slug: String?): StatusProviderType? = entries.firstOrNull { it.slug == slug }
+    }
+}
+
+/**
+ * One status source. [categoryIds] is used by [StatusProviderType.SUPABASE_CATEGORY] and [musicKeywords]
+ * by [StatusProviderType.KEYWORD_FEED]; [filterList] resolves whichever applies to this provider's type.
+ */
+data class StatusProvider(
+    val id: String,
+    val type: StatusProviderType,
+    val baseUrl: String,
+    val apiKey: String,
+    val categoryIds: List<String> = emptyList(),
+    val musicKeywords: List<String> = emptyList(),
+    val enabled: Boolean = true,
+) {
+    /** The per-type filter list an enabled provider needs (non-empty) to fetch anything. */
+    val filterList: List<String>
+        get() = when (type) {
+            StatusProviderType.SUPABASE_CATEGORY -> categoryIds
+            StatusProviderType.KEYWORD_FEED -> musicKeywords
+        }
+}
+
+/**
+ * A resolved set of status sources. [providers] holds ONLY usable descriptors (enabled, known type,
+ * non-empty filter list); an empty list is a legitimate "all sources darked" state (honored, not fallback).
+ */
+data class StatusSourcesConfig(
+    val version: Long,
+    val providers: List<StatusProvider>,
+) {
+    fun providersOfType(type: StatusProviderType): List<StatusProvider> = providers.filter { it.type == type }
+}
+
+/**
+ * Parse the mirror's `/status-sources` JSON.
+ *
+ * Returns null ONLY when a valid config cannot be obtained - blank, non-JSON, or no `providers` array. The
+ * caller then keeps its last-good config (or stays hidden if it has none); a transient failure never
+ * blanks a working feature.
+ *
+ * Otherwise returns the config, HONORED as-is with its usable providers - even when that set is empty
+ * (every provider disabled / unknown-type / empty-filter), which is an intentional dark (the row shows
+ * nothing). Usable = enabled, known type, and a non-empty per-type filter list; anything else is skipped
+ * non-fatally so the remaining providers still load.
+ */
+fun parseStatusSourcesConfig(text: String?): StatusSourcesConfig? {
+    if (text.isNullOrBlank()) return null
+    return runCatching {
+        val root = JSONObject(text)
+        val arr = root.optJSONArray("providers") ?: return null // no valid config -> keep last-good
+        val version = root.optLong("version", 0L)
+
+        val usable = (0 until arr.length()).mapNotNull { i ->
+            val o = arr.optJSONObject(i) ?: return@mapNotNull null
+            if (!o.optBoolean("enabled", true)) return@mapNotNull null // darked source: skip
+            val type = StatusProviderType.fromSlug(o.optStringOrNull("type")) ?: return@mapNotNull null // unknown -> skip
+            val id = o.optStringOrNull("id") ?: return@mapNotNull null
+            val baseUrl = o.optStringOrNull("baseUrl") ?: return@mapNotNull null
+            val apiKey = o.optStringOrNull("apiKey") ?: return@mapNotNull null
+            StatusProvider(
+                id = id,
+                type = type,
+                baseUrl = baseUrl,
+                apiKey = apiKey,
+                categoryIds = o.optJSONArray("categoryIds").toStringList(),
+                musicKeywords = o.optJSONArray("musicKeywords").toStringList(),
+                enabled = true,
+            ).takeIf { it.filterList.isNotEmpty() } // an enabled provider with no filter is misconfigured -> skip
+        }
+        StatusSourcesConfig(version, usable)
+    }.getOrNull()
+}
+
+private fun JSONArray?.toStringList(): List<String> {
+    if (this == null) return emptyList()
+    return (0 until length()).mapNotNull { optString(it).trim().takeIf(String::isNotEmpty) }
+}
+
+/**
+ * Process-wide holder for the active status-sources config. Mirrors [com.jtech.zemer.utils.BlockedIdsCache]:
+ * a validated mirror config is installed atomically via [update]; [current] returns it, or an EMPTY config
+ * (no providers -> feature hidden) until the first successful sync. There is no baked-in fallback - the
+ * mirror is the single source of truth. A failed/invalid sync never calls [update], so the last-good
+ * config stays live.
+ */
+object StatusSourcesCache {
+    private val EMPTY = StatusSourcesConfig(version = -1L, providers = emptyList())
+
+    @Volatile
+    private var installed: StatusSourcesConfig? = null
+
+    /** Install a validated mirror config. Never pass null (null from the parser means "keep last-good"). */
+    fun update(config: StatusSourcesConfig) {
+        installed = config
+    }
+
+    /** The config to use now: the installed mirror config, else an empty config (feature hidden). */
+    fun current(): StatusSourcesConfig = installed ?: EMPTY
+
+    /** The version currently installed from the mirror, or -1 if none has synced yet. */
+    val syncedVersion: Long
+        get() = installed?.version ?: -1L
+}

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt
@@ -100,7 +100,9 @@ fun parseStatusSourcesConfig(text: String?): StatusSourcesConfig? {
             if (!o.optBoolean("enabled", true)) return@mapNotNull null // darked source: skip
             val type = StatusProviderType.fromSlug(o.optStringOrNull("type")) ?: return@mapNotNull null // unknown -> skip
             val id = o.optStringOrNull("id") ?: return@mapNotNull null
-            val baseUrl = o.optStringOrNull("baseUrl") ?: return@mapNotNull null
+            // Normalized once here so EVERY handler can safely concatenate "$baseUrl/path" - the config is
+            // hand-authored and a trailing slash must not silently 404 a whole provider family.
+            val baseUrl = o.optStringOrNull("baseUrl")?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
             val apiKey = o.optStringOrNull("apiKey") ?: return@mapNotNull null
             StatusProvider(
                 id = id,
@@ -134,8 +136,15 @@ object StatusSourcesCache {
     @Volatile
     private var installed: StatusSourcesConfig? = null
 
-    /** Install a validated mirror config. Never pass null (null from the parser means "keep last-good"). */
+    /**
+     * Install a validated mirror config. Never pass null (null from the parser means "keep last-good").
+     * Never rolls back: an older-versioned config is ignored, so the startup restore of the persisted
+     * snapshot can safely race a concurrent sync that already installed something newer.
+     */
+    @Synchronized
     fun update(config: StatusSourcesConfig) {
+        val current = installed
+        if (current != null && config.version < current.version) return
         installed = config
     }
 
@@ -145,4 +154,9 @@ object StatusSourcesCache {
     /** The version currently installed from the mirror, or -1 if none has synced yet. */
     val syncedVersion: Long
         get() = installed?.version ?: -1L
+
+    /** Test-only: clear the installed config (the object is process-wide; JVM tests need isolation). */
+    internal fun resetForTest() {
+        installed = null
+    }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt
@@ -19,17 +19,13 @@ import java.net.URL
  * "no data" (the Home row hides itself). Kept deliberately dependency-free (raw [HttpURLConnection], no
  * coupling to the app's OkHttp / YouTube proxy) — it talks to a different backend.
  *
- * [KEY] is a Supabase **publishable** anon key: client-safe by design (the JewishStatus web app ships
- * the same one publicly), NOT a secret. Do not treat it like a service-account credential.
+ * The Supabase base URL, the **publishable** anon key (client-safe by design - the JewishStatus web app
+ * ships the same one publicly, NOT a secret), and which category ids count as "music" are all supplied by
+ * the caller from [StatusSourcesConfig] (server-driven; the mirror is the single source of truth).
+ * The R2 CDN host is the one JewishStatus-specific detail that stays baked in here: it is welded to this
+ * platform's media paths, not a tunable, so it lives with the handler (like YidStatus's `Origin` header).
  */
-private const val BASE = "https://raiodurvjneoehnphkrs.supabase.co/rest/v1"
 private const val CDN = "https://pub-0dd407ad34e240909673d1619658d5c2.r2.dev"
-private const val KEY = "sb_publishable_Pj9SDOxf5Xxw9LavwAl5yw_5ldleSyD"
-
-// The three music categories on JewishStatus (a creator may appear in more than one → deduped).
-private const val CAT_JEWISH_MUSIC = "dc207cab-3514-4ae8-a5c1-8a69fb27ced3"
-private const val CAT_MUSIC_IND = "02ed4e29-d461-43f4-9aab-e16d05d3f795"
-private const val CAT_CONCERTS = "5a08c0ba-400a-4576-aa33-97fa9ec38d0e"
 
 /** Which third-party platform a creator/status came from. Docs: docs/status/. */
 enum class StatusSource { JEWISH_STATUS, YID_STATUS }
@@ -144,13 +140,13 @@ fun statusMediaUrl(path: String?): String? =
 
 // --- Public API. All calls are blocking; run them off the main thread (the repository uses IO). ---
 
-/** All creators across the three music categories, deduplicated, most recent first. */
-suspend fun fetchStatusCreators(): List<StatusCreator> = coroutineScope {
-    // The three categories are independent, so fetch them concurrently instead of summing their
-    // latencies (each is a paginating series of blocking round-trips).
+/** All creators across the given music [categoryIds], deduplicated, most recent first. */
+suspend fun fetchStatusCreators(base: String, key: String, categoryIds: List<String>): List<StatusCreator> = coroutineScope {
+    // The categories are independent, so fetch them concurrently instead of summing their latencies
+    // (each is a paginating series of blocking round-trips).
     val seen = mutableSetOf<String>()
-    val base = listOf(CAT_JEWISH_MUSIC, CAT_MUSIC_IND, CAT_CONCERTS)
-        .map { cat -> async(Dispatchers.IO) { fetchByCategory(cat) } }
+    val creators = categoryIds
+        .map { cat -> async(Dispatchers.IO) { fetchByCategory(base, key, cat) } }
         .awaitAll()
         .flatten()
         .filter { seen.add(it.id) }
@@ -162,7 +158,7 @@ suspend fun fetchStatusCreators(): List<StatusCreator> = coroutineScope {
     // BACKGROUND, so the creator list (and its rings) appear instantly here; the rings then refine to
     // respect the content filter once kinds land. `recent_post_ids` carry no kind, so a blocking fetch
     // here would slow the (formerly instant) load.
-    base
+    creators
 }
 
 /**
@@ -170,14 +166,14 @@ suspend fun fetchStatusCreators(): List<StatusCreator> = coroutineScope {
  * ring can respect the hide-text/hide-image filter. Called by the repository AFTER creators are already
  * published, never on the critical path. Fail-soft: an unresolved id is simply absent (-> shown).
  */
-suspend fun fetchJewishPostKinds(ids: List<String>): Map<String, String> = withContext(Dispatchers.IO) {
+suspend fun fetchJewishPostKinds(base: String, key: String, ids: List<String>): Map<String, String> = withContext(Dispatchers.IO) {
     if (ids.isEmpty()) return@withContext emptyMap()
     val out = HashMap<String, String>(ids.size)
     ids.distinct().chunked(100).forEach { chunk ->
         // Post ids are Supabase UUIDs (URL-safe), so no encoding is needed for the `in.(...)` list.
-        val url = "$BASE/public_posts?id=in.(${chunk.joinToString(",")})&select=id,kind"
+        val url = "$base/public_posts?id=in.(${chunk.joinToString(",")})&select=id,kind"
         runCatching {
-            val arr = JSONArray(getJson(url))
+            val arr = JSONArray(getJson(url, key))
             for (i in 0 until arr.length()) {
                 val o = arr.getJSONObject(i)
                 out[o.getString("id")] = o.optString("kind")
@@ -193,18 +189,18 @@ suspend fun fetchJewishPostKinds(ids: List<String>): Map<String, String> = withC
  * 100+ posts is fully covered). We deliberately do NOT prioritize `is_featured` here — pinning featured
  * posts to the front would scramble the timeline.
  */
-fun fetchStatusPosts(creatorId: String): List<StatusPost> {
+fun fetchStatusPosts(base: String, key: String, creatorId: String): List<StatusPost> {
     val all = mutableListOf<StatusPost>()
     val pageSize = 100
     var offset = 0
     while (true) {
-        val url = "$BASE/public_posts" +
+        val url = "$base/public_posts" +
             "?creator_id=eq.$creatorId" +
             "&select=id,kind,media_path,thumb_path,caption,text_body,text_bg_color,link_url," +
             "duration_seconds,posted_at,view_count,download_count" +
             "&order=posted_at.asc" +
             "&limit=$pageSize&offset=$offset"
-        val page = parsePosts(JSONArray(getJson(url)))
+        val page = parsePosts(JSONArray(getJson(url, key)))
         all += page
         if (page.size < pageSize) break
         offset += pageSize
@@ -214,14 +210,14 @@ fun fetchStatusPosts(creatorId: String): List<StatusPost> {
 
 // --- Private helpers ---
 
-private fun fetchByCategory(catId: String): List<StatusCreator> {
+private fun fetchByCategory(base: String, key: String, catId: String): List<StatusCreator> {
     val all = mutableListOf<StatusCreator>()
     val pageSize = 100
     var offset = 0
     while (true) {
         val body = """{"p_section":"all","p_search":null,"p_limit":$pageSize,"p_offset":$offset,
             "p_category":"$catId","p_location":null,"p_sort":"recent"}"""
-        val page = parseCreators(JSONArray(postJson("$BASE/rpc/browse_creators_sorted", body)))
+        val page = parseCreators(JSONArray(postJson("$base/rpc/browse_creators_sorted", body, key)))
         all += page
         if (page.size < pageSize) break
         offset += pageSize
@@ -269,25 +265,25 @@ internal fun parsePosts(arr: JSONArray): List<StatusPost> =
         )
     }
 
-private fun postJson(url: String, body: String): String {
+private fun postJson(url: String, body: String, key: String): String {
     val conn = URL(url).openConnection() as HttpURLConnection
     conn.requestMethod = "POST"
     conn.connectTimeout = TIMEOUT_MS
     conn.readTimeout = TIMEOUT_MS
     conn.setRequestProperty("Content-Type", "application/json")
-    conn.setRequestProperty("apikey", KEY)
-    conn.setRequestProperty("Authorization", "Bearer $KEY")
+    conn.setRequestProperty("apikey", key)
+    conn.setRequestProperty("Authorization", "Bearer $key")
     conn.doOutput = true
     conn.outputStream.use { it.write(body.toByteArray()) }
     return conn.inputStream.use { it.reader().readText() }
 }
 
-private fun getJson(url: String): String {
+private fun getJson(url: String, key: String): String {
     val conn = URL(url).openConnection() as HttpURLConnection
     conn.connectTimeout = TIMEOUT_MS
     conn.readTimeout = TIMEOUT_MS
-    conn.setRequestProperty("apikey", KEY)
-    conn.setRequestProperty("Authorization", "Bearer $KEY")
+    conn.setRequestProperty("apikey", key)
+    conn.setRequestProperty("Authorization", "Bearer $key")
     return conn.inputStream.use { it.reader().readText() }
 }
 

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt
@@ -1,7 +1,14 @@
 package com.jtech.zemer.statuses
 
+import android.content.Context
 import android.os.SystemClock
+import androidx.datastore.preferences.core.edit
+import com.jtech.zemer.constants.StatusSourcesConfigKey
+import com.jtech.zemer.constants.StatusSourcesVersionKey
+import com.jtech.zemer.utils.ZemerContentClient
+import com.jtech.zemer.utils.dataStore
 import com.jtech.zemer.utils.reportException
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -17,27 +24,33 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Session-scoped access to BOTH status platforms ([StatusesApi] = JewishStatus, [YidStatusApi] =
- * YidStatus) plus the SHARED feed state both the Home-row and story-viewer ViewModels read — [creators]
- * and [seen] live here once instead of being loaded/exposed independently in each VM. The merged
- * creators list feeds the (uniform) Home row; each creator carries its [StatusCreator.source] so the
- * See-all screen can group by platform and [posts] routes to the right backend.
+ * Session-scoped access to the status platforms plus the SHARED feed state both the Home-row and
+ * story-viewer ViewModels read — [creators] and [seen] live here once instead of being loaded/exposed
+ * independently in each VM. Which platforms are fetched (and their categories/keywords) is driven by the
+ * server config in [StatusSourcesCache] (synced from the content mirror; the feature is simply hidden
+ * until the first successful sync - there is no baked-in fallback), grouped by handler [StatusProviderType]:
+ *  - [StatusProviderType.SUPABASE_CATEGORY] providers (JewishStatus shape) load via [loadJewish];
+ *  - [StatusProviderType.KEYWORD_FEED] providers (YidStatus shape) load via [loadYid].
+ * Each creator carries its [StatusCreator.source] so the See-all screen groups by platform, and each is
+ * mapped to the provider it came from ([providerByCreator]) so [posts] fetches with the right backend.
  *
- * Both platforms are fetched CONCURRENTLY and independently fail-soft: one platform being down still
- * shows the other. So the row picks up newly-posted statuses, the caches self-refresh:
- *  - screen open / re-entry re-fetches a platform whose cache is older than [STALE_MS];
+ * Both families are fetched CONCURRENTLY and independently fail-soft: one platform being down still shows
+ * the other. The caches self-refresh so newly-posted statuses appear:
+ *  - screen open / re-entry re-fetches a family whose cache is older than [STALE_MS];
  *  - pull-to-refresh forces both (`refreshCreators(force = true)`);
  *  - opening a creator re-fetches THAT creator's posts immediately ([refreshPosts]).
- * An all-empty / failed fetch keeps the previous cache (never blanks the row).
+ * An all-empty / failed fetch keeps the previous cache (never blanks the row). The source config is
+ * refreshed (version-gated) on the same path, non-blocking, and applies to subsequent loads.
  */
 @Singleton
 class StatusesRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val seenStore: StatusSeenStore,
 ) {
-    // Each platform has its own mutex + cache so they load INDEPENDENTLY and PROGRESSIVELY: the fast
-    // platform (JewishStatus) publishes immediately without waiting on the multi-MB YidStatus feed, a
-    // single platform's failure keeps the other alive, and a failed source retries on the next refresh
-    // (neither is null-cached). The per-source mutex dedupes concurrent loads of the same platform.
+    // One mutex + cache per HANDLER FAMILY so they load INDEPENDENTLY and PROGRESSIVELY: the fast family
+    // (JewishStatus) publishes immediately without waiting on the multi-MB YidStatus feed, one family's
+    // failure keeps the other alive, and a failed source retries on the next refresh (neither is
+    // null-cached). The per-family mutex dedupes concurrent loads.
     private val jewishMutex = Mutex()
     private val yidMutex = Mutex()
     @Volatile private var jewishCache: List<StatusCreator>? = null
@@ -45,7 +58,7 @@ class StatusesRepository @Inject constructor(
     @Volatile private var jewishFetchedAt = 0L
     @Volatile private var yidFetchedAt = 0L
 
-    // A cached platform this old is re-fetched on the next screen open (not just on a full app restart).
+    // A cached family this old is re-fetched on the next screen open (not just on a full app restart).
     private companion object {
         const val STALE_MS = 5 * 60 * 1000L // 5 minutes
     }
@@ -55,9 +68,11 @@ class StatusesRepository @Inject constructor(
 
     // Posts use a concurrent map with NO lock across the fetch, so preloading the next creator never
     // waits behind the current one; a rare duplicate concurrent fetch for one creator is harmless.
-    // YidStatus posts are primed here from its one-shot feed; JewishStatus posts are fetched per creator.
+    // KEYWORD_FEED posts are primed from the one-shot feed; SUPABASE_CATEGORY posts are fetched per creator.
     private val postsCache = ConcurrentHashMap<String, List<StatusPost>>()
-    private val sourceById = ConcurrentHashMap<String, StatusSource>()
+    // creatorId -> the provider it came from, so per-creator post fetches use the right baseUrl/apiKey and
+    // routing keys off the provider's TYPE (only SUPABASE_CATEGORY has a per-creator endpoint).
+    private val providerByCreator = ConcurrentHashMap<String, StatusProvider>()
 
     // Shared feed state (single source for both VMs).
     private val _creators = MutableStateFlow<List<StatusCreator>>(emptyList())
@@ -67,24 +82,27 @@ class StatusesRepository @Inject constructor(
     val seen: Flow<Set<String>> get() = seenStore.seen
 
     /**
-     * Load both platforms into [creators], each on its own coroutine so the row updates progressively as
-     * each lands. [force] (pull-to-refresh) re-fetches unconditionally; otherwise a platform is re-fetched
-     * only when its cache is empty or older than [STALE_MS]. Fail-soft per source: a failure keeps the
-     * previous cache and never blanks the other.
+     * Load both families into [creators], each on its own coroutine so the row updates progressively as
+     * each lands, and refresh the server source config (version-gated, non-blocking) for subsequent loads.
+     * [force] (pull-to-refresh) re-fetches unconditionally; otherwise a family is re-fetched only when its
+     * cache is empty or older than [STALE_MS]. Fail-soft per source: a failure keeps the previous cache.
      */
     suspend fun refreshCreators(force: Boolean = false): Unit = coroutineScope {
+        launch { syncStatusSources() } // refreshes config for the NEXT load; never blocks this one
         launch { loadJewish(force) }
         launch { loadYid(force) }
     }
 
-    /** One creator's posts (chronological), routed by source. Cached per creator. */
+    /** One creator's posts (chronological), routed by its provider. Cached per creator. */
     suspend fun posts(creatorId: String): List<StatusPost> =
         postsCache[creatorId] ?: run {
-            // YidStatus posts are primed from its feed; if a YidStatus creator misses the cache there is
-            // nothing to fetch per-creator (the statuses table is not publicly readable). Only JewishStatus
-            // fetches per creator - guard so a YidStatus id never hits the JewishStatus endpoint.
-            if (sourceById[creatorId] == StatusSource.YID_STATUS) return emptyList()
-            withContext(Dispatchers.IO) { fetchStatusPosts(creatorId) }.also { postsCache[creatorId] = it }
+            val provider = providerByCreator[creatorId]
+            // Only SUPABASE_CATEGORY fetches per creator; KEYWORD_FEED posts are feed-primed (its statuses
+            // table is not publicly readable), and an unknown provider has nothing to fetch. Guard so a
+            // feed creator never hits the per-creator endpoint.
+            if (provider?.type != StatusProviderType.SUPABASE_CATEGORY) return emptyList()
+            withContext(Dispatchers.IO) { fetchStatusPosts(provider.baseUrl, provider.apiKey, creatorId) }
+                .also { postsCache[creatorId] = it }
         }
 
     /** The already-cached posts for a creator, or null if not fetched yet (no network). */
@@ -92,13 +110,14 @@ class StatusesRepository @Inject constructor(
 
     /**
      * Re-fetch ONE creator's posts right now (called when the viewer opens a creator, so the one you
-     * tapped shows its newest statuses immediately). JewishStatus has a per-creator endpoint; YidStatus
-     * does not (its posts come from the global feed), so a YidStatus creator returns whatever the feed
-     * cache holds. Fail-soft: on error keep the cached list. Returns the up-to-date posts.
+     * tapped shows its newest statuses immediately). Only SUPABASE_CATEGORY has a per-creator endpoint;
+     * a KEYWORD_FEED creator returns whatever the feed cache holds. Fail-soft: on error keep the cached
+     * list. Returns the up-to-date posts.
      */
     suspend fun refreshPosts(creatorId: String): List<StatusPost> {
-        if (sourceById[creatorId] == StatusSource.YID_STATUS) return postsCache[creatorId] ?: emptyList()
-        return runCatching { withContext(Dispatchers.IO) { fetchStatusPosts(creatorId) } }
+        val provider = providerByCreator[creatorId]
+        if (provider?.type != StatusProviderType.SUPABASE_CATEGORY) return postsCache[creatorId] ?: emptyList()
+        return runCatching { withContext(Dispatchers.IO) { fetchStatusPosts(provider.baseUrl, provider.apiKey, creatorId) } }
             .onFailure { reportException(it) }
             .getOrNull()?.also { postsCache[creatorId] = it }
             ?: (postsCache[creatorId] ?: emptyList())
@@ -107,20 +126,69 @@ class StatusesRepository @Inject constructor(
     /** Record a status as viewed (persisted). */
     suspend fun markSeen(postId: String) = seenStore.markSeen(listOf(postId))
 
+    /**
+     * Version-gated refresh of the server-driven source config. Re-fetches [ZemerContentClient.statusSourcesRaw]
+     * only when `/status-sources/version` reports a newer integer than what is installed, installs it into
+     * [StatusSourcesCache], and persists the raw JSON + version so it survives restarts. Fully fail-soft:
+     * an unreachable mirror, a 503 (invalid config), or an unparseable body leaves the last-good config
+     * live (or the feature hidden if none has synced). Runs off the load's critical path (a config change
+     * applies to the next refresh).
+     */
+    private suspend fun syncStatusSources() = withContext(Dispatchers.IO) {
+        if (!ZemerContentClient.enabled) return@withContext
+        runCatching {
+            val remoteVersion = ZemerContentClient.statusSourcesVersion()
+            if (remoteVersion <= StatusSourcesCache.syncedVersion) return@runCatching // already current
+            val raw = ZemerContentClient.statusSourcesRaw()
+            val config = parseStatusSourcesConfig(raw) ?: return@runCatching // invalid -> keep current (fallback)
+            StatusSourcesCache.update(config)
+            context.dataStore.edit {
+                it[StatusSourcesConfigKey] = raw
+                it[StatusSourcesVersionKey] = config.version
+            }
+        }.onFailure { reportException(it) }
+    }
+
     private suspend fun loadJewish(force: Boolean) = jewishMutex.withLock {
         if (!force && jewishCache != null && isFresh(jewishFetchedAt)) return@withLock republish()
-        val loaded = runCatching { withContext(Dispatchers.IO) { fetchStatusCreators() } }
-            .onFailure { reportException(it) }.getOrNull() ?: return@withLock republish() // keep old on failure
-        loaded.forEach { sourceById[it.id] = StatusSource.JEWISH_STATUS }
+        val providers = StatusSourcesCache.current().providersOfType(StatusProviderType.SUPABASE_CATEGORY)
+        if (providers.isEmpty()) { // no active supabase-category source (darked / none) -> honored empty
+            jewishCache = emptyList()
+            jewishFetchedAt = SystemClock.elapsedRealtime()
+            return@withLock republish()
+        }
+        var anySuccess = false
+        val byId = LinkedHashMap<String, StatusCreator>() // dedupe by id across providers, keep order
+        withContext(Dispatchers.IO) {
+            providers.forEach { provider ->
+                runCatching { fetchStatusCreators(provider.baseUrl, provider.apiKey, provider.categoryIds) }
+                    .onFailure { reportException(it) }
+                    .getOrNull()?.let { list ->
+                        anySuccess = true
+                        list.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
+                    }
+            }
+        }
+        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache
+        val loaded = byId.values.toList()
         jewishCache = loaded
         jewishFetchedAt = SystemClock.elapsedRealtime()
         republish() // creators (and rings) appear NOW; rings refine once kinds land below
 
-        // Resolve each recent status's KIND off the critical path, then re-publish so the rings drop the
-        // hidden kinds (JewishStatus recent_post_ids carry no kind). Fail-soft; a failure just leaves the
-        // full ring showing. Only re-publish if the cache still holds this exact load (no newer refresh).
-        val kinds = runCatching { fetchJewishPostKinds(loaded.flatMap { it.recentPostIds }) }
-            .getOrDefault(emptyMap())
+        // Resolve each recent status's KIND off the critical path (SUPABASE_CATEGORY recent ids carry no
+        // kind), fetched per provider so each uses the right backend, then re-publish so the rings drop the
+        // hidden kinds. Fail-soft; a failure just leaves the full ring. Only re-publish if the cache still
+        // holds this exact load (no newer refresh landed meanwhile).
+        val kinds = runCatching {
+            withContext(Dispatchers.IO) {
+                buildMap {
+                    providers.forEach { provider ->
+                        val ids = loaded.filter { providerByCreator[it.id] === provider }.flatMap { it.recentPostIds }
+                        putAll(fetchJewishPostKinds(provider.baseUrl, provider.apiKey, ids))
+                    }
+                }
+            }
+        }.getOrDefault(emptyMap())
         if (kinds.isNotEmpty() && jewishCache === loaded) {
             jewishCache = loaded.map { c -> c.copy(recentPostKinds = c.recentPostIds.map { kinds[it].orEmpty() }) }
             republish()
@@ -129,9 +197,28 @@ class StatusesRepository @Inject constructor(
 
     private suspend fun loadYid(force: Boolean) = yidMutex.withLock {
         if (!force && yidCache != null && isFresh(yidFetchedAt)) return@withLock republish()
-        val feed = runCatching { withContext(Dispatchers.IO) { fetchYidStatusFeed() } }
-            .onFailure { reportException(it) }.getOrNull() ?: return@withLock republish() // keep old on failure
-        feed.creators.forEach { sourceById[it.id] = StatusSource.YID_STATUS }
+        val providers = StatusSourcesCache.current().providersOfType(StatusProviderType.KEYWORD_FEED)
+        if (providers.isEmpty()) { // no active keyword-feed source (darked / none) -> honored empty
+            yidCache = YidFeed(emptyList(), emptyMap())
+            yidFetchedAt = SystemClock.elapsedRealtime()
+            return@withLock republish()
+        }
+        var anySuccess = false
+        val byId = LinkedHashMap<String, StatusCreator>()
+        val postsByCreator = HashMap<String, List<StatusPost>>()
+        withContext(Dispatchers.IO) {
+            providers.forEach { provider ->
+                runCatching { fetchYidStatusFeed(provider.baseUrl, provider.apiKey, provider.musicKeywords) }
+                    .onFailure { reportException(it) }
+                    .getOrNull()?.let { feed ->
+                        anySuccess = true
+                        feed.creators.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
+                        postsByCreator.putAll(feed.postsByCreator)
+                    }
+            }
+        }
+        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache
+        val feed = YidFeed(byId.values.toList(), postsByCreator)
         feed.postsByCreator.forEach { (id, posts) -> postsCache[id] = posts }
         yidCache = feed
         yidFetchedAt = SystemClock.elapsedRealtime()
@@ -139,7 +226,7 @@ class StatusesRepository @Inject constructor(
     }
 
     /**
-     * Publish the merge of whatever each platform has loaded so far (JewishStatus first, then YidStatus),
+     * Publish the merge of whatever each family has loaded so far (JewishStatus first, then YidStatus),
      * dropping cross-platform duplicate creators (same person on both) - see [mergeStatusCreators].
      */
     @Synchronized

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt
@@ -57,6 +57,11 @@ class StatusesRepository @Inject constructor(
     @Volatile private var yidCache: YidFeed? = null
     @Volatile private var jewishFetchedAt = 0L
     @Volatile private var yidFetchedAt = 0L
+    // The config version each family cache was loaded under. A config change (first sync landing, a
+    // source darked/re-enabled) makes the cache stale IMMEDIATELY - without this, an empty "no config
+    // yet" load stamped fresh would hide the row for a whole STALE_MS after the first sync succeeds.
+    @Volatile private var jewishConfigVersion = Long.MIN_VALUE
+    @Volatile private var yidConfigVersion = Long.MIN_VALUE
 
     // A cached family this old is re-fetched on the next screen open (not just on a full app restart).
     private companion object {
@@ -65,6 +70,10 @@ class StatusesRepository @Inject constructor(
 
     private fun isFresh(fetchedAt: Long) =
         fetchedAt != 0L && SystemClock.elapsedRealtime() - fetchedAt < STALE_MS
+
+    /** A family cache is fresh only if recently fetched AND loaded under the currently-installed config. */
+    private fun isFamilyFresh(fetchedAt: Long, loadedVersion: Long) =
+        isFresh(fetchedAt) && loadedVersion == StatusSourcesCache.syncedVersion
 
     // Posts use a concurrent map with NO lock across the fetch, so preloading the next creator never
     // waits behind the current one; a rare duplicate concurrent fetch for one creator is harmless.
@@ -88,7 +97,14 @@ class StatusesRepository @Inject constructor(
      * cache is empty or older than [STALE_MS]. Fail-soft per source: a failure keeps the previous cache.
      */
     suspend fun refreshCreators(force: Boolean = false): Unit = coroutineScope {
-        launch { syncStatusSources() } // refreshes config for the NEXT load; never blocks this one
+        // Until the FIRST config has synced the sync is AWAITED, so a fresh install's very first load runs
+        // with a real config instead of loading empty (server-only design: no config = nothing to fetch).
+        // After that it runs non-blocking - a config change applies via the version staleness check.
+        if (StatusSourcesCache.syncedVersion < 0) {
+            syncStatusSources(force)
+        } else {
+            launch { syncStatusSources(force) }
+        }
         launch { loadJewish(force) }
         launch { loadYid(force) }
     }
@@ -126,53 +142,79 @@ class StatusesRepository @Inject constructor(
     /** Record a status as viewed (persisted). */
     suspend fun markSeen(postId: String) = seenStore.markSeen(listOf(postId))
 
+    // The sync itself is throttled to one attempt per STALE_MS window (whatever the outcome), so the
+    // per-screen-entry refresh path doesn't hammer /status-sources/version. The mutex also dedupes
+    // concurrent entries. force (pull-to-refresh) bypasses the throttle, never the in-flight dedupe.
+    private val syncMutex = Mutex()
+    @Volatile private var syncAttemptedAt = 0L
+
     /**
      * Version-gated refresh of the server-driven source config. Re-fetches [ZemerContentClient.statusSourcesRaw]
      * only when `/status-sources/version` reports a newer integer than what is installed, installs it into
-     * [StatusSourcesCache], and persists the raw JSON + version so it survives restarts. Fully fail-soft:
-     * an unreachable mirror, a 503 (invalid config), or an unparseable body leaves the last-good config
-     * live (or the feature hidden if none has synced). Runs off the load's critical path (a config change
-     * applies to the next refresh).
+     * [StatusSourcesCache], and persists the raw JSON + the EFFECTIVE version so it survives restarts.
+     * The installed version is capped at the endpoint's ([minOf]): a CDN-stale body keeps its older version
+     * (so the next poll retries until the body catches up), and a body ever ahead of the endpoint can never
+     * permanently suppress future syncs. Fully fail-soft AND deliberately QUIET on failure (like
+     * `refreshBlockedIds` / the whitelist sync - an unreachable mirror offline is expected, not a
+     * reportable error): any failure leaves the last-good config live (or the feature hidden if none has
+     * synced).
      */
-    private suspend fun syncStatusSources() = withContext(Dispatchers.IO) {
+    private suspend fun syncStatusSources(force: Boolean = false) = withContext(Dispatchers.IO) {
         if (!ZemerContentClient.enabled) return@withContext
-        runCatching {
-            val remoteVersion = ZemerContentClient.statusSourcesVersion()
-            if (remoteVersion <= StatusSourcesCache.syncedVersion) return@runCatching // already current
-            val raw = ZemerContentClient.statusSourcesRaw()
-            val config = parseStatusSourcesConfig(raw) ?: return@runCatching // invalid -> keep current (fallback)
-            StatusSourcesCache.update(config)
-            context.dataStore.edit {
-                it[StatusSourcesConfigKey] = raw
-                it[StatusSourcesVersionKey] = config.version
+        syncMutex.withLock {
+            if (!force && isFresh(syncAttemptedAt)) return@withLock // one poll per window
+            syncAttemptedAt = SystemClock.elapsedRealtime()
+            runCatching {
+                val remoteVersion = ZemerContentClient.statusSourcesVersion()
+                if (remoteVersion <= StatusSourcesCache.syncedVersion) return@runCatching // already current
+                val raw = ZemerContentClient.statusSourcesRaw()
+                val parsed = parseStatusSourcesConfig(raw) ?: return@runCatching // invalid -> keep current
+                val config = parsed.copy(version = minOf(parsed.version, remoteVersion))
+                StatusSourcesCache.update(config)
+                context.dataStore.edit {
+                    it[StatusSourcesConfigKey] = raw
+                    it[StatusSourcesVersionKey] = config.version
+                }
             }
-        }.onFailure { reportException(it) }
+        }
     }
 
     private suspend fun loadJewish(force: Boolean) = jewishMutex.withLock {
-        if (!force && jewishCache != null && isFresh(jewishFetchedAt)) return@withLock republish()
-        val providers = StatusSourcesCache.current().providersOfType(StatusProviderType.SUPABASE_CATEGORY)
+        if (!force && jewishCache != null && isFamilyFresh(jewishFetchedAt, jewishConfigVersion)) {
+            return@withLock republish()
+        }
+        val config = StatusSourcesCache.current()
+        val providers = config.providersOfType(StatusProviderType.SUPABASE_CATEGORY)
         if (providers.isEmpty()) { // no active supabase-category source (darked / none) -> honored empty
             jewishCache = emptyList()
             jewishFetchedAt = SystemClock.elapsedRealtime()
+            jewishConfigVersion = config.version
             return@withLock republish()
         }
         var anySuccess = false
         val byId = LinkedHashMap<String, StatusCreator>() // dedupe by id across providers, keep order
         withContext(Dispatchers.IO) {
             providers.forEach { provider ->
-                runCatching { fetchStatusCreators(provider.baseUrl, provider.apiKey, provider.categoryIds) }
+                val list = runCatching { fetchStatusCreators(provider.baseUrl, provider.apiKey, provider.categoryIds) }
                     .onFailure { reportException(it) }
-                    .getOrNull()?.let { list ->
-                        anySuccess = true
-                        list.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
+                    .getOrNull()
+                if (list != null) {
+                    anySuccess = true
+                    list.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
+                } else {
+                    // Fail-soft PER provider: keep THIS provider's previously-loaded creators so one
+                    // source's outage never blanks its rows while its siblings refresh.
+                    jewishCache?.filter { providerByCreator[it.id]?.id == provider.id }?.forEach { c ->
+                        if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider
                     }
+                }
             }
         }
-        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache
+        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache unstamped
         val loaded = byId.values.toList()
         jewishCache = loaded
         jewishFetchedAt = SystemClock.elapsedRealtime()
+        jewishConfigVersion = config.version
         republish() // creators (and rings) appear NOW; rings refine once kinds land below
 
         // Resolve each recent status's KIND off the critical path (SUPABASE_CATEGORY recent ids carry no
@@ -196,11 +238,15 @@ class StatusesRepository @Inject constructor(
     }
 
     private suspend fun loadYid(force: Boolean) = yidMutex.withLock {
-        if (!force && yidCache != null && isFresh(yidFetchedAt)) return@withLock republish()
-        val providers = StatusSourcesCache.current().providersOfType(StatusProviderType.KEYWORD_FEED)
+        if (!force && yidCache != null && isFamilyFresh(yidFetchedAt, yidConfigVersion)) {
+            return@withLock republish()
+        }
+        val config = StatusSourcesCache.current()
+        val providers = config.providersOfType(StatusProviderType.KEYWORD_FEED)
         if (providers.isEmpty()) { // no active keyword-feed source (darked / none) -> honored empty
             yidCache = YidFeed(emptyList(), emptyMap())
             yidFetchedAt = SystemClock.elapsedRealtime()
+            yidConfigVersion = config.version
             return@withLock republish()
         }
         var anySuccess = false
@@ -208,20 +254,31 @@ class StatusesRepository @Inject constructor(
         val postsByCreator = HashMap<String, List<StatusPost>>()
         withContext(Dispatchers.IO) {
             providers.forEach { provider ->
-                runCatching { fetchYidStatusFeed(provider.baseUrl, provider.apiKey, provider.musicKeywords) }
+                val feed = runCatching { fetchYidStatusFeed(provider.baseUrl, provider.apiKey, provider.musicKeywords) }
                     .onFailure { reportException(it) }
-                    .getOrNull()?.let { feed ->
-                        anySuccess = true
-                        feed.creators.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
-                        postsByCreator.putAll(feed.postsByCreator)
+                    .getOrNull()
+                if (feed != null) {
+                    anySuccess = true
+                    feed.creators.forEach { c -> if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider }
+                    // FIRST provider wins for posts too, matching the creator merge: the published
+                    // creator's ring came from its provider's keyword-filtered posts, so its posts must
+                    // come from the same provider (last-wins here would skew ring vs viewer content).
+                    feed.postsByCreator.forEach { (id, posts) -> postsByCreator.putIfAbsent(id, posts) }
+                } else {
+                    // Fail-soft PER provider: keep THIS provider's previously-loaded creators (their posts
+                    // are still in postsCache) so one source's outage never blanks its rows.
+                    yidCache?.creators?.filter { providerByCreator[it.id]?.id == provider.id }?.forEach { c ->
+                        if (byId.putIfAbsent(c.id, c) == null) providerByCreator[c.id] = provider
                     }
+                }
             }
         }
-        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache
+        if (!anySuccess) return@withLock republish() // every provider failed -> keep old cache unstamped
         val feed = YidFeed(byId.values.toList(), postsByCreator)
         feed.postsByCreator.forEach { (id, posts) -> postsCache[id] = posts }
         yidCache = feed
         yidFetchedAt = SystemClock.elapsedRealtime()
+        yidConfigVersion = config.version
         republish()
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt
@@ -18,28 +18,22 @@ import java.util.concurrent.TimeUnit
  * we fetch it once, filter to the MUSIC categories, and group statuses by creator. Media URLs come back
  * fully qualified, so they pass straight through [statusMediaUrl]/[statusAvatarUrl].
  *
- * Two non-obvious rules (see the doc):
- *  - The `/feed` edge function returns 403 unless the request carries `Origin: https://yidstatus.com`.
- *    A native client may set it freely; treat the whole thing as fail-soft (the row hides on failure).
- *  - [KEY] is the platform's public anon JWT (client-safe, read-only), NOT a secret.
+ * The base URL, the public anon JWT (client-safe, read-only, NOT a secret), and which category keywords
+ * count as "music" are supplied by the caller from [StatusSourcesConfig] (server-driven; the mirror is
+ * the single source of truth). Two YidStatus-specific PROTOCOL details stay baked in here,
+ * because they are welded to this platform rather than tunable:
+ *  - The `/functions/v1/feed` edge path ([yidFeedUrl]).
+ *  - The `Origin: https://yidstatus.com` header the feed requires (a 403 without it). It is a JDK/Android
+ *    "restricted header" that HttpURLConnection silently drops, which is why this client uses OkHttp.
  */
-private const val YID_BASE = "https://api.yidstatus.com"
-private const val YID_FEED_URL = "$YID_BASE/functions/v1/feed"
 private const val YID_ORIGIN = "https://yidstatus.com"
-private const val YID_KEY =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZzaW53YWxxaGd3YXBldndpYm1k" +
-        "Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODI2ODEyODUsImV4cCI6MjA5ODI1NzI4NX0." +
-        "ZwrXgeUknPSDAWsOzdI8jdj7wCO9xOe7glLSj3OB_vA"
+private fun yidFeedUrl(base: String) = "${base.trimEnd('/')}/functions/v1/feed"
 
 // Rolling window (days). Kept at 1 deliberately: the feed is GLOBAL (all categories) and costs ~3.35 MB
 // per day before filtering, and the edge function hard-errors past ~15 days (WORKER_RESOURCE_LIMIT).
 // YidStatus exposes NO per-creator history endpoint, so a deep "jump to date" like JewishStatus is not
 // achievable from its public API - one day already spans ~2 calendar dates, which is the practical cap.
 private const val YID_FEED_DAYS = 1
-
-// A creator is "music" if any of its categories contains one of these (case-insensitive). Owner choice
-// (2026-08-02): music acts + simchas/events + concerts; NOT comedy/entertainment/news/business/etc.
-private val YID_MUSIC_KEYWORDS = listOf("music", "singer", "kumzits", "simcha", "concert")
 
 /** A creator's music-filtered YidStatus feed: creators (with statuses in the window) + their posts. */
 data class YidFeed(
@@ -51,9 +45,9 @@ data class YidFeed(
  * Fetch the YidStatus feed and reduce it to music creators + their statuses (oldest-first per creator).
  * Blocking; run off the main thread. Throws on network/HTTP error (callers are fail-soft).
  */
-fun fetchYidStatusFeed(days: Int = YID_FEED_DAYS): YidFeed {
-    val root = JSONObject(postFeed("""{"days":$days,"since":null}"""))
-    val musicCreators = parseYidCreators(root.optJSONArray("influencers") ?: JSONArray())
+fun fetchYidStatusFeed(base: String, key: String, keywords: List<String>, days: Int = YID_FEED_DAYS): YidFeed {
+    val root = JSONObject(postFeed(yidFeedUrl(base), key, """{"days":$days,"since":null}"""))
+    val musicCreators = parseYidCreators(root.optJSONArray("influencers") ?: JSONArray(), keywords)
     val musicIds = musicCreators.associateBy { it.id }
     val byCreator = parseYidStatuses(root.optJSONArray("statuses") ?: JSONArray(), musicIds.keys)
     // Keep only creators that actually have a status in the window; attach their status ids as the ring.
@@ -66,12 +60,12 @@ fun fetchYidStatusFeed(days: Int = YID_FEED_DAYS): YidFeed {
 
 // --- Parsing ---
 
-internal fun parseYidCreators(arr: JSONArray): List<StatusCreator> =
+internal fun parseYidCreators(arr: JSONArray, keywords: List<String>): List<StatusCreator> =
     (0 until arr.length()).mapNotNull { i ->
         val o = arr.getJSONObject(i)
         // Exclude hidden/paused/unlisted creators and anything outside the music categories.
         if (o.optBoolean("paused") || o.optBoolean("unlisted") || o.optBoolean("review_hidden")) return@mapNotNull null
-        if (!isMusicCreator(o)) return@mapNotNull null
+        if (!isMusicCreator(o, keywords)) return@mapNotNull null
         StatusCreator(
             id = o.getString("id"),
             slug = o.optStringOrNull("slug") ?: o.getString("id"),
@@ -119,12 +113,12 @@ internal fun parseYidStatuses(arr: JSONArray, musicIds: Set<String>): Map<String
 
 private val ALLOWED_YID_KINDS = setOf("video", "image", "text")
 
-private fun isMusicCreator(o: JSONObject): Boolean {
+private fun isMusicCreator(o: JSONObject, keywords: List<String>): Boolean {
     val cats = buildList {
         o.optStringOrNull("category")?.let { add(it) }
         o.optJSONArray("categories")?.let { a -> for (i in 0 until a.length()) add(a.optString(i)) }
     }
-    return cats.any { c -> YID_MUSIC_KEYWORDS.any { kw -> c.lowercase().contains(kw) } }
+    return cats.any { c -> keywords.any { kw -> c.lowercase().contains(kw.lowercase()) } }
 }
 
 // --- HTTP ---
@@ -139,11 +133,11 @@ private val yidHttpClient by lazy {
 }
 private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
-private fun postFeed(body: String): String {
+private fun postFeed(feedUrl: String, key: String, body: String): String {
     val request = Request.Builder()
-        .url(YID_FEED_URL)
+        .url(feedUrl)
         .post(body.toRequestBody(JSON_MEDIA_TYPE))
-        .header("apikey", YID_KEY)
+        .header("apikey", key)
         .header("Origin", YID_ORIGIN) // required; see docs/status/yidstatus-api.md
         .build()
     yidHttpClient.newCall(request).execute().use { resp ->

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
@@ -124,7 +124,8 @@ object ZemerContentClient {
      * `/status-sources/version` → the monotonic INTEGER gate for the Music Status source config (same
      * version-gate pattern as `/whitelist/version`). Poll this; re-fetch [statusSourcesRaw] only when it
      * increases. Throws on a missing version or any non-2xx (e.g. the 503 the mirror serves for an
-     * invalid config) so the caller falls back to the last-good / baked-in config.
+     * invalid config) so the caller keeps its last-good config (or the feature stays hidden if none has
+     * ever synced - there is no baked-in fallback).
      */
     suspend fun statusSourcesVersion(): Long {
         val dto = json.decodeFromString(StatusSourcesVersionDto.serializer(), getText("/status-sources/version", SMALL_TIMEOUT_MS))
@@ -136,7 +137,7 @@ object ZemerContentClient {
     /**
      * `/status-sources` → the raw typed-descriptor config JSON, parsed by
      * [com.jtech.zemer.statuses.parseStatusSourcesConfig] (org.json, shared with the unit tests). Kept as
-     * raw text here so the parse/validate/fallback logic lives in one place next to the baked-in default.
+     * raw text here so the parse/validate/fail-soft logic lives in one place (the `statuses` package).
      */
     suspend fun statusSourcesRaw(): String = getText("/status-sources", SMALL_TIMEOUT_MS)
 

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
@@ -120,6 +120,26 @@ object ZemerContentClient {
         return ids
     }
 
+    /**
+     * `/status-sources/version` → the monotonic INTEGER gate for the Music Status source config (same
+     * version-gate pattern as `/whitelist/version`). Poll this; re-fetch [statusSourcesRaw] only when it
+     * increases. Throws on a missing version or any non-2xx (e.g. the 503 the mirror serves for an
+     * invalid config) so the caller falls back to the last-good / baked-in config.
+     */
+    suspend fun statusSourcesVersion(): Long {
+        val dto = json.decodeFromString(StatusSourcesVersionDto.serializer(), getText("/status-sources/version", SMALL_TIMEOUT_MS))
+        val version = dto.version ?: error("content mirror: missing version in /status-sources/version")
+        Timber.d("ZemerContentClient: /status-sources/version version=%d", version)
+        return version
+    }
+
+    /**
+     * `/status-sources` → the raw typed-descriptor config JSON, parsed by
+     * [com.jtech.zemer.statuses.parseStatusSourcesConfig] (org.json, shared with the unit tests). Kept as
+     * raw text here so the parse/validate/fallback logic lives in one place next to the baked-in default.
+     */
+    suspend fun statusSourcesRaw(): String = getText("/status-sources", SMALL_TIMEOUT_MS)
+
     private const val CONNECT_TIMEOUT_MS = 3_000L
     private const val DEFAULT_TIMEOUT_MS = 4_000L
     private const val SMALL_TIMEOUT_MS = 4_000L
@@ -141,6 +161,13 @@ data class ContentVersionDto(
 data class ContentBlockedDto(
     val global: List<String> = emptyList(),
     val female: List<String> = emptyList(),
+)
+
+/** `/status-sources/version`. `version` is the monotonic integer the app version-gates on; `updatedAt` is informational. */
+@Serializable
+data class StatusSourcesVersionDto(
+    val version: Long? = null,
+    val updatedAt: String? = null,
 )
 
 /**

--- a/app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt
@@ -1,0 +1,124 @@
+package com.jtech.zemer.statuses
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM coverage of the server-driven status-sources config (SERVER-ONLY, no baked-in fallback): the
+ * typed-descriptor parse and the fail-soft distinction that keeps the feature safe - "could not obtain a
+ * valid config" (-> null, caller keeps its last-good / stays hidden) vs. "valid config" (-> honored as-is,
+ * even when empty = intentional dark). Uses the real `org.json` (test dep).
+ * Contract: `handoff-docs/zemer-status-sources-config-request.md`.
+ */
+class StatusSourcesConfigTest {
+
+    private fun descriptor(
+        id: String = "jewish-status",
+        type: String = "supabase-category",
+        enabled: Boolean = true,
+        filterKey: String = "categoryIds",
+        filter: String = """["cat-1","cat-2"]""",
+    ) = """{"id":"$id","type":"$type","baseUrl":"https://x","apiKey":"k","enabled":$enabled,"$filterKey":$filter}"""
+
+    private fun doc(vararg providers: String, version: Int = 3) =
+        """{"version":$version,"updatedAt":"2026-08-04T00:00:00Z","providers":[${providers.joinToString(",")}]}"""
+
+    // --- Happy path ---
+
+    @Test
+    fun `parses a valid two-provider config with version and per-type filters`() {
+        val json = doc(
+            descriptor(id = "jewish-status", type = "supabase-category", filterKey = "categoryIds", filter = """["a","b"]"""),
+            descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music","singer"]"""),
+            version = 7,
+        )
+        val config = parseStatusSourcesConfig(json)!!
+        assertEquals(7L, config.version)
+        assertEquals(2, config.providers.size)
+        assertEquals(listOf("a", "b"), config.providersOfType(StatusProviderType.SUPABASE_CATEGORY).single().categoryIds)
+        assertEquals(listOf("music", "singer"), config.providersOfType(StatusProviderType.KEYWORD_FEED).single().musicKeywords)
+    }
+
+    // --- Non-fatal skips ---
+
+    @Test
+    fun `an unknown type is skipped but the known providers still load`() {
+        val json = doc(
+            descriptor(id = "future", type = "telegram-stories", filterKey = "categoryIds", filter = """["z"]"""),
+            descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""),
+        )
+        val config = parseStatusSourcesConfig(json)!!
+        assertEquals(listOf("yid-status"), config.providers.map { it.id })
+    }
+
+    @Test
+    fun `a disabled provider is skipped, an enabled one is kept`() {
+        val json = doc(
+            descriptor(id = "jewish-status", enabled = false),
+            descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""),
+        )
+        val config = parseStatusSourcesConfig(json)!!
+        assertEquals(listOf("yid-status"), config.providers.map { it.id })
+    }
+
+    @Test
+    fun `an enabled provider with an empty filter list is skipped`() {
+        val json = doc(
+            descriptor(id = "jewish-status", filter = "[]"),
+            descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""),
+        )
+        val config = parseStatusSourcesConfig(json)!!
+        assertEquals(listOf("yid-status"), config.providers.map { it.id })
+    }
+
+    // --- The fail-soft fork: a VALID doc is honored (even empty); only an UNOBTAINABLE one keeps last-good ---
+
+    @Test
+    fun `a valid doc with an empty usable set is honored, not treated as failure`() {
+        // All disabled, all unknown-type, and an empty array are all VALID configs -> honored (row hidden),
+        // NOT null. Null is reserved for "could not obtain a valid config" (see below).
+        val allDisabled = doc(
+            descriptor(id = "jewish-status", enabled = false),
+            descriptor(id = "yid-status", type = "keyword-feed", enabled = false, filterKey = "musicKeywords", filter = """["music"]"""),
+        )
+        val allUnknownType = doc(descriptor(id = "future", type = "telegram-stories", filter = """["z"]"""))
+        for (json in listOf(allDisabled, allUnknownType, """{"version":3,"providers":[]}""")) {
+            val config = parseStatusSourcesConfig(json)
+            assertNotNull("valid doc should be honored, not null: $json", config)
+            assertTrue("usable set should be empty: $json", config!!.providers.isEmpty())
+        }
+    }
+
+    @Test
+    fun `an unobtainable config returns null so the caller keeps its last-good`() {
+        // Structurally broken / absent -> null. The repository keeps the last-good config (or stays hidden).
+        assertNull(parseStatusSourcesConfig("not json at all"))
+        assertNull(parseStatusSourcesConfig("""{"version":3}""")) // no providers array
+        assertNull(parseStatusSourcesConfig(""))
+        assertNull(parseStatusSourcesConfig(null))
+    }
+
+    // --- Enum + cache ---
+
+    @Test
+    fun `type slug resolves known values and rejects unknown`() {
+        assertEquals(StatusProviderType.SUPABASE_CATEGORY, StatusProviderType.fromSlug("supabase-category"))
+        assertEquals(StatusProviderType.KEYWORD_FEED, StatusProviderType.fromSlug("keyword-feed"))
+        assertNull(StatusProviderType.fromSlug("telegram-stories"))
+        assertNull(StatusProviderType.fromSlug(null))
+    }
+
+    @Test
+    fun `installing a config makes it current and reports its version`() {
+        // NOTE: process-wide singleton; this test installs a config and does not assume a pristine start.
+        val installed = parseStatusSourcesConfig(
+            doc(descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""), version = 42),
+        )!!
+        StatusSourcesCache.update(installed)
+        assertEquals(42L, StatusSourcesCache.syncedVersion)
+        assertEquals(listOf("yid-status"), StatusSourcesCache.current().providers.map { it.id })
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt
@@ -15,6 +15,13 @@ import org.junit.Test
  */
 class StatusSourcesConfigTest {
 
+    @org.junit.Before
+    fun resetCache() {
+        // The cache is a process-wide singleton with a no-rollback guard; without a reset the
+        // version-dependent tests below would interfere across (arbitrary) JUnit method order.
+        StatusSourcesCache.resetForTest()
+    }
+
     private fun descriptor(
         id: String = "jewish-status",
         type: String = "supabase-category",
@@ -112,13 +119,38 @@ class StatusSourcesConfigTest {
     }
 
     @Test
+    fun `baseUrl is normalized - a trailing slash never reaches a handler`() {
+        // Handlers concatenate "$baseUrl/path"; an un-normalized trailing slash would build //rpc URLs
+        // and silently 404 the whole provider family (the config is hand-authored).
+        val json = doc(
+            """{"id":"jewish-status","type":"supabase-category","baseUrl":"https://x.supabase.co/rest/v1/","apiKey":"k","categoryIds":["a"]}""",
+        )
+        assertEquals("https://x.supabase.co/rest/v1", parseStatusSourcesConfig(json)!!.providers.single().baseUrl)
+    }
+
+    @Test
     fun `installing a config makes it current and reports its version`() {
-        // NOTE: process-wide singleton; this test installs a config and does not assume a pristine start.
         val installed = parseStatusSourcesConfig(
             doc(descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""), version = 42),
         )!!
         StatusSourcesCache.update(installed)
         assertEquals(42L, StatusSourcesCache.syncedVersion)
+        assertEquals(listOf("yid-status"), StatusSourcesCache.current().providers.map { it.id })
+    }
+
+    @Test
+    fun `update never rolls back to an older config`() {
+        // Guards the startup-restore race: a persisted older snapshot must not clobber a config a
+        // concurrent sync already installed. Same version re-installs (harmless, same content).
+        val newer = parseStatusSourcesConfig(
+            doc(descriptor(id = "yid-status", type = "keyword-feed", filterKey = "musicKeywords", filter = """["music"]"""), version = 100),
+        )!!
+        val older = parseStatusSourcesConfig(
+            doc(descriptor(id = "jewish-status"), version = 99),
+        )!!
+        StatusSourcesCache.update(newer)
+        StatusSourcesCache.update(older) // ignored
+        assertEquals(100L, StatusSourcesCache.syncedVersion)
         assertEquals(listOf("yid-status"), StatusSourcesCache.current().providers.map { it.id })
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt
@@ -13,6 +13,9 @@ import org.junit.Test
  */
 class YidStatusApiTest {
 
+    // The keyword filter is now config-driven; the tests pin the (baked-in) default set.
+    private val keywords = listOf("music", "singer", "kumzits", "simcha", "concert")
+
     @Test
     fun `parseYidCreators keeps only music categories, drops hidden creators`() {
         val json = """
@@ -26,7 +29,7 @@ class YidStatusApiTest {
               {"id":"c7","name":"Hidden","category":"Kumzits","review_hidden":true}
             ]
         """.trimIndent()
-        val creators = parseYidCreators(JSONArray(json))
+        val creators = parseYidCreators(JSONArray(json), keywords)
         // Music / Singer / Concerts / Simcha kept; Comedy + News dropped; paused/hidden dropped.
         assertEquals(listOf("c1", "c2", "c3"), creators.map { it.id })
         val c1 = creators.first()

--- a/app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
  */
 class YidStatusApiTest {
 
-    // The keyword filter is now config-driven; the tests pin the (baked-in) default set.
+    // The keyword filter is server-config-driven; the tests pin the currently-deployed set.
     private val keywords = listOf("music", "singer", "kumzits", "simcha", "concert")
 
     @Test

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (557)
+## `app` Kotlin files (559)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -10,7 +10,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 505 | `com.jtech.zemer` | no | 75 | 50 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 509 | `com.jtech.zemer` | no | 75 | 51 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2289 | `com.jtech.zemer` | no | 286 | 232 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 | `com.jtech.zemer.auth` | no | 0 | 16 |  |
@@ -20,7 +20,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 | `com.jtech.zemer.constants` | no | 2 | 14 | android.os, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 576 | `com.jtech.zemer.constants` | no | 9 | 179 | androidx.annotation, androidx.datastore, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 577 | `com.jtech.zemer.constants` | no | 9 | 179 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 | `com.jtech.zemer.constants` | no | 3 | 4 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1633 | `com.jtech.zemer.db` | no | 62 | 219 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
@@ -171,11 +171,12 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownloadsView.kt` | 30 | `com.jtech.zemer.statuses` | no | 0 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusGallery.kt` | 107 | `com.jtech.zemer.statuses` | no | 13 | 19 | android.content, android.graphics, android.net, android.os, android.provider, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSeenStore.kt` | 31 | `com.jtech.zemer.statuses` | no | 9 | 5 | android.content, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt` | 162 | `com.jtech.zemer.statuses` | no | 2 | 35 | org.json |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusText.kt` | 45 | `com.jtech.zemer.statuses` | no | 9 | 9 | android.util, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTextImage.kt` | 60 | `com.jtech.zemer.statuses` | no | 8 | 12 | android.graphics, android.text, androidx.core |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 | `com.jtech.zemer.statuses` | no | 4 | 20 | java.time, java.util |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 290 | `com.jtech.zemer.statuses` | no | 9 | 68 | java.net, kotlinx.coroutines, org.json |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 236 | `com.jtech.zemer.statuses` | no | 22 | 41 | android.content, android.os, androidx.datastore, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 293 | `com.jtech.zemer.statuses` | no | 22 | 51 | android.content, android.os, androidx.datastore, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 147 | `com.jtech.zemer.statuses` | no | 8 | 29 | java.io, java.util, okhttp3.MediaType, okhttp3.OkHttpClient, okhttp3.Request, okhttp3.RequestBody, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 | `com.jtech.zemer.sync` | no | 18 | 42 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
@@ -423,7 +424,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 | `com.jtech.zemer.utils` | no | 6 | 32 | com.google, java.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 | `com.jtech.zemer.utils` | no | 10 | 42 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 642 | `com.jtech.zemer.utils` | no | 40 | 75 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 212 | `com.jtech.zemer.utils` | no | 21 | 50 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 213 | `com.jtech.zemer.utils` | no | 21 | 50 | io.ktor, java.io, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 | `com.jtech.zemer.utils.sabr` | no | 17 | 37 | android.content, android.net, android.webkit, com.zemer, java.io, kotlin.coroutines, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 | `com.jtech.zemer.utils.sabr` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 | `com.jtech.zemer.utils.updater` | yes | 15 | 15 | androidx.activity, androidx.compose, java.io, kotlinx.coroutines |
@@ -526,6 +527,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadNamingTest.kt` | 39 | `com.jtech.zemer.statuses` | no | 3 | 2 | java.time, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadTest.kt` | 40 | `com.jtech.zemer.statuses` | no | 4 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadsViewTest.kt` | 40 | `com.jtech.zemer.statuses` | no | 2 | 3 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt` | 156 | `com.jtech.zemer.statuses` | no | 5 | 19 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 | `com.jtech.zemer.statuses` | no | 5 | 8 | java.time, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 | `com.jtech.zemer.statuses` | no | 6 | 28 | org.json, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 81 | `com.jtech.zemer.statuses` | no | 5 | 11 | org.json, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -10,7 +10,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 493 | `com.jtech.zemer` | no | 73 | 50 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 505 | `com.jtech.zemer` | no | 75 | 50 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.net, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Credentials, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2289 | `com.jtech.zemer` | no | 286 | 232 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 | `com.jtech.zemer.auth` | no | 0 | 16 |  |
@@ -20,7 +20,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 | `com.jtech.zemer.constants` | no | 2 | 14 | android.os, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 571 | `com.jtech.zemer.constants` | no | 9 | 177 | androidx.annotation, androidx.datastore, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 576 | `com.jtech.zemer.constants` | no | 9 | 179 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 | `com.jtech.zemer.constants` | no | 3 | 4 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1633 | `com.jtech.zemer.db` | no | 62 | 219 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
@@ -174,9 +174,9 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusText.kt` | 45 | `com.jtech.zemer.statuses` | no | 9 | 9 | android.util, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTextImage.kt` | 60 | `com.jtech.zemer.statuses` | no | 8 | 12 | android.graphics, android.text, androidx.core |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 | `com.jtech.zemer.statuses` | no | 4 | 20 | java.time, java.util |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 294 | `com.jtech.zemer.statuses` | no | 9 | 73 | java.net, kotlinx.coroutines, org.json |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 149 | `com.jtech.zemer.statuses` | no | 15 | 26 | android.os, java.util, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 153 | `com.jtech.zemer.statuses` | no | 8 | 32 | java.io, java.util, okhttp3.MediaType, okhttp3.OkHttpClient, okhttp3.Request, okhttp3.RequestBody, org.json |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 290 | `com.jtech.zemer.statuses` | no | 9 | 68 | java.net, kotlinx.coroutines, org.json |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 236 | `com.jtech.zemer.statuses` | no | 22 | 41 | android.content, android.os, androidx.datastore, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 147 | `com.jtech.zemer.statuses` | no | 8 | 29 | java.io, java.util, okhttp3.MediaType, okhttp3.OkHttpClient, okhttp3.Request, okhttp3.RequestBody, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 | `com.jtech.zemer.sync` | no | 18 | 42 | android.util, javax.inject, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 | `com.jtech.zemer.sync` | no | 6 | 7 | com.google, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 709 | `com.jtech.zemer.sync` | no | 39 | 103 | android.content, android.util, androidx.datastore, com.google, dagger.hilt, java.util, javax.inject, kotlinx.coroutines |
@@ -423,7 +423,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 | `com.jtech.zemer.utils` | no | 6 | 32 | com.google, java.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 | `com.jtech.zemer.utils` | no | 10 | 42 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 642 | `com.jtech.zemer.utils` | no | 40 | 75 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 185 | `com.jtech.zemer.utils` | no | 21 | 43 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 212 | `com.jtech.zemer.utils` | no | 21 | 50 | io.ktor, java.io, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 | `com.jtech.zemer.utils.sabr` | no | 17 | 37 | android.content, android.net, android.webkit, com.zemer, java.io, kotlin.coroutines, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 | `com.jtech.zemer.utils.sabr` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 | `com.jtech.zemer.utils.updater` | yes | 15 | 15 | androidx.activity, androidx.compose, java.io, kotlinx.coroutines |
@@ -528,7 +528,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadsViewTest.kt` | 40 | `com.jtech.zemer.statuses` | no | 2 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 | `com.jtech.zemer.statuses` | no | 5 | 8 | java.time, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 | `com.jtech.zemer.statuses` | no | 6 | 28 | org.json, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 78 | `com.jtech.zemer.statuses` | no | 5 | 10 | org.json, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 81 | `com.jtech.zemer.statuses` | no | 5 | 11 | org.json, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 | `com.jtech.zemer.sync` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/FlushScheduleTest.kt` | 57 | `com.jtech.zemer.tracking` | no | 2 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/LibraryActionBackfillTest.kt` | 101 | `com.jtech.zemer.tracking` | no | 9 | 10 | java.time, org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 801 lines | text `.md` |
+| `AGENTS.md` | 809 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 786 lines | text `.md` |
+| `AGENTS.md` | 801 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 786 lines | `.md` |
+| `AGENTS.md` | 801 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -169,7 +169,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 493 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 505 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2289 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 lines | `.kt` |
@@ -179,7 +179,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 571 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 576 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1633 lines | `.kt` |
@@ -333,9 +333,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusText.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTextImage.kt` | 60 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 294 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 149 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 153 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 290 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 236 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/UserPreferencesRepository.kt` | 709 lines | `.kt` |
@@ -582,7 +582,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 642 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 185 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 212 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 lines | `.kt` |
@@ -881,7 +881,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadsViewTest.kt` | 40 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 78 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/sync/ContentReportRepositoryTest.kt` | 81 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/FlushScheduleTest.kt` | 57 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/tracking/LibraryActionBackfillTest.kt` | 101 lines | `.kt` |
@@ -973,7 +973,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
 | `docs/repository-map.md` | 1181 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
-| `docs/status/README.md` | 83 lines | `.md` |
+| `docs/status/README.md` | 116 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |
 | `docs/status/yidstatus-api.md` | 238 lines | `.md` |
 | `docs/tracking/README.md` | 347 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1071`
+- Files counted: `1073`
 - By extension:
-  - `.kt`: `654`
+  - `.kt`: `656`
   - `.xml`: `178`
   - `.mjs`: `72`
   - `.md`: `68`
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 801 lines | `.md` |
+| `AGENTS.md` | 809 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -169,7 +169,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 505 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 509 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2289 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 57 lines | `.kt` |
@@ -179,7 +179,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/HistorySource.kt` | 7 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 576 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 577 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/StatPeriod.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1633 lines | `.kt` |
@@ -330,11 +330,12 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownloadsView.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusGallery.kt` | 107 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSeenStore.kt` | 31 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusSourcesConfig.kt` | 162 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusText.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTextImage.kt` | 60 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusTimeline.kt` | 76 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesApi.kt` | 290 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 236 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/statuses/StatusesRepository.kt` | 293 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/YidStatusApi.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentFilterSyncService.kt` | 347 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/sync/ContentReportRepository.kt` | 54 lines | `.kt` |
@@ -582,7 +583,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 310 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 642 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 212 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 213 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 lines | `.kt` |
@@ -879,6 +880,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadNamingTest.kt` | 39 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadTest.kt` | 40 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusDownloadsViewTest.kt` | 40 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/statuses/StatusSourcesConfigTest.kt` | 156 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusTimelineTest.kt` | 105 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/StatusesApiTest.kt` | 208 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/statuses/YidStatusApiTest.kt` | 81 lines | `.kt` |
@@ -960,7 +962,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 677 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 679 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 363 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -971,7 +973,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1181 lines | `.md` |
+| `docs/repository-map.md` | 1183 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 116 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -59,6 +59,38 @@ Notable YidStatus-only concepts to handle if integrated: an **`audio`** status t
 JewishStatus), an **`is_ad`** flag + `storyAds`/`placements` (must be filtered out for kosher content),
 and rich link-preview fields (`link_title`/`link_image_url`/...).
 
+## Server-driven source config (which categories / keywords count as "music")
+
+The per-platform "music" filter - JewishStatus's category UUIDs and YidStatus's keyword list - is **no
+longer hardcoded in the APK**. It is synced (version-gated) from the **private content mirror**,
+`GET content.zemer.io/status-sources` (+ `/status-sources/version`), so the owner can retune it, dark a
+flaky source, or add a source **without an app release**. The status *content* still comes straight from
+the third parties; only the filter *config* is centralized. Full contract:
+`handoff-docs/zemer-status-sources-config-request.md`.
+
+- **Typed descriptors.** The config is `{ version, updatedAt, providers: [ { id, type, baseUrl, apiKey,
+  categoryIds | musicKeywords, enabled } ] }`. The app has **one handler per `type`**
+  (`StatusProviderType`): `supabase-category` (JewishStatus shape, per-category + per-creator fetch) and
+  `keyword-feed` (YidStatus shape, one global feed + keyword filter). A provider of an existing `type` is
+  pure config - **no release**; a brand-new `type` is the only thing that needs an app change.
+- **Server-only, no baked-in fallback.** The mirror is the single source of truth; the values live in the
+  private mirror config, not in the APK. The app persists the last-good config (reloaded at startup) so it
+  survives restarts / offline; until a device's **first successful sync it has NO config and the row is
+  simply hidden** (fail-soft - the worst case is an absent row, never wrong content).
+- **Fail-soft, precisely.** `parseStatusSourcesConfig` returns null ONLY when a valid config cannot be
+  obtained (unreachable, the mirror's `503` for an invalid doc, non-JSON, `providers` not an array) -> the
+  caller KEEPS its last-good config (or stays hidden if none). A **valid** config is honored as-is, even
+  when its usable set is empty (every provider `enabled:false` / unknown-type / empty-filter) = an
+  intentional dark (row hidden). An unknown `type`, a disabled provider, or an enabled provider with an
+  empty filter list is **skipped non-fatally**; the others still load.
+- **Protocol details stay in the handler, not the config.** The JewishStatus R2 CDN host and the YidStatus
+  `/functions/v1/feed` path + required `Origin` header are welded to their `type`'s handler, never in a
+  descriptor (a descriptor carries only tunable data). Baked into `StatusesApi.kt` / `YidStatusApi.kt`.
+- **Where it lives.** `statuses/StatusSourcesConfig.kt` (model + parse + `StatusSourcesCache`); synced by
+  `StatusesRepository.syncStatusSources()` (version-gated, non-blocking, on the refresh path); persisted to
+  DataStore (`StatusSourcesConfigKey` / `StatusSourcesVersionKey`) and reloaded at startup in `App.kt` so
+  the last-good config survives restarts / offline. Fetch methods live on `ZemerContentClient`.
+
 ## Integration caveats (how each is handled in the app today)
 
 - **Origin gate (YidStatus).** `/functions/v1/feed` returns `403 {"error":"Forbidden"}` unless the
@@ -73,9 +105,10 @@ and rich link-preview fields (`link_title`/`link_image_url`/...).
   `review_hidden` influencers, the `storyAds`/`placements` arrays, and `audio`-type statuses (the viewer
   renders only video/image/text). None of the rest is kosher-relevant content.
 - **Music-only (YidStatus).** The feed is all-categories, so `YidStatusApi` keeps only creators whose
-  category matches the shipped keyword list `music, singer, kumzits, simcha, concert` (substring,
-  case-insensitive). **Comedy and general Entertainment are deliberately excluded** (owner decision).
-  JewishStatus is already scoped to its three music categories server-side, so it needs no such filter.
+  category matches the keyword list (substring, case-insensitive) - **server-driven** (currently `music,
+  singer, kumzits, simcha, concert`; see *Server-driven source config* above). **Comedy and general
+  Entertainment are deliberately excluded** (owner decision). JewishStatus is scoped by its category UUIDs
+  (also server-driven), so it needs no keyword filter.
 - **Client-safe keys only.** The anon/publishable keys in these docs are the same ones the platforms ship
   in their public web bundles (RLS-scoped, read-only). They are **not** secrets. Do **not** confuse them
   with a Supabase *service-role* key (never present here).

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -87,9 +87,15 @@ the third parties; only the filter *config* is centralized. Full contract:
   `/functions/v1/feed` path + required `Origin` header are welded to their `type`'s handler, never in a
   descriptor (a descriptor carries only tunable data). Baked into `StatusesApi.kt` / `YidStatusApi.kt`.
 - **Where it lives.** `statuses/StatusSourcesConfig.kt` (model + parse + `StatusSourcesCache`); synced by
-  `StatusesRepository.syncStatusSources()` (version-gated, non-blocking, on the refresh path); persisted to
-  DataStore (`StatusSourcesConfigKey` / `StatusSourcesVersionKey`) and reloaded at startup in `App.kt` so
-  the last-good config survives restarts / offline. Fetch methods live on `ZemerContentClient`.
+  `StatusesRepository.syncStatusSources()` on the status refresh path - AWAITED only for the first-ever
+  sync (a fresh install's first load runs with a real config), non-blocking after; throttled to one poll
+  per `STALE_MS` window and quiet on network failure (matches the other mirror syncs); the installed
+  version is endpoint-capped (`minOf(body, endpoint)`) so a stale CDN body can never suppress future
+  syncs; the family caches are config-version-stamped so a config change invalidates them immediately, and
+  a failed provider's previous creators are kept while sibling providers refresh (per-provider fail-soft).
+  Persisted to DataStore (`StatusSourcesConfigKey` / `StatusSourcesVersionKey` - the effective version,
+  read back at startup) and reloaded in `App.kt`; `StatusSourcesCache.update()` never rolls back to an
+  older version (restore/sync race safe). Fetch methods live on `ZemerContentClient`.
 
 ## Integration caveats (how each is handled in the app today)
 


### PR DESCRIPTION
## What

Moves the Music Status source filter (JewishStatus category UUIDs + YidStatus keyword list) out of the APK and into a **version-gated config synced from `content.zemer.io/status-sources`**, so the owner can retune categories/keywords, dark a flaky source, or add a source of an existing type **without an app release**. The status *content* still comes straight from the third parties; only the *filter config* is centralized.

Contract (settled, both sides): `ZemerTeam/handoff-docs/zemer-status-sources-config-request.md`.

## How

- **Typed provider descriptors**, one handler per `type`: `supabase-category` (JewishStatus shape) and `keyword-feed` (YidStatus shape). The two clients now take `baseUrl`/`apiKey`/filter as params; each type's **protocol details** (the R2 CDN host, the YidStatus feed path + required `Origin` header) stay welded into their handler, never in a descriptor.
- **Server-only, no baked-in fallback.** The mirror is the single source of truth. The last-good config is persisted and reloaded at startup; until a device's first successful sync the feature is simply **hidden** (fail-soft, never wrong content).
- **Fail-soft parse.** Returns null only when a valid config can't be obtained (unreachable / `503` / non-JSON / no `providers` array) → caller keeps last-good (or stays hidden). A **valid** config is honored as-is even when its usable set is empty (all `enabled:false` / unknown-type / empty-filter = intentional dark). Unknown `type` / disabled / empty-filter providers are skipped non-fatally, so a new-type descriptor can ship in config before its handler.
- **Version-gated sync** runs non-blocking on the status refresh path (applies to the next load); adds `StatusSourcesConfigKey`/`StatusSourcesVersionKey` + `status-sources` fetch methods on `ZemerContentClient`; reloaded at startup in `App.kt`.
- Supports **N providers per type** (iterate + merge + dedupe), so adding a provider of an existing type is config-only.

## Verification

- New `StatusSourcesConfigTest` (8) covers the parse + fail-soft fork; `YidStatusApiTest` (3) updated for the config-driven keyword param; `StatusesApiTest` (12) unchanged and green. `:app:testDebugUnitTest --tests 'com.jtech.zemer.statuses.*'` passes.
- Parses cleanly against the **deployed v1** endpoint (`/status-sources` + `/status-sources/version`).
- `assembleDebug` builds; `ui-audit.sh` passes; docs regenerated.

## Note

The `StatusSource` enum stays as the two handler families, so a newly-added provider of an existing type flows into the Home row and that family's See-all section immediately (no release); it just won't get its own separately-labeled See-all section without a future tweak.