### PR TITLE
feat(ui): filter the Featured Videos hero to server-flagged real videos

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
@@ -296,7 +296,9 @@ fun offlineHomeRows(
             contentGatePasses(femInv, artist?.isKidZone == true, isVideo = false, allowFemale, blockVideos, kidZone) &&
                 !corpus.idDropped(t.videoId, allowFemale) && !corpus.idDropped(t.artistId, allowFemale)
         }
-        .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec) }
+        // realVideo = true offline: the on-device snapshot has no server CLIP classification, so it shows
+        // its whole video set in the Featured hero (the pre-flag behaviour) rather than an empty row.
+        .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec, realVideo = true) }
 
     // top-artists → ZemerArtist. Gate by the artist's own flags + id-override; no _female cross-credit.
     val topArtists = ranked("top-artists").mapNotNull { corpus.artistsById[it.refId] }

--- a/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt
@@ -296,9 +296,9 @@ fun offlineHomeRows(
             contentGatePasses(femInv, artist?.isKidZone == true, isVideo = false, allowFemale, blockVideos, kidZone) &&
                 !corpus.idDropped(t.videoId, allowFemale) && !corpus.idDropped(t.artistId, allowFemale)
         }
-        // realVideo = true offline: the on-device snapshot has no server CLIP classification, so it shows
-        // its whole video set in the Featured hero (the pre-flag behaviour) rather than an empty row.
-        .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec, realVideo = true) }
+        // realVideo left at its default false: the snapshot has no CLIP classifier, so no video is flagged
+        // real -> the ViewModel's empty-pool fallback shows the whole set in the hero (no special-case here).
+        .map { ZemerTrack(videoId = it.videoId, title = it.title, artist = corpus.artistsById[it.artistId]?.name ?: "", artistId = it.artistId, explicit = it.explicit, durationSec = it.durationSec) }
 
     // top-artists → ZemerArtist. Gate by the artist's own flags + id-override; no _female cross-credit.
     val topArtists = ranked("top-artists").mapNotNull { corpus.artistsById[it.refId] }

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -186,6 +186,7 @@ object ZemerResultMapper {
                 .distinctBy { it.id }
                 .dropBlocked(),
             community = playlistItems(resp.topCommunity, formatSongCount),
+            realVideoIds = resp.topVideos.filter { it.realVideo }.map { it.videoId }.toSet(),
         )
 
     /** The four telemetry/discovery-ranked home rows in native item types (see [homeRows]). */
@@ -194,6 +195,9 @@ object ZemerResultMapper {
         val videos: List<SongItem>,
         val artists: List<ArtistItem>,
         val community: List<PlaylistItem>,
+        // The videoIds among [videos] the server classified as REAL filmed videos (topVideos[].realVideo).
+        // The Featured Videos hero carousel shows only these; the See-all shows the full [videos] row.
+        val realVideoIds: Set<String> = emptySet(),
     )
 
     /**

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt
@@ -65,6 +65,13 @@ data class ZemerTrack(
     // instead of the letterboxed video frame). Absent on surfaces that don't provide it yet;
     // [ZemerResultMapper.toSongItem] then falls back to the videoId-derived thumbnail.
     val thumbnail: String? = null,
+    // `/home-rows` `topVideos` only: true = a REAL filmed music video (kept in the Featured Videos hero
+    // carousel); false/absent = an audio single with a designed cover graphic, or not-yet-classified -
+    // stays in the See-all but OUT of the hero, which crops a square cover wrong at 16:9. A server-side
+    // CLIP classifier over the thumbnail sets it (contract:
+    // handoff-docs/zemer-app-featured-videos-real-videos-request.md); absent on the other surfaces and on
+    // older servers, so it defaults false = conservative (out of the hero).
+    val realVideo: Boolean = false,
     // The track's album {id (browseId), name}, when the server links it — powers the song menu's
     // "View album". Null for standalone singles / videos (no album in the corpus).
     val album: ZemerTrackAlbum? = null,

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -730,10 +730,13 @@ class HomeViewModel @Inject constructor(
             val communityPool = homeRows?.community.orEmpty().filter { it.isAllowedRanked() }
             val finalFeaturedAlbums = rotateByArtist(albumsPool, maxPerArtist = 1, target = 20)
             val finalFeaturedArtists = rotateByArtist(artistsPool, maxPerArtist = 1, target = 20)
-            // The hero shows the full one-per-artist set of REAL (server-flagged) videos, up to 20;
-            // rotateByArtist keeps it one video per artist for variety. The See-all (displayedFirst below)
-            // still leads with these but then shows the WHOLE videosPool, real-flagged or not.
-            val finalFeaturedVideos = rotateByArtist(realVideosPool, maxPerArtist = 1, target = 20)
+            // The hero shows the one-per-artist set of REAL (server-flagged) videos, up to 20. If the pool
+            // has NONE flagged real - a heavily-filtered user whose ranked videos are all cover-graphics, an
+            // older server that omits the flag, or the offline snapshot (no CLIP classifier) - fall back to
+            // the FULL pool so the shelf AND its See-all never vanish (an empty carousel returns early,
+            // taking the title + See-all arrow with it - worse than showing cover-graphics). The See-all
+            // (displayedFirst below) shows the WHOLE videosPool either way.
+            val finalFeaturedVideos = rotateByArtist(realVideosPool.ifEmpty { videosPool }, maxPerArtist = 1, target = 20)
             // Community has no artist id (so no rotateByArtist recent-avoidance): shuffle, then prefer the
             // playlists NOT shown on the previous load so a pull-to-refresh turns the 8-of-16 row over fully.
             val communityShuffled = communityPool.shuffled(Random(System.nanoTime()))

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -718,21 +718,22 @@ class HomeViewModel @Inject constructor(
             // row rather than falling back to a scrape. All featured content is therefore Zemer-sourced.
             val albumsPool = homeRows?.albums.orEmpty().filter { it.isAllowedRanked() }
             val artistsPool = homeRows?.artists.orEmpty().filter { it.isAllowedRanked() }
-            // Featured Videos must be ACTUAL music videos, not audio tracks that merely carry a square
-            // cover: a real video's thumbnail is a 16:9 i.ytimg.com frame, an audio track's is square
-            // album art (googleusercontent). Keep only the ytimg-framed items (the same video/art split
-            // the mapper's headerCovers uses), so the hero carousel never crops a square cover to 16:9.
-            val videosPool = homeRows?.videos.orEmpty()
-                .filter { it.isAllowedRanked() }
-                .filter { it.thumbnail?.contains("i.ytimg.com") == true }
+            // Featured Videos is the Videos-tab HERO CAROUSEL, which crops each cover to 16:9 - so it must
+            // show only ACTUAL filmed videos, not audio singles with a designed cover graphic (those are
+            // typed OMV with a real 16:9 thumbnail, so no client-side signal separates them). The server
+            // flags real videos per topVideos row (a CLIP classifier); the app keeps the FULL pool for the
+            // See-all and filters only the HERO to the flagged ids. Absent/false = out of the hero (the
+            // conservative default). Contract: handoff-docs/zemer-app-featured-videos-real-videos-request.md.
+            val videosPool = homeRows?.videos.orEmpty().filter { it.isAllowedRanked() }
+            val realVideoIds = homeRows?.realVideoIds.orEmpty()
+            val realVideosPool = videosPool.filter { it.id in realVideoIds }
             val communityPool = homeRows?.community.orEmpty().filter { it.isAllowedRanked() }
             val finalFeaturedAlbums = rotateByArtist(albumsPool, maxPerArtist = 1, target = 20)
             val finalFeaturedArtists = rotateByArtist(artistsPool, maxPerArtist = 1, target = 20)
-            // Featured Videos is the Videos-tab HERO CAROUSEL you swipe through, so show the full
-            // one-per-artist set (the pool is ~14-19 whitelisted music videos over ~14 distinct artists
-            // that clear the 30-day reach floor) rather than the old curated 8-of-a-row. rotateByArtist
-            // still keeps it to one video per artist for variety; the See-all shows the whole pool.
-            val finalFeaturedVideos = rotateByArtist(videosPool, maxPerArtist = 1, target = 20)
+            // The hero shows the full one-per-artist set of REAL (server-flagged) videos, up to 20;
+            // rotateByArtist keeps it one video per artist for variety. The See-all (displayedFirst below)
+            // still leads with these but then shows the WHOLE videosPool, real-flagged or not.
+            val finalFeaturedVideos = rotateByArtist(realVideosPool, maxPerArtist = 1, target = 20)
             // Community has no artist id (so no rotateByArtist recent-avoidance): shuffle, then prefer the
             // playlists NOT shown on the previous load so a pull-to-refresh turns the 8-of-16 row over fully.
             val communityShuffled = communityPool.shuffled(Random(System.nanoTime()))

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -603,6 +603,28 @@ class ZemerResultMapperTest {
     }
 
     @Test
+    fun `home rows expose only realVideo-flagged ids while videos row stays full`() {
+        // The Featured Videos hero shows only server-flagged REAL videos (topVideos[].realVideo); the
+        // See-all still gets the full videos row. realVideoIds carries which of them are real; an absent
+        // flag counts as not-real (the server's conservative default).
+        val resp = ZemerHomeRowsResponse(
+            topVideos = listOf(
+                ZemerTrack(videoId = "real1", title = "Filmed", artist = "A", artistId = "UCa", realVideo = true),
+                ZemerTrack(videoId = "cover1", title = "Cover graphic", artist = "B", artistId = "UCb", realVideo = false),
+                ZemerTrack(videoId = "unset1", title = "Not classified", artist = "C", artistId = "UCc"), // realVideo absent
+                ZemerTrack(videoId = "real2", title = "Filmed 2", artist = "D", artistId = "UCd", realVideo = true),
+            ),
+        )
+
+        val rows = ZemerResultMapper.homeRows(resp)
+
+        // The videos row itself is unfiltered — the See-all shows all four.
+        assertEquals(listOf("real1", "cover1", "unset1", "real2"), rows.videos.map { it.id })
+        // Only the flagged videos are real; absent/false are excluded.
+        assertEquals(setOf("real1", "real2"), rows.realVideoIds)
+    }
+
+    @Test
     fun `home rows drop blank and duplicate ids per row`() {
         val resp = ZemerHomeRowsResponse(
             topAlbums = listOf(

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -520,7 +520,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 | `com.jtech.zemer.viewmodels` | no | 20 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 | `com.jtech.zemer.viewmodels` | no | 14 | 38 | androidx.annotation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 990 | `com.jtech.zemer.viewmodels` | no | 57 | 199 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 993 | `com.jtech.zemer.viewmodels` | no | 57 | 199 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 17 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -622,7 +622,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 | `com.jtech.zemer.search` | no | 5 | 24 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 | `com.jtech.zemer.search` | no | 14 | 19 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 748 | `com.jtech.zemer.search` | no | 18 | 89 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 770 | `com.jtech.zemer.search` | no | 18 | 91 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 75 | `com.jtech.zemer.search` | no | 3 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 | `com.jtech.zemer.search` | no | 2 | 4 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -106,7 +106,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt` | 123 | `com.jtech.zemer.offline` | no | 1 | 20 | java.util |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt` | 74 | `com.jtech.zemer.offline` | no | 1 | 21 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetNormalize.kt` | 115 | `com.jtech.zemer.offline` | no | 2 | 29 | java.text, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt` | 761 | `com.jtech.zemer.offline` | no | 23 | 123 | java.util |
+| `app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt` | 763 | `com.jtech.zemer.offline` | no | 23 | 123 | java.util |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetSearch.kt` | 315 | `com.jtech.zemer.offline` | no | 4 | 116 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt` | 115 | `com.jtech.zemer.offline` | no | 5 | 26 | android.content, java.io, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt` | 61 | `com.jtech.zemer.offline` | no | 12 | 10 | io.ktor, java.io, javax.inject, kotlinx.serialization |
@@ -185,10 +185,10 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 | `com.jtech.zemer.search` | no | 2 | 9 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 | `com.jtech.zemer.search` | no | 1 | 42 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 | `com.jtech.zemer.search` | no | 1 | 26 | kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 699 | `com.jtech.zemer.search` | no | 21 | 103 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 703 | `com.jtech.zemer.search` | no | 21 | 104 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 71 | `com.jtech.zemer.search` | no | 1 | 14 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 599 | `com.jtech.zemer.search` | no | 16 | 62 | io.ktor, java.io, javax.inject, kotlinx.serialization, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 410 | `com.jtech.zemer.search` | no | 2 | 158 | kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 417 | `com.jtech.zemer.search` | no | 2 | 159 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 32 | `com.jtech.zemer.search` | no | 5 | 6 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 474 | `com.jtech.zemer.search` | no | 34 | 68 | android.content, dagger.hilt, java.io, java.nio, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 | `com.jtech.zemer.search` | no | 1 | 39 | kotlinx.serialization |
@@ -520,7 +520,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 | `com.jtech.zemer.viewmodels` | no | 20 | 5 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 | `com.jtech.zemer.viewmodels` | no | 14 | 38 | androidx.annotation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 989 | `com.jtech.zemer.viewmodels` | no | 57 | 197 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 990 | `com.jtech.zemer.viewmodels` | no | 57 | 199 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 | `com.jtech.zemer.viewmodels` | no | 15 | 11 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 17 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -680,7 +680,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 990 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 993 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 lines | `.kt` |
@@ -994,7 +994,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 748 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 770 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 75 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -266,7 +266,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetLiveWhitelist.kt` | 123 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetManifest.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetNormalize.kt` | 115 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt` | 761 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/offline/SubsetReadLayer.kt` | 763 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetSearch.kt` | 315 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetStore.kt` | 115 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/SubsetSyncClient.kt` | 61 lines | `.kt` |
@@ -345,10 +345,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 699 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 703 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 71 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 599 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 410 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 417 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchOptions.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchRepository.kt` | 474 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerStationsModels.kt` | 135 lines | `.kt` |
@@ -680,7 +680,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 989 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 990 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 56 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 47 lines | `.kt` |


### PR DESCRIPTION
The Featured Videos hero carousel on the Videos tab crops each cover to 16:9, so it must show only real
filmed videos - not audio singles with a designed cover graphic (YouTube types those OMV with a real 16:9
thumbnail, so no client-side signal separates them).

`/home-rows` `topVideos` now carries an additive per-track `realVideo` boolean. The app:
- parses `ZemerTrack.realVideo` (defaults false = out of the hero),
- surfaces the real-video ids from the home-rows mapper,
- filters the hero carousel to real videos while the See-all still renders the FULL `topVideos` row
  (nothing leaves the row, only the hero),
- removes the earlier thumbnail-host filter (a no-op: `topVideos` sends no thumbnail, so a ytimg URL is
  derived for every item),
- marks offline videos real (the on-device snapshot has no classifier) so the offline hero shows its full
  set instead of going empty.

Additive and back-compatible; older builds ignore the field. Built + full unit tests + audits green locally.
