### PR TITLE
Point Latest Releases feed URL at whitelisted root domain

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt
@@ -21,7 +21,7 @@ import java.io.File
 /**
  * The "latest releases" feed: recent releases from kosher (whitelisted) artists, precomputed
  * server-side and served as a small JSON. Mirrors the shape produced by the VPS builder
- * (flipphoneguy-api `/zemer/recent-releases.json`); `ignoreUnknownKeys` keeps the app forward-
+ * (flipphoneguy-api `/?page=zemer_releases`); `ignoreUnknownKeys` keeps the app forward-
  * compatible if the server adds fields.
  */
 @Serializable
@@ -67,7 +67,7 @@ data class LatestRelease(
  */
 object LatestReleasesStore {
     private const val TAG = "Zemer_LatestReleases"
-    private const val FEED_URL = "https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json"
+    private const val FEED_URL = "https://flipphoneguy.duckdns.org/?page=zemer_releases"
     private const val MAX_ATTEMPTS = 3
 
     // A cached feed older than this (since its last successful fetch) is treated as gone: the server

--- a/docs/latest_releases/02-feed-format-and-server.md
+++ b/docs/latest_releases/02-feed-format-and-server.md
@@ -71,7 +71,7 @@ subtitle.
 
 ## Where the feed comes from
 
-- **URL:** `https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json`
+- **URL:** `https://flipphoneguy.duckdns.org/?page=zemer_releases`
   (`LatestReleasesStore.FEED_URL`, `LatestReleasesStore.kt:69`), served with an ETag (the store
   sends `If-None-Match` and honours `304` — doc 03).
 - **Builder location:** the deployed job is **not** in this repo. Per

--- a/docs/latest_releases/03-runtime-store.md
+++ b/docs/latest_releases/03-runtime-store.md
@@ -9,7 +9,7 @@ refresh. Modelled on the cipher `PlayerConfigStore` (its KDoc says so, `:50-53`)
 | Constant | Value | Meaning |
 |---|---|---|
 | `TAG` | `"Zemer_LatestReleases"` | Timber tag (shared with the ViewModel). |
-| `FEED_URL` | `https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json` | The feed. |
+| `FEED_URL` | `https://flipphoneguy.duckdns.org/?page=zemer_releases` | The feed. |
 | `MAX_ATTEMPTS` | `3` | Network tries per launch before giving up. |
 | `MAX_STALE_MS` | `3 * 24 * 60 * 60 * 1000L` (3 days) | A disk cache older than this is treated as gone. |
 | `CACHE_FILE` | `"latest_releases.json"` | The cached feed body. |

--- a/docs/latest_releases/07-runbook.md
+++ b/docs/latest_releases/07-runbook.md
@@ -11,7 +11,7 @@ vps repo job (4x/day, systemd)  --writes-->  recent-releases.json  --ETag-->  FE
 app: LatestReleasesStore (fetch + cache)  ->  LatestReleasesViewModel (filter)  -> UI shelf + See-all
 ```
 
-- **Feed URL:** `https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json`
+- **Feed URL:** `https://flipphoneguy.duckdns.org/?page=zemer_releases`
   (`LatestReleasesStore.FEED_URL`).
 - **App refresh cadence:** once per launch, up to 3 attempts, then give up until next launch
   (doc 03). There is no in-session re-poll.
@@ -27,7 +27,7 @@ The header/list are only emitted when the **filtered** list is non-empty
 
 1. **Is the feed reachable and non-empty?**
    ```bash
-   curl -s https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json | head -c 400
+   curl -s "https://flipphoneguy.duckdns.org/?page=zemer_releases" | head -c 400
    ```
    Expect a JSON with a non-empty `releases`. If it errors or `count` is 0, it's the **server
    job** (vps repo), not the app.

--- a/docs/latest_releases/README.md
+++ b/docs/latest_releases/README.md
@@ -32,7 +32,7 @@ simply makes the shelf empty.
 
 | Where | File |
 |---|---|
-| Feed URL | `https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json` (`LatestReleasesStore.FEED_URL`) |
+| Feed URL | `https://flipphoneguy.duckdns.org/?page=zemer_releases` (`LatestReleasesStore.FEED_URL`) |
 | Runtime store | `app/.../latestreleases/LatestReleasesStore.kt` |
 | ViewModel | `app/.../viewmodels/LatestReleasesViewModel.kt` |
 | Feed -> AlbumItem adapter | `app/.../latestreleases/LatestReleaseMapping.kt` |

--- a/tests/recent-releases/README.md
+++ b/tests/recent-releases/README.md
@@ -55,7 +55,7 @@ node --test tests/recent-releases/self-test.mjs            # parsers/helpers, no
 
 The deployed job is a self-contained copy in the **vps repo** (`~/github/private/my-vps` →
 `flask_app/apps/api/zemer/`), run by a systemd timer hourly and served (with ETag) at
-`https://api.flipphoneguy.duckdns.org/zemer/recent-releases.json`. Keep `build.mjs` / `lib.mjs` /
+`https://flipphoneguy.duckdns.org/?page=zemer_releases`. Keep `build.mjs` / `lib.mjs` /
 `whitelist.mjs` there in sync with the algorithm here. The app fetches that JSON via
 `com.jtech.zemer.latestreleases.LatestReleasesStore` (+ `LatestReleasesViewModel` and the Home
 "Latest Releases" section); the store's resilience logic is unit-tested in


### PR DESCRIPTION
Moves the Latest Releases feed link from `api.flipphoneguy.duckdns.org/zemer/recent-releases.json` to `flipphoneguy.duckdns.org/?page=zemer_releases`.

The goal is to let **filtered devices** reach the feed: the root domain is whitelisted by most kosher content filters, so serving the feed from the root (rather than the `api.` subdomain) should hopefully make Latest Releases work on filtered devices too. The server responds identically at both the old and new URL — only the link the app fetches changes.

Updates the `LatestReleasesStore.FEED_URL` constant (and its KDoc path note) plus every doc/test reference to the URL. Old URL no longer appears anywhere.