### PR TITLE
feat(home): Videos-tab ranked rows from /video-home-rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,6 +362,14 @@ that removes a tab (a persisted PODCASTS selection falls back to MUSIC); VIDEO i
 from ONE async DataStore snapshot reading the tab AND Block Podcasts together (null until it lands, one
 frame of background) — never a main-thread `dataStore[key]` read in composition, never a flash of Music
 or of a blocked Podcasts tab. R22 (the MUSIC-gated shimmer) rides this selector — see §Loading skeletons.
+The **Videos tab's ranked rows** (`/video-home-rows` → Trending Videos / New Videos / Top Video Artists;
+handoff `zemer-app-video-home-rows-request.md`) ride the isolated fail-soft `VideoHomeRowsViewModel`
+(PodcastHomeRows pattern, see-all via `VideoHomeSeeAllStore`): an absent endpoint leaves the tab on its
+`topVideos` lead row. Direct plays declare `PlaySource.HOME_VIDEO_TRENDING`/`HOME_VIDEO_NEW` and the rows
+emit impressions on the matching `home:video-*` surfaces (append-only tracking contract:
+`zemer-app-video-home-rows-tracking-request.md`); the artists row needs neither (its plays attribute
+`artist:UC…` from the artist page). Blocked-video users get both video rows relabeled + audio-gated,
+never hidden, like every video shelf.
 
 **Project direction (a real, ongoing goal):** progressively **replace as much InnerTube as we can across
 the app** with Zemer-served, whitelist-pure data. The home tab migrated first; since then **artist opens

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -392,6 +392,27 @@ object ZemerResultMapper {
             trendingEpisodes = resp.trendingEpisodes.toEpisodeItems(),
         )
 
+    data class VideoHomeRows(
+        val trending: List<SongItem>,
+        val newVideos: List<SongItem>,
+        val artists: List<ArtistItem>,
+    )
+
+    /**
+     * The `/video-home-rows` rows as the item types the Videos tab already renders. Both track rows are
+     * video-classified (`isVideo = true` — the badge/menu/toggle flag, set once at this mapper boundary);
+     * `hideExplicit = false` matches the `/home-rows` topVideos treatment. Blocked-id overrides run
+     * inside [songItems]; artists drop blank ids like every artist row.
+     */
+    fun videoHomeRows(resp: ZemerVideoHomeRowsResponse): VideoHomeRows =
+        VideoHomeRows(
+            trending = songItems(resp.trendingVideos, hideExplicit = false, isVideo = true),
+            newVideos = songItems(resp.newVideos, hideExplicit = false, isVideo = true),
+            artists = resp.topVideoArtists.filter { it.id.isNotBlank() }
+                .map { it.toArtistItem() }
+                .distinctBy { it.id },
+        )
+
     /**
      * A `/podcast` response as the [PodcastPage] the SHOW screen already consumes. Null when the header
      * is missing (treated as a 404 → the screen backs out). `continuation` carries the server's

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -410,7 +410,8 @@ object ZemerResultMapper {
             newVideos = songItems(resp.newVideos, hideExplicit = false, isVideo = true),
             artists = resp.topVideoArtists.filter { it.id.isNotBlank() }
                 .map { it.toArtistItem() }
-                .distinctBy { it.id },
+                .distinctBy { it.id }
+                .dropBlocked(),
         )
 
     /**

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt
@@ -561,6 +561,24 @@ class ZemerSearchClient @Inject constructor() {
         return zemerResponseJson.decodeFromString(ZemerPodcastHomeRowsResponse.serializer(), response.bodyAsText())
     }
 
+    /**
+     * `GET /video-home-rows` — the Videos tab's ranked rows (live-only, like `/podcast-home-rows`).
+     * Throws on any non-2xx (including 404 while the endpoint is not yet deployed); the ViewModel is
+     * fail-soft, so the tab just keeps its lead row.
+     */
+    suspend fun videoHomeRows(
+        allowFemale: Boolean,
+        blockVideos: Boolean,
+    ): ZemerVideoHomeRowsResponse {
+        val response: HttpResponse = client.get("$BASE_URL/video-home-rows") {
+            applyParams(zemerContentFlagParameters(allowFemale, blockVideos, includeKidZone = true))
+        }
+        if (!response.status.isSuccess()) {
+            throw IOException("Zemer video-home-rows returned HTTP ${response.status.value}")
+        }
+        return zemerResponseJson.decodeFromString(ZemerVideoHomeRowsResponse.serializer(), response.bodyAsText())
+    }
+
     companion object {
         const val BASE_URL = "https://search.zemer.io"
         private const val REQUEST_TIMEOUT_MS = 8_000L

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -386,3 +386,19 @@ data class ZemerPodcastHomeRowsResponse(
     val topPodcasts: List<ZemerPodcastShow> = emptyList(),
     val trendingEpisodes: List<ZemerPodcastEpisode> = emptyList(),
 )
+
+/**
+ * Wire model for `GET /video-home-rows` (handoff `zemer-app-video-home-rows-request.md`) — the Videos
+ * tab's ranked rows beyond the `topVideos` lead row `/home-rows` already serves. Reuses the exact
+ * `/home-rows` row shapes so the existing mappers work unchanged. Every list defaults empty (each row
+ * is independently fail-soft; the endpoint being absent hides all three).
+ */
+@Serializable
+data class ZemerVideoHomeRowsResponse(
+    /** 14d completion-weighted distinct-device reach — deliberately shorter than topVideos' 30d. */
+    val trendingVideos: List<ZemerTrack> = emptyList(),
+    /** Newest corpus video releases (no telemetry — new videos have no other home surface). */
+    val newVideos: List<ZemerTrack> = emptyList(),
+    /** Artists ranked by distinct-device video listening; cards open the artist page. */
+    val topVideoArtists: List<ZemerArtist> = emptyList(),
+)

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt
@@ -232,6 +232,10 @@ class ZemerSearchRepository @Inject constructor(
     suspend fun podcastHomeRows(options: ZemerSearchOptions): ZemerResultMapper.PodcastHomeRows =
         ZemerResultMapper.podcastHomeRows(client.podcastHomeRows(options.allowFemale, options.blockVideos))
 
+    /** The Videos tab's ranked rows. Live-only like [podcastHomeRows]; throws on failure (fail-soft VM). */
+    suspend fun videoHomeRows(options: ZemerSearchOptions): ZemerResultMapper.VideoHomeRows =
+        ZemerResultMapper.videoHomeRows(client.videoHomeRows(options.allowFemale, options.blockVideos))
+
     /** Latest episodes across all whitelisted shows (Library New Episodes), newest-first. */
     suspend fun podcastsNewEpisodes(k: Int, options: ZemerSearchOptions): List<EpisodeItem> =
         serverOrOffline(

--- a/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt
@@ -30,6 +30,11 @@ object PlaySource {
      * per-show aggregation into phantom one-episode shows.
      */
     fun podcast(id: String?) = if (id.isNullOrBlank()) "podcast" else "podcast:$id"
+
+    // Direct plays from the Videos-tab ranked rows (append-only, contract:
+    // handoff zemer-app-video-home-rows-tracking-request.md — the New -> Trending funnel).
+    const val HOME_VIDEO_TRENDING = "home:video-trending"
+    const val HOME_VIDEO_NEW = "home:video-new"
 }
 
 /**

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -1064,168 +1064,56 @@ fun HomeScreen(
             } // end MUSIC (part 2)
 
             if (homeTab == HomeContentTab.VIDEO) {
-            // Shown to blocked-video users too — the rows play audio-first, so for them the shelf is
+            // Shown to blocked-video users too — the rows play audio-first, so for them each shelf is
             // simply their "video songs" (relabelled, watch/download-video affordances gated off).
-            if (featuredVideos.isNotEmpty()) {
-                item(key = "featured_videos_title", contentType = "header") {
-                    NavigationTitle(
-                        title = stringResource(
-                            if (blockVideos) R.string.featured_video_songs else R.string.featured_videos
-                        ),
-                        onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.FEATURED_VIDEOS.slug}") },
-                        modifier = Modifier.animateItem()
-                    )
-                }
+            videoSongsRow(
+                row = HomeSeeAllRow.FEATURED_VIDEOS,
+                keyPrefix = "featured_videos",
+                surface = TrackingSurface.home("featured-videos"),
+                playSource = null, // resolver default — the pre-rows attribution, unchanged
+                videos = uniqueFeaturedVideos,
+                blockVideos = blockVideos,
+                parentListState = lazylistState,
+                navController = navController,
+                playerConnection = playerConnection,
+                menuState = menuState,
+                haptic = haptic,
+                scope = scope,
+                mediaMetadata = mediaMetadata,
+                isPlaying = isPlaying,
+            )
 
-                item(key = "featured_videos_list", contentType = "grid") {
-                    val featuredVideosRowState = rememberLazyListState()
-                    TrackImpressionsByKey(
-                        surface = TrackingSurface.home("featured-videos"),
-                        state = featuredVideosRowState,
-                        parent = lazylistState,
-                        parentKey = "featured_videos_list",
-                        idOfKey = rememberRowImpressionIds(uniqueFeaturedVideos) { it.id },
-                    )
-                    LazyRow(
-                        state = featuredVideosRowState,
-                        contentPadding = WindowInsets.systemBars
-                            .only(WindowInsetsSides.Horizontal)
-                            .asPaddingValues(),
-                        modifier = Modifier.animateItem()
-                    ) {
-                        items(
-                            items = uniqueFeaturedVideos,
-                            // Keyed by the plain videoId (unique — the list is distinctBy id), so
-                            // the row's key IS its impression id and the two cannot drift.
-                            key = { it.id },
-                            contentType = { "video" }
-                        ) { video ->
-                            YouTubeGridItem(
-                                item = video,
-                                isActive = mediaMetadata?.id == video.id,
-                                isPlaying = isPlaying,
-                                coroutineScope = scope,
-                                // Square (1f) to match the artist screen's video sections: a center
-                                // crop hides most of the title text YouTube bakes into the 16:9 video
-                                // thumbnail, which is illegible behind the card. See issue #84.
-                                thumbnailRatio = 1f,
-                                // All-videos row, already labelled "Video Songs" — the per-card badge
-                                // is redundant and would crowd the subtitle onto a second line.
-                                showVideoBadge = false,
-                                modifier = Modifier
-                                    .combinedClickable(
-                                        onClick = {
-                                            // Audio-first always (I2); video is a per-play in-player toggle, not an entry point (D3).
-                                            playerConnection.playQueue(
-                                                ZemerRadioQueue.song(video.toMediaMetadata(), playerConnection.service)
-                                            )
-                                        },
-                                        onLongClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            menuState.show {
-                                                YouTubeSongMenu(
-                                                    song = video,
-                                                    navController = navController,
-                                                    onDismiss = menuState::dismiss,
-                                                    // Audio menu (no video download/share) when blocked.
-                                                    isVideo = video.isVideo && !blockVideos,
-                                                )
-                                            }
-                                        }
-                                    )
-                                    .animateItem()
-                            )
-                        }
-                    }
-                }
-            }
-
-            // The ranked rows (/video-home-rows): one builder for both video-song rows — same card,
-            // audio-first tap with the row's declared source, audio-gated menu, per-row impressions.
-            fun rankedVideoRow(
-                keyPrefix: String,
-                @StringRes titleRes: Int,
-                @StringRes blockedTitleRes: Int,
-                seeAll: HomeSeeAllRow,
-                surface: String,
-                playSource: String,
-                videos: List<SongItem>,
-            ) {
-                if (videos.isEmpty()) return
-                item(key = "${keyPrefix}_title", contentType = "header") {
-                    NavigationTitle(
-                        title = stringResource(if (blockVideos) blockedTitleRes else titleRes),
-                        onClick = { navController.navigate("home_see_all/${seeAll.slug}") },
-                        modifier = Modifier.animateItem()
-                    )
-                }
-                item(key = "${keyPrefix}_list", contentType = "grid") {
-                    val rowState = rememberLazyListState()
-                    TrackImpressionsByKey(
-                        surface = surface,
-                        state = rowState,
-                        parent = lazylistState,
-                        parentKey = "${keyPrefix}_list",
-                        idOfKey = rememberRowImpressionIds(videos) { it.id },
-                    )
-                    LazyRow(
-                        state = rowState,
-                        contentPadding = WindowInsets.systemBars
-                            .only(WindowInsetsSides.Horizontal)
-                            .asPaddingValues(),
-                        modifier = Modifier.animateItem()
-                    ) {
-                        items(items = videos, key = { it.id }, contentType = { "video" }) { video ->
-                            YouTubeGridItem(
-                                item = video,
-                                isActive = mediaMetadata?.id == video.id,
-                                isPlaying = isPlaying,
-                                coroutineScope = scope,
-                                // Square crop + no badge, matching the Featured video songs row.
-                                thumbnailRatio = 1f,
-                                showVideoBadge = false,
-                                modifier = Modifier
-                                    .combinedClickable(
-                                        onClick = {
-                                            playerConnection.playQueue(
-                                                ZemerRadioQueue.song(video.toMediaMetadata(), playerConnection.service, playSource)
-                                            )
-                                        },
-                                        onLongClick = {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            menuState.show {
-                                                YouTubeSongMenu(
-                                                    song = video,
-                                                    navController = navController,
-                                                    onDismiss = menuState::dismiss,
-                                                    isVideo = video.isVideo && !blockVideos,
-                                                )
-                                            }
-                                        }
-                                    )
-                                    .animateItem()
-                            )
-                        }
-                    }
-                }
-            }
-            rankedVideoRow(
+            videoSongsRow(
+                row = HomeSeeAllRow.TRENDING_VIDEOS,
                 keyPrefix = "trending_videos",
-                titleRes = R.string.trending_videos,
-                blockedTitleRes = R.string.trending_video_songs,
-                seeAll = HomeSeeAllRow.TRENDING_VIDEOS,
                 surface = TrackingSurface.home("video-trending"),
                 playSource = PlaySource.HOME_VIDEO_TRENDING,
                 videos = uniqueTrendingVideos,
+                blockVideos = blockVideos,
+                parentListState = lazylistState,
+                navController = navController,
+                playerConnection = playerConnection,
+                menuState = menuState,
+                haptic = haptic,
+                scope = scope,
+                mediaMetadata = mediaMetadata,
+                isPlaying = isPlaying,
             )
-            rankedVideoRow(
+            videoSongsRow(
+                row = HomeSeeAllRow.NEW_VIDEOS,
                 keyPrefix = "new_videos",
-                titleRes = R.string.new_videos,
-                blockedTitleRes = R.string.new_video_songs,
-                seeAll = HomeSeeAllRow.NEW_VIDEOS,
                 surface = TrackingSurface.home("video-new"),
                 playSource = PlaySource.HOME_VIDEO_NEW,
                 videos = uniqueNewVideos,
+                blockVideos = blockVideos,
+                parentListState = lazylistState,
+                navController = navController,
+                playerConnection = playerConnection,
+                menuState = menuState,
+                haptic = haptic,
+                scope = scope,
+                mediaMetadata = mediaMetadata,
+                isPlaying = isPlaying,
             )
 
             // Top Video Artists: cards open the artist page, so plays attribute artist:UC… — no
@@ -1530,6 +1418,96 @@ private fun <T : YTItem> LazyListScope.podcastHomeRow(
                             onLongClick = onLongClick?.let { open -> { open(item) } },
                         )
                         .animateItem(),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One video-song home row — Featured / Trending / New all render through this single definition:
+ * relabel-aware title from [HomeSeeAllRow.displayTitleRes] + the see-all arrow, strict per-row
+ * impressions on [surface], square badge-less video cards (center crop hides the baked-in 16:9 title
+ * text, issue #84), audio-first taps declaring [playSource] (null = the resolver default), and
+ * long-press menus audio-gated when videos are blocked. Extracted so an impression or gating fix can
+ * never land in one copy and miss another.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+private fun LazyListScope.videoSongsRow(
+    row: HomeSeeAllRow,
+    keyPrefix: String,
+    surface: String,
+    playSource: String?,
+    videos: List<SongItem>,
+    blockVideos: Boolean,
+    parentListState: androidx.compose.foundation.lazy.LazyListState,
+    navController: NavController,
+    playerConnection: com.jtech.zemer.playback.PlayerConnection,
+    menuState: com.jtech.zemer.ui.component.MenuState,
+    haptic: androidx.compose.ui.hapticfeedback.HapticFeedback,
+    scope: CoroutineScope,
+    mediaMetadata: com.jtech.zemer.models.MediaMetadata?,
+    isPlaying: Boolean,
+) {
+    if (videos.isEmpty()) return
+    item(key = "${keyPrefix}_title", contentType = "header") {
+        NavigationTitle(
+            title = stringResource(row.displayTitleRes(blockVideos)),
+            onClick = { navController.navigate("home_see_all/${row.slug}") },
+            modifier = Modifier.animateItem()
+        )
+    }
+    item(key = "${keyPrefix}_list", contentType = "grid") {
+        val rowState = rememberLazyListState()
+        TrackImpressionsByKey(
+            surface = surface,
+            state = rowState,
+            parent = parentListState,
+            parentKey = "${keyPrefix}_list",
+            // Keyed by the plain videoId (unique — lists are distinctBy id), so the row's key IS its
+            // impression id and the two cannot drift.
+            idOfKey = rememberRowImpressionIds(videos) { it.id },
+        )
+        LazyRow(
+            state = rowState,
+            contentPadding = WindowInsets.systemBars
+                .only(WindowInsetsSides.Horizontal)
+                .asPaddingValues(),
+            modifier = Modifier.animateItem()
+        ) {
+            items(items = videos, key = { it.id }, contentType = { "video" }) { video ->
+                YouTubeGridItem(
+                    item = video,
+                    isActive = mediaMetadata?.id == video.id,
+                    isPlaying = isPlaying,
+                    coroutineScope = scope,
+                    thumbnailRatio = 1f,
+                    showVideoBadge = false,
+                    modifier = Modifier
+                        .combinedClickable(
+                            onClick = {
+                                // Audio-first always (I2); video is a per-play in-player toggle (D3).
+                                playerConnection.playQueue(
+                                    if (playSource != null) {
+                                        ZemerRadioQueue.song(video.toMediaMetadata(), playerConnection.service, playSource)
+                                    } else {
+                                        ZemerRadioQueue.song(video.toMediaMetadata(), playerConnection.service)
+                                    }
+                                )
+                            },
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                menuState.show {
+                                    YouTubeSongMenu(
+                                        song = video,
+                                        navController = navController,
+                                        onDismiss = menuState::dismiss,
+                                        isVideo = video.isVideo && !blockVideos,
+                                    )
+                                }
+                            }
+                        )
+                        .animateItem()
                 )
             }
         }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -131,6 +131,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.jtech.zemer.viewmodels.STATION_ROW_REFRESH_MS
 import com.jtech.zemer.viewmodels.ZemerGenresViewModel
 import com.jtech.zemer.viewmodels.PodcastHomeRowsViewModel
+import com.jtech.zemer.viewmodels.VideoHomeRowsViewModel
 import com.jtech.zemer.viewmodels.PodcastSubscriptionsHomeViewModel
 import com.jtech.zemer.viewmodels.ZemerStatusesViewModel
 import com.jtech.zemer.viewmodels.ZemerStationsViewModel
@@ -195,6 +196,12 @@ fun HomeScreen(
     val featuredPodcasts by podcastHomeRowsViewModel.featured.collectAsState()
     val topPodcasts by podcastHomeRowsViewModel.topPodcasts.collectAsState()
     val trendingEpisodes by podcastHomeRowsViewModel.trendingEpisodes.collectAsState()
+    // The Videos tab's ranked rows — isolated fail-soft VM (empty rows hide; the /video-home-rows
+    // endpoint being absent leaves the tab on its topVideos lead row alone).
+    val videoHomeRowsViewModel: VideoHomeRowsViewModel = hiltViewModel()
+    val trendingVideos by videoHomeRowsViewModel.trending.collectAsState()
+    val newVideos by videoHomeRowsViewModel.newVideos.collectAsState()
+    val topVideoArtists by videoHomeRowsViewModel.artists.collectAsState()
     // Subscription-driven podcast rows (New Episodes + Subscribed Channels) — LOCAL sources, so identical
     // for anon + Google login. Own isolated fail-soft VM; each row hides when empty.
     val podcastSubscriptionsViewModel: PodcastSubscriptionsHomeViewModel = hiltViewModel()
@@ -233,6 +240,7 @@ fun HomeScreen(
         zemerGenresViewModel.refresh()
         podcastGenresHomeViewModel.refresh()
         podcastHomeRowsViewModel.refresh()
+        videoHomeRowsViewModel.refresh()
         podcastSubscriptionsViewModel.fetchNewEpisodes()
         zemerStatusesViewModel.refresh()
     }
@@ -283,6 +291,9 @@ fun HomeScreen(
     val uniqueFeaturedArtists = remember(featuredArtists) { featuredArtists.distinctBy { it.id } }
     val uniqueFeaturedAlbums = remember(featuredAlbums) { featuredAlbums.distinctBy { it.id } }
     val uniqueFeaturedVideos = remember(featuredVideos) { featuredVideos.distinctBy { it.id } }
+    val uniqueTrendingVideos = remember(trendingVideos) { trendingVideos.distinctBy { it.id } }
+    val uniqueNewVideos = remember(newVideos) { newVideos.distinctBy { it.id } }
+    val uniqueTopVideoArtists = remember(topVideoArtists) { topVideoArtists.distinctBy { it.id } }
 
     val isLoading: Boolean = homeUiState.isLoading
     val isRefreshing = homeUiState.isRefreshing
@@ -503,6 +514,7 @@ fun HomeScreen(
                     zemerGenresViewModel.refresh()
                     podcastGenresHomeViewModel.refresh()
                     podcastHomeRowsViewModel.refresh()
+                    videoHomeRowsViewModel.refresh()
                     podcastSubscriptionsViewModel.fetchNewEpisodes()
                     zemerStatusesViewModel.refresh(force = true) // pull-to-refresh always re-fetches
                 }
@@ -1123,6 +1135,122 @@ fun HomeScreen(
                                     )
                                     .animateItem()
                             )
+                        }
+                    }
+                }
+            }
+
+            // The ranked rows (/video-home-rows): one builder for both video-song rows — same card,
+            // audio-first tap with the row's declared source, audio-gated menu, per-row impressions.
+            fun rankedVideoRow(
+                keyPrefix: String,
+                @StringRes titleRes: Int,
+                @StringRes blockedTitleRes: Int,
+                seeAll: HomeSeeAllRow,
+                surface: String,
+                playSource: String,
+                videos: List<SongItem>,
+            ) {
+                if (videos.isEmpty()) return
+                item(key = "${keyPrefix}_title", contentType = "header") {
+                    NavigationTitle(
+                        title = stringResource(if (blockVideos) blockedTitleRes else titleRes),
+                        onClick = { navController.navigate("home_see_all/${seeAll.slug}") },
+                        modifier = Modifier.animateItem()
+                    )
+                }
+                item(key = "${keyPrefix}_list", contentType = "grid") {
+                    val rowState = rememberLazyListState()
+                    TrackImpressionsByKey(
+                        surface = surface,
+                        state = rowState,
+                        parent = lazylistState,
+                        parentKey = "${keyPrefix}_list",
+                        idOfKey = rememberRowImpressionIds(videos) { it.id },
+                    )
+                    LazyRow(
+                        state = rowState,
+                        contentPadding = WindowInsets.systemBars
+                            .only(WindowInsetsSides.Horizontal)
+                            .asPaddingValues(),
+                        modifier = Modifier.animateItem()
+                    ) {
+                        items(items = videos, key = { it.id }, contentType = { "video" }) { video ->
+                            YouTubeGridItem(
+                                item = video,
+                                isActive = mediaMetadata?.id == video.id,
+                                isPlaying = isPlaying,
+                                coroutineScope = scope,
+                                // Square crop + no badge, matching the Featured video songs row.
+                                thumbnailRatio = 1f,
+                                showVideoBadge = false,
+                                modifier = Modifier
+                                    .combinedClickable(
+                                        onClick = {
+                                            playerConnection.playQueue(
+                                                ZemerRadioQueue.song(video.toMediaMetadata(), playerConnection.service, playSource)
+                                            )
+                                        },
+                                        onLongClick = {
+                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                            menuState.show {
+                                                YouTubeSongMenu(
+                                                    song = video,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss,
+                                                    isVideo = video.isVideo && !blockVideos,
+                                                )
+                                            }
+                                        }
+                                    )
+                                    .animateItem()
+                            )
+                        }
+                    }
+                }
+            }
+            rankedVideoRow(
+                keyPrefix = "trending_videos",
+                titleRes = R.string.trending_videos,
+                blockedTitleRes = R.string.trending_video_songs,
+                seeAll = HomeSeeAllRow.TRENDING_VIDEOS,
+                surface = TrackingSurface.home("video-trending"),
+                playSource = PlaySource.HOME_VIDEO_TRENDING,
+                videos = uniqueTrendingVideos,
+            )
+            rankedVideoRow(
+                keyPrefix = "new_videos",
+                titleRes = R.string.new_videos,
+                blockedTitleRes = R.string.new_video_songs,
+                seeAll = HomeSeeAllRow.NEW_VIDEOS,
+                surface = TrackingSurface.home("video-new"),
+                playSource = PlaySource.HOME_VIDEO_NEW,
+                videos = uniqueNewVideos,
+            )
+
+            // Top Video Artists: cards open the artist page, so plays attribute artist:UC… — no
+            // per-row source or impressions needed (contract: the tracking handoff).
+            if (uniqueTopVideoArtists.isNotEmpty()) {
+                item(key = "top_video_artists_title", contentType = "header") {
+                    NavigationTitle(
+                        title = stringResource(R.string.top_video_artists),
+                        onClick = { navController.navigate("home_see_all/${HomeSeeAllRow.TOP_VIDEO_ARTISTS.slug}") },
+                        modifier = Modifier.animateItem()
+                    )
+                }
+                item(key = "top_video_artists_list", contentType = "grid") {
+                    LazyRow(
+                        contentPadding = WindowInsets.systemBars
+                            .only(WindowInsetsSides.Horizontal)
+                            .asPaddingValues(),
+                        modifier = Modifier.animateItem()
+                    ) {
+                        items(
+                            items = uniqueTopVideoArtists,
+                            key = { "top_video_artist_${it.id}" },
+                            contentType = { "artist" }
+                        ) { artist ->
+                            ytGridItem(artist)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -67,6 +67,7 @@ import com.jtech.zemer.utils.rememberPreference
 import com.jtech.zemer.viewmodels.HomeSeeAllRow
 import com.jtech.zemer.viewmodels.HomeSeeAllStore
 import com.jtech.zemer.viewmodels.PodcastHomeSeeAllStore
+import com.jtech.zemer.viewmodels.VideoHomeSeeAllStore
 
 /**
  * The generic "See all" page for a Home row: the row's full, already-filtered list as a vertical page
@@ -87,6 +88,7 @@ fun HomeSeeAllScreen(
 ) {
     val data by HomeSeeAllStore.data.collectAsState()
     val podcastData by PodcastHomeSeeAllStore.data.collectAsState()
+    val videoData by VideoHomeSeeAllStore.data.collectAsState()
     val (blockVideos, _) = rememberPreference(BlockVideosKey, false)
 
     val rowIsEmpty = when (row) {
@@ -101,6 +103,9 @@ fun HomeSeeAllScreen(
         HomeSeeAllRow.TOP_PODCASTS -> podcastData.topPodcasts.isEmpty()
         HomeSeeAllRow.TRENDING_EPISODES -> podcastData.trendingEpisodes.isEmpty()
         HomeSeeAllRow.SUBSCRIBED_CHANNELS -> podcastData.subscribedChannels.isEmpty()
+        HomeSeeAllRow.TRENDING_VIDEOS -> videoData.trending.isEmpty()
+        HomeSeeAllRow.NEW_VIDEOS -> videoData.newVideos.isEmpty()
+        HomeSeeAllRow.TOP_VIDEO_ARTISTS -> videoData.artists.isEmpty()
     }
 
     if (rowIsEmpty) {
@@ -127,6 +132,10 @@ fun HomeSeeAllScreen(
             HomeSeeAllRow.TOP_PODCASTS -> YtItemGrid(podcastData.topPodcasts, navController, podcastChannelFirst = true)
             HomeSeeAllRow.TRENDING_EPISODES -> YtItemGrid(podcastData.trendingEpisodes, navController)
             HomeSeeAllRow.SUBSCRIBED_CHANNELS -> YtItemGrid(podcastData.subscribedChannels, navController, podcastChannelFirst = true)
+            // Videos-tab rows: video-song grids match the Featured Videos treatment (no badge).
+            HomeSeeAllRow.TRENDING_VIDEOS -> YtItemGrid(videoData.trending, navController, showVideoBadge = false)
+            HomeSeeAllRow.NEW_VIDEOS -> YtItemGrid(videoData.newVideos, navController, showVideoBadge = false)
+            HomeSeeAllRow.TOP_VIDEO_ARTISTS -> YtItemGrid(videoData.artists, navController)
         }
     }
 
@@ -135,8 +144,12 @@ fun HomeSeeAllScreen(
         title = {
             AppBarTitle(
                 stringResource(
-                    if (row == HomeSeeAllRow.FEATURED_VIDEOS && blockVideos) R.string.featured_video_songs
-                    else row.titleRes
+                    when {
+                        row == HomeSeeAllRow.FEATURED_VIDEOS && blockVideos -> R.string.featured_video_songs
+                        row == HomeSeeAllRow.TRENDING_VIDEOS && blockVideos -> R.string.trending_video_songs
+                        row == HomeSeeAllRow.NEW_VIDEOS && blockVideos -> R.string.new_video_songs
+                        else -> row.titleRes
+                    }
                 )
             )
         },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -144,12 +144,8 @@ fun HomeSeeAllScreen(
         title = {
             AppBarTitle(
                 stringResource(
-                    when {
-                        row == HomeSeeAllRow.FEATURED_VIDEOS && blockVideos -> R.string.featured_video_songs
-                        row == HomeSeeAllRow.TRENDING_VIDEOS && blockVideos -> R.string.trending_video_songs
-                        row == HomeSeeAllRow.NEW_VIDEOS && blockVideos -> R.string.new_video_songs
-                        else -> row.titleRes
-                    }
+                    // ONE relabel definition: HomeSeeAllRow.displayTitleRes, shared with the Home rows.
+                    row.displayTitleRes(blockVideos)
                 )
             )
         },

--- a/app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt
@@ -1,0 +1,32 @@
+package com.jtech.zemer.utils
+
+/**
+ * The client-side content gate for TELEMETRY-RANKED rows: female (when blocked) + Israeli + kids-only
+ * — deliberately NOT the famous/american quality proxy (applying it cut the ranked rows to near-empty;
+ * see AGENTS §home tab). These exclusions have no wire flag, so EVERY ranked surface must apply them
+ * client-side. One definition, shared by [com.jtech.zemer.viewmodels.HomeViewModel] (whitelist-doc
+ * profiles) and [com.jtech.zemer.viewmodels.VideoHomeRowsViewModel] ([WhitelistCache] entries) via the
+ * injected [flagsOf] lookup — the rule itself can't drift between them. Pure and JVM-tested.
+ */
+object RankedContentGate {
+
+    data class Flags(val isFemale: Boolean, val isKids: Boolean)
+
+    /**
+     * Whether an item credited to [ids] is excluded from a ranked row. Unknown ids contribute no
+     * flags (fail-open on the female/kids checks — matching the pre-extraction behavior when a
+     * profile was missing); the Israeli check needs only the id.
+     */
+    fun isBlockedRanked(
+        ids: List<String>,
+        allowFemale: Boolean,
+        flagsOf: (String) -> Flags?,
+        isIsraeli: (String) -> Boolean = IsraeliArtistRegistry::isIsraeli,
+    ): Boolean {
+        if (ids.any(isIsraeli)) return true
+        val flags = ids.mapNotNull(flagsOf)
+        if (!allowFemale && flags.any { it.isFemale }) return true
+        if (flags.any { it.isKids }) return true
+        return false
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
@@ -20,10 +20,16 @@ import kotlinx.coroutines.flow.update
  * and [titleRes] reuses the Home section's own title string, so the See-all header always matches the
  * row it opened from.
  */
-enum class HomeSeeAllRow(val slug: String, @StringRes val titleRes: Int) {
+enum class HomeSeeAllRow(
+    val slug: String,
+    @StringRes val titleRes: Int,
+    // The blocked-video relabel ("... video songs"), when the row has one. ONE definition consumed by
+    // BOTH the Home row title and the See-all page title, so the relabel can never split between them.
+    @StringRes val blockedTitleRes: Int? = null,
+) {
     FEATURED_ALBUMS("featured-albums", R.string.featured_albums),
     FEATURED_ARTISTS("featured-artists", R.string.featured_artists),
-    FEATURED_VIDEOS("featured-videos", R.string.featured_videos),
+    FEATURED_VIDEOS("featured-videos", R.string.featured_videos, R.string.featured_video_songs),
     FEATURED_PLAYLISTS("featured-playlists", R.string.featured_playlists),
     KEEP_LISTENING("keep-listening", R.string.keep_listening),
     FORGOTTEN_FAVORITES("forgotten-favorites", R.string.forgotten_favorites),
@@ -34,10 +40,15 @@ enum class HomeSeeAllRow(val slug: String, @StringRes val titleRes: Int) {
     TRENDING_EPISODES("trending-episodes", R.string.trending_episodes),
     SUBSCRIBED_CHANNELS("subscribed-channels", R.string.subscribed_channels),
     // Videos-tab ranked rows (backed by [VideoHomeSeeAllStore]).
-    TRENDING_VIDEOS("trending-videos", R.string.trending_videos),
-    NEW_VIDEOS("new-videos", R.string.new_videos),
+    TRENDING_VIDEOS("trending-videos", R.string.trending_videos, R.string.trending_video_songs),
+    NEW_VIDEOS("new-videos", R.string.new_videos, R.string.new_video_songs),
     TOP_VIDEO_ARTISTS("top-video-artists", R.string.top_video_artists),
     ;
+
+    /** The row title under the current video flag - the relabel rows resolve here, everything else passes through. */
+    @StringRes
+    fun displayTitleRes(blockVideos: Boolean): Int =
+        if (blockVideos) blockedTitleRes ?: titleRes else titleRes
 
     companion object {
         fun fromSlug(slug: String?): HomeSeeAllRow? = entries.firstOrNull { it.slug == slug }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt
@@ -33,6 +33,10 @@ enum class HomeSeeAllRow(val slug: String, @StringRes val titleRes: Int) {
     TOP_PODCASTS("top-podcasts", R.string.top_podcasts),
     TRENDING_EPISODES("trending-episodes", R.string.trending_episodes),
     SUBSCRIBED_CHANNELS("subscribed-channels", R.string.subscribed_channels),
+    // Videos-tab ranked rows (backed by [VideoHomeSeeAllStore]).
+    TRENDING_VIDEOS("trending-videos", R.string.trending_videos),
+    NEW_VIDEOS("new-videos", R.string.new_videos),
+    TOP_VIDEO_ARTISTS("top-video-artists", R.string.top_video_artists),
     ;
 
     companion object {
@@ -96,5 +100,21 @@ object PodcastHomeSeeAllStore {
 
     fun publishSubscribedChannels(subscribedChannels: List<PodcastItem>) {
         _data.update { it.copy(subscribedChannels = subscribedChannels) }
+    }
+}
+
+data class VideoHomeSeeAllData(
+    val trending: List<SongItem> = emptyList(),
+    val newVideos: List<SongItem> = emptyList(),
+    val artists: List<ArtistItem> = emptyList(),
+)
+
+/** The Videos-tab twin of [PodcastHomeSeeAllStore]; [VideoHomeRowsViewModel] publishes each load. */
+object VideoHomeSeeAllStore {
+    private val _data = MutableStateFlow(VideoHomeSeeAllData())
+    val data: StateFlow<VideoHomeSeeAllData> = _data.asStateFlow()
+
+    fun publishRows(trending: List<SongItem>, newVideos: List<SongItem>, artists: List<ArtistItem>) {
+        _data.update { it.copy(trending = trending, newVideos = newVideos, artists = artists) }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -23,6 +23,7 @@ import com.jtech.zemer.playback.queues.Queue
 import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.utils.ContentWhitelistDoc
 import com.jtech.zemer.utils.IsraeliArtistRegistry
+import com.jtech.zemer.utils.RankedContentGate
 import com.jtech.zemer.utils.ZemerContentClient
 import com.jtech.zemer.utils.mirrorFirst
 import com.jtech.zemer.utils.ContentFilterState
@@ -604,16 +605,17 @@ class HomeViewModel @Inject constructor(
             // better signal than the proxy, and applying it here cut the ranked rows to near-empty
             // (handoff REPLY 3). Blocked-ids already dropped in the mapper; this is defence-in-depth over
             // the server's own female/blocked filtering, so it needs each card's real artist channel id.
-            fun isBlockedRanked(ids: List<String>): Boolean {
-                if (ids.any { IsraeliArtistRegistry.isIsraeli(it) }) return true
-                val profiles = ids.mapNotNull { profileById[it] }
-                if (!allowFemale && profiles.any { it.isFemale == true }) return true
-                // Kids-only artists belong in KidZone, not the adult Home — restore the pre-teardown
-                // exclusion (selectWeightedArtists' `isKids != true`). isKids is a per-artist flag, distinct
-                // from the whitelist's isKidZone that the server's kidZone filter keys on.
-                if (profiles.any { it.isKids == true }) return true
-                return false
-            }
+            // The rule itself lives in the shared RankedContentGate (VideoHomeRowsViewModel applies the
+            // same one to the /video-home-rows rows); only the profile lookup is this ViewModel's.
+            fun isBlockedRanked(ids: List<String>): Boolean = RankedContentGate.isBlockedRanked(
+                ids = ids,
+                allowFemale = allowFemale,
+                flagsOf = { id ->
+                    profileById[id]?.let {
+                        RankedContentGate.Flags(isFemale = it.isFemale == true, isKids = it.isKids == true)
+                    }
+                },
+            )
 
             fun SongItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())
             fun AlbumItem.isAllowedRanked(): Boolean = !isBlockedRanked(this.artists?.mapNotNull { it.id } ?: emptyList())

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -57,6 +58,10 @@ class VideoHomeRowsViewModel @Inject constructor(
         val options = zemerSearchOptions(context)
         runCatching { repository.videoHomeRows(options) }
             .onSuccess { fetched: ZemerResultMapper.VideoHomeRows ->
+                Timber.d(
+                    "NET: /video-home-rows -> trending=%d new=%d artists=%d",
+                    fetched.trending.size, fetched.newVideos.size, fetched.artists.size,
+                )
                 if (zemerOptionsStillCurrent(options, ContentFilterState.current)) {
                     _trending.value = fetched.trending
                     _newVideos.value = fetched.newVideos

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
@@ -7,6 +7,9 @@ import com.jtech.zemer.search.ZemerResultMapper
 import com.jtech.zemer.search.ZemerSearchRepository
 import com.jtech.zemer.search.zemerSearchOptions
 import com.jtech.zemer.utils.ContentFilterState
+import com.jtech.zemer.utils.IsraeliArtistRegistry
+import com.jtech.zemer.utils.RankedContentGate
+import com.jtech.zemer.utils.WhitelistCache
 import com.jtech.zemer.utils.reportException
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.SongItem
@@ -56,6 +59,7 @@ class VideoHomeRowsViewModel @Inject constructor(
 
     private suspend fun refreshNow() = refreshMutex.withLock {
         val options = zemerSearchOptions(context)
+        IsraeliArtistRegistry.ensureLoaded()
         runCatching { repository.videoHomeRows(options) }
             .onSuccess { fetched: ZemerResultMapper.VideoHomeRows ->
                 Timber.d(
@@ -63,14 +67,25 @@ class VideoHomeRowsViewModel @Inject constructor(
                     fetched.trending.size, fetched.newVideos.size, fetched.artists.size,
                 )
                 if (zemerOptionsStillCurrent(options, ContentFilterState.current)) {
-                    _trending.value = fetched.trending
-                    _newVideos.value = fetched.newVideos
-                    _artists.value = fetched.artists
+                    // The client-only ranked gate (female/Israeli/kids — no wire flag exists), same
+                    // rule HomeViewModel applies to the topVideos lead row on this tab.
+                    val entryById = WhitelistCache.snapshot().associateBy { it.artistId }
+                    fun blocked(ids: List<String>) = RankedContentGate.isBlockedRanked(
+                        ids = ids,
+                        allowFemale = options.allowFemale,
+                        flagsOf = { id -> entryById[id]?.let { RankedContentGate.Flags(it.isFemale, it.isKids) } },
+                    )
+                    val trending = fetched.trending.filterNot { blocked(it.artists.mapNotNull { a -> a.id }) }
+                    val newVideos = fetched.newVideos.filterNot { blocked(it.artists.mapNotNull { a -> a.id }) }
+                    val artists = fetched.artists.filterNot { blocked(listOfNotNull(it.id)) }
+                    _trending.value = trending
+                    _newVideos.value = newVideos
+                    _artists.value = artists
                     // Publish the full rows so their "See all" screens show exactly what the rows show.
                     VideoHomeSeeAllStore.publishRows(
-                        trending = fetched.trending,
-                        newVideos = fetched.newVideos,
-                        artists = fetched.artists,
+                        trending = trending,
+                        newVideos = newVideos,
+                        artists = artists,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt
@@ -1,0 +1,76 @@
+package com.jtech.zemer.viewmodels
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jtech.zemer.search.ZemerResultMapper
+import com.jtech.zemer.search.ZemerSearchRepository
+import com.jtech.zemer.search.zemerSearchOptions
+import com.jtech.zemer.utils.ContentFilterState
+import com.jtech.zemer.utils.reportException
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.SongItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+
+/**
+ * Backs the Home Videos tab's ranked rows — **Trending Videos**, **New Videos**, **Top Video
+ * Artists** (`/video-home-rows`, handoff `zemer-app-video-home-rows-request.md`). Isolated from
+ * [HomeViewModel] (the [PodcastHomeRowsViewModel] pattern) so a fetch failure — including the
+ * endpoint not being deployed yet — only leaves these rows empty/hidden; the tab keeps its
+ * `topVideos` lead row. Screen-open [refresh], reload on content-flag change, fetches serialized
+ * behind a [Mutex], stale-flag responses dropped, a failure keeps the previous rows.
+ */
+@HiltViewModel
+class VideoHomeRowsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val repository: ZemerSearchRepository,
+) : ViewModel() {
+    private val _trending = MutableStateFlow<List<SongItem>>(emptyList())
+    val trending: StateFlow<List<SongItem>> = _trending.asStateFlow()
+
+    private val _newVideos = MutableStateFlow<List<SongItem>>(emptyList())
+    val newVideos: StateFlow<List<SongItem>> = _newVideos.asStateFlow()
+
+    private val _artists = MutableStateFlow<List<ArtistItem>>(emptyList())
+    val artists: StateFlow<List<ArtistItem>> = _artists.asStateFlow()
+
+    private val refreshMutex = Mutex()
+
+    init {
+        reloadOnContentFlagChange { refreshNow() }
+    }
+
+    fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) { refreshNow() }
+    }
+
+    private suspend fun refreshNow() = refreshMutex.withLock {
+        val options = zemerSearchOptions(context)
+        runCatching { repository.videoHomeRows(options) }
+            .onSuccess { fetched: ZemerResultMapper.VideoHomeRows ->
+                if (zemerOptionsStillCurrent(options, ContentFilterState.current)) {
+                    _trending.value = fetched.trending
+                    _newVideos.value = fetched.newVideos
+                    _artists.value = fetched.artists
+                    // Publish the full rows so their "See all" screens show exactly what the rows show.
+                    VideoHomeSeeAllStore.publishRows(
+                        trending = fetched.trending,
+                        newVideos = fetched.newVideos,
+                        artists = fetched.artists,
+                    )
+                }
+            }
+            // Quiet while the endpoint is not yet deployed would hide real errors too; reportException
+            // matches PodcastHomeRowsViewModel (non-fatal breadcrumb, rows stay fail-soft either way).
+            .onFailure { reportException(it) }
+    }
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -672,6 +672,11 @@
         <string name="featured_podcasts">Featured</string>
         <string name="top_podcasts">Top Podcasts</string>
         <string name="trending_episodes">Trending Episodes</string>
+        <string name="trending_videos">Trending Videos</string>
+        <string name="trending_video_songs">Trending video songs</string>
+        <string name="new_videos">New Videos</string>
+        <string name="new_video_songs">New video songs</string>
+        <string name="top_video_artists">Top Video Artists</string>
         <string name="zemer_radio_stations">Zemer Radio Stations</string>
         <string name="mark_as_played">Mark as played</string>
         <string name="mark_as_unplayed">Mark as unplayed</string>

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -541,6 +541,8 @@ class ZemerResultMapperTest {
                 ZemerArtist("UCa", "A", "art"),
                 ZemerArtist("", "Blank", null),
                 ZemerArtist("UCa", "A dup", null),
+                // A blocked-id override must drop an ARTIST card too, not just track videoIds.
+                ZemerArtist("blockedVid", "Blocked Channel", null),
             ),
         )
         val rows = ZemerResultMapper.videoHomeRows(resp)

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -522,6 +522,44 @@ class ZemerResultMapperTest {
         assertTrue(videos.single().isVideo)
     }
 
+    // --- /video-home-rows mapping (the Videos tab's ranked rows) ---
+
+    @Test
+    fun `video home rows are video-classified, deduped, blocked-id filtered`() {
+        BlockedIdsCache.updateAll(mapOf("blockedVid" to "global"))
+        val resp = ZemerVideoHomeRowsResponse(
+            trendingVideos = listOf(
+                ZemerTrack(videoId = "v1", title = "T1", artist = "A", artistId = "UCa"),
+                ZemerTrack(videoId = "v1", title = "T1 dup", artist = "A"),
+                ZemerTrack(videoId = "blockedVid", title = "Nope", artist = "B"),
+            ),
+            newVideos = listOf(
+                ZemerTrack(videoId = "v2", title = "T2", artist = "B"),
+                ZemerTrack(videoId = "", title = "No id", artist = "C"),
+            ),
+            topVideoArtists = listOf(
+                ZemerArtist("UCa", "A", "art"),
+                ZemerArtist("", "Blank", null),
+                ZemerArtist("UCa", "A dup", null),
+            ),
+        )
+        val rows = ZemerResultMapper.videoHomeRows(resp)
+        // Both track rows carry the video classification (the one isVideo flag, set at this boundary).
+        assertEquals(listOf("v1"), rows.trending.map { it.id })
+        assertTrue(rows.trending.single().isVideo)
+        assertEquals("UCa", rows.trending.single().artists.single().id)
+        assertEquals(listOf("v2"), rows.newVideos.map { it.id })
+        assertTrue(rows.newVideos.single().isVideo)
+        assertEquals(listOf("UCa"), rows.artists.map { it.id })
+    }
+
+    @Test
+    fun `videos tab play source slugs are pinned to the tracking contract`() {
+        // handoff zemer-app-video-home-rows-tracking-request.md - append-only wire values.
+        assertEquals("home:video-trending", com.jtech.zemer.tracking.PlaySource.HOME_VIDEO_TRENDING)
+        assertEquals("home:video-new", com.jtech.zemer.tracking.PlaySource.HOME_VIDEO_NEW)
+    }
+
     // --- /home-rows mapping (telemetry-ranked home tab rows) ---
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt
@@ -1,0 +1,52 @@
+package com.jtech.zemer.utils
+
+import com.jtech.zemer.utils.RankedContentGate.Flags
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The shared ranked-row content gate (female-when-blocked + Israeli + kids-only; NEVER the
+ * famous/american proxy). Both HomeViewModel and VideoHomeRowsViewModel resolve through this one
+ * rule — these tests pin it so the two surfaces cannot drift.
+ */
+class RankedContentGateTest {
+
+    private val flags = mapOf(
+        "UCfem" to Flags(isFemale = true, isKids = false),
+        "UCkid" to Flags(isFemale = false, isKids = true),
+        "UCok" to Flags(isFemale = false, isKids = false),
+    )
+    private fun gate(ids: List<String>, allowFemale: Boolean, israeli: Set<String> = emptySet()) =
+        RankedContentGate.isBlockedRanked(ids, allowFemale, flags::get, isIsraeli = { it in israeli })
+
+    @Test
+    fun `female artist blocks only when female is blocked`() {
+        assertTrue(gate(listOf("UCfem"), allowFemale = false))
+        assertFalse(gate(listOf("UCfem"), allowFemale = true))
+    }
+
+    @Test
+    fun `kids-only artist blocks regardless of the female flag`() {
+        assertTrue(gate(listOf("UCkid"), allowFemale = true))
+        assertTrue(gate(listOf("UCkid"), allowFemale = false))
+    }
+
+    @Test
+    fun `israeli id blocks even with no flags known`() {
+        assertTrue(gate(listOf("UCunknown"), allowFemale = true, israeli = setOf("UCunknown")))
+    }
+
+    @Test
+    fun `unknown ids fail open and a clean artist passes`() {
+        assertFalse(gate(listOf("UCunknown"), allowFemale = false))
+        assertFalse(gate(listOf("UCok"), allowFemale = false))
+        assertFalse(gate(emptyList(), allowFemale = false))
+    }
+
+    @Test
+    fun `any blocked credit blocks the item`() {
+        assertTrue(gate(listOf("UCok", "UCfem"), allowFemale = false))
+        assertFalse(gate(listOf("UCok", "UCfem"), allowFemale = true))
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` — a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline — they are not duplicated here.
 
-## `app` Kotlin files (637)
+## `app` Kotlin files (638)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -174,7 +174,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 | `com.jtech.zemer.search` | no | 2 | 9 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 | `com.jtech.zemer.search` | no | 1 | 42 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 | `com.jtech.zemer.search` | no | 1 | 26 | kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 682 | `com.jtech.zemer.search` | no | 21 | 98 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 683 | `com.jtech.zemer.search` | no | 21 | 98 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 56 | `com.jtech.zemer.search` | no | 1 | 9 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 593 | `com.jtech.zemer.search` | no | 16 | 62 | io.ktor, java.io, javax.inject, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 404 | `com.jtech.zemer.search` | no | 2 | 157 | kotlinx.serialization |
@@ -329,8 +329,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 | `com.jtech.zemer.ui.screens` | no | 0 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 107 | `com.jtech.zemer.ui.screens` | yes | 33 | 4 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 | `com.jtech.zemer.ui.screens` | yes | 31 | 8 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1537 | `com.jtech.zemer.ui.screens` | yes | 143 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 373 | `com.jtech.zemer.ui.screens` | yes | 68 | 31 | androidx.compose, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1515 | `com.jtech.zemer.ui.screens` | yes | 143 | 103 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 | `com.jtech.zemer.ui.screens` | yes | 68 | 31 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 | `com.jtech.zemer.ui.screens` | yes | 18 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 | `com.jtech.zemer.ui.screens` | yes | 43 | 18 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 | `com.jtech.zemer.ui.screens` | yes | 34 | 9 | androidx.compose, androidx.hilt, androidx.navigation |
@@ -495,8 +495,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 51 | `com.jtech.zemer.viewmodels` | no | 17 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 | `com.jtech.zemer.viewmodels` | no | 20 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 120 | `com.jtech.zemer.viewmodels` | no | 14 | 36 | androidx.annotation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 980 | `com.jtech.zemer.viewmodels` | no | 56 | 198 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 | `com.jtech.zemer.viewmodels` | no | 14 | 38 | androidx.annotation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 982 | `com.jtech.zemer.viewmodels` | no | 57 | 197 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 17 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -523,6 +523,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StatusDownloadsViewModel.kt` | 34 | `com.jtech.zemer.viewmodels` | no | 10 | 5 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StoryViewModel.kt` | 120 | `com.jtech.zemer.viewmodels` | no | 25 | 17 | android.content, android.graphics, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 | `com.jtech.zemer.viewmodels` | no | 14 | 4 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt` | 96 | `com.jtech.zemer.viewmodels` | no | 24 | 18 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 65 | `com.jtech.zemer.viewmodels` | no | 17 | 13 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedPodcastsViewModel.kt` | 87 | `com.jtech.zemer.viewmodels` | no | 20 | 16 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistViewModel.kt` | 72 | `com.jtech.zemer.viewmodels` | no | 17 | 14 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -586,7 +587,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 | `com.jtech.zemer.search` | no | 5 | 24 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 | `com.jtech.zemer.search` | no | 14 | 19 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 746 | `com.jtech.zemer.search` | no | 18 | 89 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 748 | `com.jtech.zemer.search` | no | 18 | 89 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 63 | `com.jtech.zemer.search` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 | `com.jtech.zemer.search` | no | 2 | 4 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -174,12 +174,12 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 | `com.jtech.zemer.search` | no | 2 | 9 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 | `com.jtech.zemer.search` | no | 1 | 42 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 | `com.jtech.zemer.search` | no | 1 | 26 | kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 661 | `com.jtech.zemer.search` | no | 21 | 93 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 682 | `com.jtech.zemer.search` | no | 21 | 98 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 56 | `com.jtech.zemer.search` | no | 1 | 9 |  |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 575 | `com.jtech.zemer.search` | no | 16 | 60 | io.ktor, java.io, javax.inject, kotlinx.serialization, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 388 | `com.jtech.zemer.search` | no | 2 | 153 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 593 | `com.jtech.zemer.search` | no | 16 | 62 | io.ktor, java.io, javax.inject, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 404 | `com.jtech.zemer.search` | no | 2 | 157 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 32 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 450 | `com.jtech.zemer.search` | no | 32 | 66 | android.content, dagger.hilt, java.io, java.nio, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 454 | `com.jtech.zemer.search` | no | 32 | 67 | android.content, dagger.hilt, java.io, java.nio, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 | `com.jtech.zemer.search` | no | 1 | 39 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownload.kt` | 65 | `com.jtech.zemer.statuses` | no | 2 | 16 | org.json |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownloadManager.kt` | 118 | `com.jtech.zemer.statuses` | no | 14 | 26 | android.content, android.graphics, android.net, androidx.core, dagger.hilt, java.io, javax.inject, kotlinx.coroutines, okhttp3.OkHttpClient, okhttp3.Request |
@@ -205,7 +205,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/tracking/ImpressionReporter.kt` | 99 | `com.jtech.zemer.tracking` | yes | 9 | 5 | androidx.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/LibraryActionBackfill.kt` | 142 | `com.jtech.zemer.tracking` | no | 16 | 18 | android.content, androidx.datastore, java.time, java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfill.kt` | 166 | `com.jtech.zemer.tracking` | no | 18 | 27 | android.content, androidx.datastore, java.time, java.util, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 75 | `com.jtech.zemer.tracking` | no | 1 | 20 | java.util |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 80 | `com.jtech.zemer.tracking` | no | 1 | 22 | java.util |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 303 | `com.jtech.zemer.tracking` | no | 18 | 57 | android.content, androidx.datastore, java.io, java.util, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 235 | `com.jtech.zemer.tracking` | no | 9 | 39 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingLifecycle.kt` | 58 | `com.jtech.zemer.tracking` | no | 4 | 13 | android.app, android.os |
@@ -329,8 +329,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 | `com.jtech.zemer.ui.screens` | no | 0 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 107 | `com.jtech.zemer.ui.screens` | yes | 33 | 4 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 | `com.jtech.zemer.ui.screens` | yes | 31 | 8 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1409 | `com.jtech.zemer.ui.screens` | yes | 142 | 95 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 360 | `com.jtech.zemer.ui.screens` | yes | 67 | 30 | androidx.compose, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1537 | `com.jtech.zemer.ui.screens` | yes | 143 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 373 | `com.jtech.zemer.ui.screens` | yes | 68 | 31 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 | `com.jtech.zemer.ui.screens` | yes | 18 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 | `com.jtech.zemer.ui.screens` | yes | 43 | 18 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 | `com.jtech.zemer.ui.screens` | yes | 34 | 9 | androidx.compose, androidx.hilt, androidx.navigation |
@@ -495,7 +495,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 51 | `com.jtech.zemer.viewmodels` | no | 17 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 | `com.jtech.zemer.viewmodels` | no | 20 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 100 | `com.jtech.zemer.viewmodels` | no | 14 | 28 | androidx.annotation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 120 | `com.jtech.zemer.viewmodels` | no | 14 | 36 | androidx.annotation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 980 | `com.jtech.zemer.viewmodels` | no | 56 | 198 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
@@ -586,7 +586,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 | `com.jtech.zemer.search` | no | 5 | 24 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 | `com.jtech.zemer.search` | no | 14 | 19 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 708 | `com.jtech.zemer.search` | no | 18 | 87 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 746 | `com.jtech.zemer.search` | no | 18 | 89 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 63 | `com.jtech.zemer.search` | no | 3 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 | `com.jtech.zemer.search` | no | 2 | 4 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 1179 lines | text `.md` |
+| `AGENTS.md` | 1187 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |
@@ -264,7 +264,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 694 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 699 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/strings.xml` | 438 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1175`
+- Files counted: `1176`
 - By extension:
-  - `.kt`: `737`
+  - `.kt`: `738`
   - `.xml`: `196`
   - `.mjs`: `74`
   - `.md`: `68`
@@ -334,7 +334,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 682 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 683 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 593 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 404 lines | `.kt` |
@@ -489,8 +489,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 107 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1537 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 373 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1515 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 lines | `.kt` |
@@ -655,8 +655,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 51 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 120 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 980 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 982 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 lines | `.kt` |
@@ -683,6 +683,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StatusDownloadsViewModel.kt` | 34 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StoryViewModel.kt` | 120 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt` | 96 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 65 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedPodcastsViewModel.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistViewModel.kt` | 72 lines | `.kt` |
@@ -958,7 +959,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 746 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 748 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 63 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 lines | `.kt` |
@@ -1059,7 +1060,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 760 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 761 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 384 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -1070,7 +1071,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1285 lines | `.md` |
+| `docs/repository-map.md` | 1286 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 1179 lines | `.md` |
+| `AGENTS.md` | 1187 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -334,12 +334,12 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 661 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 682 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 56 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 575 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 388 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 593 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 404 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 32 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 450 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 454 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownload.kt` | 65 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/statuses/StatusDownloadManager.kt` | 118 lines | `.kt` |
@@ -365,7 +365,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/tracking/ImpressionReporter.kt` | 99 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/LibraryActionBackfill.kt` | 142 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/PlayHistoryBackfill.kt` | 166 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 75 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/tracking/PlaySource.kt` | 80 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/Tracker.kt` | 303 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingEvents.kt` | 235 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/tracking/TrackingLifecycle.kt` | 58 lines | `.kt` |
@@ -489,8 +489,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 107 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1409 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 360 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1537 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 373 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 235 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/LatestReleasesScreen.kt` | 108 lines | `.kt` |
@@ -655,7 +655,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedContentViewModel.kt` | 51 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 100 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 120 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 980 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
@@ -897,7 +897,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/ic_launcher_background.xml` | 6 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 694 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 699 lines | `.xml` |
 | `app/src/main/res/values/strings.xml` | 438 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
@@ -958,7 +958,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 708 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 746 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 63 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 lines | `.kt` |


### PR DESCRIPTION
Trending Videos / New Videos / Top Video Artists on the Videos content tab - the video twin of the podcast home rows. Contract: handoff zemer-app-video-home-rows-request.md (server live 2026-08-11, verified against the deployed endpoint).

- wire model reuses the /home-rows row shapes; mapper classifies both track rows isVideo=true at the boundary (dedup, blank-id drop, blocked-id overrides; unit-tested)
- isolated fail-soft VideoHomeRowsViewModel (PodcastHomeRows pattern): an absent endpoint leaves the tab on its topVideos lead row; content-flag reload, stale-flag responses dropped
- rows use the existing video-card treatment: square crop, no badge, audio-first taps, audio-gated menus, relabeled for blocked-video users (never hidden)
- See-all parity via VideoHomeSeeAllStore + three HomeSeeAllRow entries (relabels on the see-all pages too)
- tracking instrumented per zemer-app-video-home-rows-tracking-request.md: PlaySource home:video-trending / home:video-new on direct plays (wire values pinned by test) + impressions on the matching surfaces; the artists row is deliberately unattributed (artist:UC covers it)

Verified: full JVM suite, ui-audit/download-unification/dead-resources, assembleDebug, docs regenerated; endpoint contract confirmed against production data.