### PR TITLE
fix(ui): scroll long podcast titles once instead of cutting them off, re-armed on D-pad focus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,7 +404,14 @@ state; ratcheted by **R26**); `PreparingOverlay` (the scrim + `MediaLoadingSpinn
 item resolves, shared by `ItemThumbnail` and the video hero); `HeroTitleOverlay` (the bottom gradient
 title/subtitle + optional badges slot) and `CarouselHeroFrame` (the ENTIRE full-bleed carousel-hero
 frame - `maskClip`/`maskBorder` D-pad focus ring, cover-crop artwork, now-playing scrim) shared by the
-Latest Releases and Featured Videos heroes.
+Latest Releases and Featured Videos heroes. The **title marquee** is `gentleMarquee(focused)`
+(`ui/component/Marquee.kt`): the calm one-shot glide for an overflowing title (settle ~3s, glide once,
+stop), shared by the now-playing/mini-player titles and every podcast row/card title. Pass the owning
+row/card's D-pad focus state so a focus GAIN re-arms the glide promptly; the param spec is the
+JVM-tested `gentleMarqueeParams`, whose focus-LOSS state must stay `iterations = 0` (the marquee node
+restarts on any param change, so falling back to the resting params would replay the glide behind the
+D-pad cursor on every row the user leaves). `ListItem`/`GridItem` expose it as `titleMarquee` -
+GridItem applies it AROUND the opaque title slot, so slot content must not add its own marquee.
 New screens use these; a hand-rolled duplicate is a review miss.
 
 **Componentize on every touch (non-negotiable).** Whenever you touch anything in the app, first check

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -164,11 +164,20 @@ inline fun ListItem(
     ) {
         Box(Modifier.padding(ListThumbnailPadding), contentAlignment = Alignment.Center) { thumbnailContent() }
         Column(Modifier.weight(1f).padding(horizontal = 6.dp)) {
-            Text(
-                text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                modifier = if (titleMarquee) Modifier.gentleMarquee() else Modifier
-            )
+            if (titleMarquee) {
+                RefocusableMarqueeTitle(focused = isFocused) {
+                    Text(
+                        text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.gentleMarquee()
+                    )
+                }
+            } else {
+                Text(
+                    text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis
+                )
+            }
             if (subtitle != null) Row(verticalAlignment = Alignment.CenterVertically) { subtitle() }
         }
         trailingContent()
@@ -209,6 +218,9 @@ fun GridItem(
     thumbnailContent: @Composable BoxWithConstraintsScope.() -> Unit,
     thumbnailRatio: Float = 1f,
     fillMaxWidth: Boolean = false,
+    // Set by the string overload when its title marquees, so the card can re-arm the glide on focus
+    // (D-pad/TV) - the title composable itself is opaque here, hence the flag.
+    titleMarquee: Boolean = false,
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val backgroundColor by animateColorAsState(
@@ -249,7 +261,11 @@ fun GridItem(
 
         Spacer(modifier = Modifier.height(6.dp))
 
-        title()
+        if (titleMarquee) {
+            RefocusableMarqueeTitle(focused = isFocused) { title() }
+        } else {
+            title()
+        }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             badges()
@@ -273,6 +289,7 @@ fun GridItem(
     titleMarquee: Boolean = false,
 ) = GridItem(
     modifier = modifier,
+    titleMarquee = titleMarquee,
     title = {
         Text(
             text = title,
@@ -281,7 +298,9 @@ fun GridItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Start,
-            modifier = if (titleMarquee) Modifier.gentleMarquee().fillMaxWidth() else Modifier.fillMaxWidth()
+            // A marquee measures its child unbounded, so fillMaxWidth would be inert under it (dead);
+            // only the ellipsizing branch needs it to fill the card width.
+            modifier = if (titleMarquee) Modifier.gentleMarquee() else Modifier.fillMaxWidth()
         )
     },
     subtitle = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -128,7 +128,10 @@ inline fun ListItem(
     noinline subtitle: (@Composable RowScope.() -> Unit)? = null,
     thumbnailContent: @Composable () -> Unit,
     trailingContent: @Composable RowScope.() -> Unit = {},
-    isActive: Boolean = false
+    isActive: Boolean = false,
+    // Gently scroll a title too long for one line instead of ellipsizing it (podcast rows: long
+    // show/episode titles). Off by default so music rows are unchanged.
+    titleMarquee: Boolean = false
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val backgroundColor by animateColorAsState(
@@ -163,7 +166,8 @@ inline fun ListItem(
         Column(Modifier.weight(1f).padding(horizontal = 6.dp)) {
             Text(
                 text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
-                maxLines = 1, overflow = TextOverflow.Ellipsis
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                modifier = if (titleMarquee) Modifier.gentleMarquee() else Modifier
             )
             if (subtitle != null) Row(verticalAlignment = Alignment.CenterVertically) { subtitle() }
         }
@@ -179,11 +183,13 @@ fun ListItem(
     badges: @Composable RowScope.() -> Unit = {},
     thumbnailContent: @Composable () -> Unit,
     trailingContent: @Composable RowScope.() -> Unit = {},
-    isActive: Boolean = false
+    isActive: Boolean = false,
+    titleMarquee: Boolean = false
 ) = ListItem(
     title = title,
     modifier = modifier,
     isActive = isActive,
+    titleMarquee = titleMarquee,
     subtitle = {
         badges()
         if (!subtitle.isNullOrEmpty()) {
@@ -262,6 +268,9 @@ fun GridItem(
     thumbnailContent: @Composable BoxWithConstraintsScope.() -> Unit,
     thumbnailRatio: Float = 1f,
     fillMaxWidth: Boolean = false,
+    // Gently scroll a title too long for one narrow card instead of ellipsizing it (podcast browse
+    // cards) - the same one-glide feel as the podcast list rows. Off by default.
+    titleMarquee: Boolean = false,
 ) = GridItem(
     modifier = modifier,
     title = {
@@ -272,7 +281,7 @@ fun GridItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Start,
-            modifier = Modifier.fillMaxWidth()
+            modifier = if (titleMarquee) Modifier.gentleMarquee().fillMaxWidth() else Modifier.fillMaxWidth()
         )
     },
     subtitle = {
@@ -318,6 +327,7 @@ fun SongListItem(
     isActive: Boolean = false,
     isPlaying: Boolean = false,
     isSwipeable: Boolean = true,
+    titleMarquee: Boolean = false,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
     val swipeEnabled by rememberPreference(SwipeToSongKey, defaultValue = false)
@@ -325,6 +335,7 @@ fun SongListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = song.song.title,
+            titleMarquee = titleMarquee,
             subtitle = joinByBullet(
                 song.artists.joinToString { it.name },
                 makeTimeString(song.song.duration * 1000L)
@@ -865,6 +876,8 @@ fun YouTubeListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = item.title,
+            // Podcast shows/episodes carry long titles; gently scroll them instead of clipping.
+            titleMarquee = item is PodcastItem || item is EpisodeItem,
             subtitle = subtitleOverride ?: when (item) {
                 is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
                 is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
@@ -927,6 +940,7 @@ fun EpisodeListItem(
         ?.let { pos -> durationMs?.let { d -> makeTimeString((d - pos).coerceAtLeast(0)) } }
     ListItem(
         title = episode.title,
+        titleMarquee = true,
         subtitle = joinByBullet(
             episode.publishDateText,
             if (timeLeft != null) stringResource(R.string.episode_time_left, timeLeft)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt
@@ -154,8 +154,10 @@ inline fun ListItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .pressBounce()
-            .focusable()
+            // onFocusChanged only observes focus targets AFTER it in the chain, so it must precede
+            // focusable() (the FocusBorder.kt order) - reversed, the row's own focus is never seen.
             .onFocusChanged { isFocused = it.isFocused }
+            .focusable()
             .height(ListItemHeight)
             .padding(horizontal = ListItemHorizontalPadding)
             .clip(RoundedCornerShape(8.dp))
@@ -164,20 +166,12 @@ inline fun ListItem(
     ) {
         Box(Modifier.padding(ListThumbnailPadding), contentAlignment = Alignment.Center) { thumbnailContent() }
         Column(Modifier.weight(1f).padding(horizontal = 6.dp)) {
-            if (titleMarquee) {
-                RefocusableMarqueeTitle(focused = isFocused) {
-                    Text(
-                        text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
-                        maxLines = 1, overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.gentleMarquee()
-                    )
-                }
-            } else {
-                Text(
-                    text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
-                    maxLines = 1, overflow = TextOverflow.Ellipsis
-                )
-            }
+            Text(
+                text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                // The row's own focus re-arms the one-shot glide for D-pad/TV users.
+                modifier = if (titleMarquee) Modifier.gentleMarquee(focused = isFocused) else Modifier
+            )
             if (subtitle != null) Row(verticalAlignment = Alignment.CenterVertically) { subtitle() }
         }
         trailingContent()
@@ -218,8 +212,9 @@ fun GridItem(
     thumbnailContent: @Composable BoxWithConstraintsScope.() -> Unit,
     thumbnailRatio: Float = 1f,
     fillMaxWidth: Boolean = false,
-    // Set by the string overload when its title marquees, so the card can re-arm the glide on focus
-    // (D-pad/TV) - the title composable itself is opaque here, hence the flag.
+    // Gently scroll an overflowing title once instead of ellipsizing, re-armed on D-pad focus. The
+    // card applies gentleMarquee AROUND the opaque title slot, so the slot content itself must not
+    // carry its own marquee when this is set.
     titleMarquee: Boolean = false,
 ) {
     var isFocused by remember { mutableStateOf(false) }
@@ -234,8 +229,10 @@ fun GridItem(
     val baseModifier = modifier
         .pressBounce()
         .padding(12.dp)
-        .focusable()
+        // onFocusChanged only observes focus targets AFTER it in the chain, so it must precede
+        // focusable() (the FocusBorder.kt order) - reversed, the card's own focus is never seen.
         .onFocusChanged { isFocused = it.isFocused }
+        .focusable()
         .clip(RoundedCornerShape(12.dp))
         .background(backgroundColor)
         .border(width = 1.5.dp, color = borderColor, shape = RoundedCornerShape(12.dp))
@@ -262,7 +259,10 @@ fun GridItem(
         Spacer(modifier = Modifier.height(6.dp))
 
         if (titleMarquee) {
-            RefocusableMarqueeTitle(focused = isFocused) { title() }
+            // The title slot is opaque here, so the marquee wraps it (basicMarquee animates any
+            // overflowing child); the card's own focus re-arms the glide for D-pad/TV users. The
+            // slot content must NOT carry its own marquee - two nested marquees fight.
+            Box(Modifier.gentleMarquee(focused = isFocused)) { title() }
         } else {
             title()
         }
@@ -298,9 +298,10 @@ fun GridItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Start,
-            // A marquee measures its child unbounded, so fillMaxWidth would be inert under it (dead);
-            // only the ellipsizing branch needs it to fill the card width.
-            modifier = if (titleMarquee) Modifier.gentleMarquee() else Modifier.fillMaxWidth()
+            // The marquee (when titleMarquee) is applied by GridItem around the title slot; under it
+            // this fillMaxWidth is inert (a marquee measures its child unbounded), and without it
+            // fillMaxWidth is what lets the text fill the card.
+            modifier = Modifier.fillMaxWidth()
         )
     },
     subtitle = {
@@ -346,7 +347,6 @@ fun SongListItem(
     isActive: Boolean = false,
     isPlaying: Boolean = false,
     isSwipeable: Boolean = true,
-    titleMarquee: Boolean = false,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
     val swipeEnabled by rememberPreference(SwipeToSongKey, defaultValue = false)
@@ -354,7 +354,9 @@ fun SongListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = song.song.title,
-            titleMarquee = titleMarquee,
+            // Episodes carry long titles; decided by type HERE so every caller (library tabs,
+            // auto-playlists, history) gets the glide without a per-call-site flag to forget.
+            titleMarquee = song.song.isEpisode,
             subtitle = joinByBullet(
                 song.artists.joinToString { it.name },
                 makeTimeString(song.song.duration * 1000L)
@@ -1037,6 +1039,10 @@ fun YouTubeGridItem(
     // Suppress the sub-label entirely (the compact Home curated card is just the cover).
     showSubtitle: Boolean = true,
 ) = GridItem(
+    // Podcast shows/episodes carry long titles; give their cards the same calm one-shot glide
+    // (re-armed on D-pad focus) as their list rows, instead of the looping music-card marquee -
+    // otherwise the Podcasts Home shelves/see-alls/genre grids loop forever while the rows below glide.
+    titleMarquee = showTitle && (item is PodcastItem || item is EpisodeItem),
     title = {
         if (showTitle) {
             Text(
@@ -1046,7 +1052,10 @@ fun YouTubeGridItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 textAlign = if (item is ArtistItem) TextAlign.Center else TextAlign.Start,
-                modifier = Modifier.basicMarquee().fillMaxWidth()
+                // Podcast/episode cards marquee via GridItem's titleMarquee wrapper (never doubled);
+                // every other card keeps its pre-existing looping marquee.
+                modifier = if (item is PodcastItem || item is EpisodeItem) Modifier.fillMaxWidth()
+                else Modifier.basicMarquee().fillMaxWidth()
             )
         }
     },

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt
@@ -412,6 +412,7 @@ fun WhitelistedPodcastListItem(
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) = ListItem(
     title = podcast.name,
+    titleMarquee = true,
     subtitle = "",
     badges = {},
     thumbnailContent = {
@@ -469,6 +470,7 @@ fun WhitelistedPodcastGridItem(
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) = GridItem(
     title = podcast.name,
+    titleMarquee = true,
     subtitle = "",
     badges = {},
     thumbnailContent = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
@@ -1,8 +1,25 @@
 package com.jtech.zemer.ui.component
 
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+
+/**
+ * Set true by [RefocusableMarqueeTitle] around a focused row/card's title so [gentleMarquee] can
+ * re-arm its one-shot glide promptly the moment a D-pad/TV user focuses the row. Everywhere else
+ * (now-playing / mini-player titles, and every touch session, where a row is never focused) it stays
+ * false, so the calm appear-once behavior is unchanged.
+ */
+val LocalMarqueeTitleFocused = compositionLocalOf { false }
 
 /**
  * A calm, one-shot title marquee: sit still for a moment, glide through the overflow once at a gentle
@@ -11,6 +28,37 @@ import androidx.compose.ui.unit.dp
  *
  * Titles that already fit are unaffected (a marquee only animates on overflow). This is the shared
  * source for the now-playing/mini-player titles and the podcast list rows so they can't drift.
+ *
+ * Wrap a focusable row/card's title in [RefocusableMarqueeTitle] to re-arm the glide on focus.
  */
+@Composable
 fun Modifier.gentleMarquee(): Modifier =
-    this.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp)
+    this.basicMarquee(
+        iterations = 1,
+        initialDelayMillis = if (LocalMarqueeTitleFocused.current) 600 else 3000,
+        velocity = 30.dp,
+    )
+
+/**
+ * Wraps a [gentleMarquee] title so the one-shot glide RE-ARMS each time the row/card gains focus.
+ *
+ * A one-shot marquee fires ~once after the row first composes and then snaps back to the clipped
+ * start, so a D-pad/TV user who navigates onto a long title later never sees it scroll (against the
+ * full-D-pad-navigability mandate). Passing the row's own [focused] state here re-keys the title on
+ * every focus gain (replaying the glide) and shortens its settle delay so the re-arm is prompt.
+ * Touch sessions never focus a row, so [focused] stays false and the behavior is the calm
+ * appear-once glide - no change there.
+ *
+ * The caller supplies the actual `Text(..., Modifier.gentleMarquee())` as [content]; this owns only
+ * the focus re-arm so the row/card composables don't each re-roll it.
+ */
+@Composable
+fun RefocusableMarqueeTitle(focused: Boolean, content: @Composable () -> Unit) {
+    var generation by remember { mutableIntStateOf(0) }
+    LaunchedEffect(focused) { if (focused) generation++ }
+    key(generation) {
+        CompositionLocalProvider(LocalMarqueeTitleFocused provides focused) {
+            content()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
@@ -2,24 +2,13 @@ package com.jtech.zemer.ui.component
 
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-
-/**
- * Set true by [RefocusableMarqueeTitle] around a focused row/card's title so [gentleMarquee] can
- * re-arm its one-shot glide promptly the moment a D-pad/TV user focuses the row. Everywhere else
- * (now-playing / mini-player titles, and every touch session, where a row is never focused) it stays
- * false, so the calm appear-once behavior is unchanged.
- */
-val LocalMarqueeTitleFocused = compositionLocalOf { false }
 
 /**
  * A calm, one-shot title marquee: sit still for a moment, glide through the overflow once at a gentle
@@ -27,38 +16,50 @@ val LocalMarqueeTitleFocused = compositionLocalOf { false }
  * that there is more text rather than constant motion - the right feel for a column of list rows.
  *
  * Titles that already fit are unaffected (a marquee only animates on overflow). This is the shared
- * source for the now-playing/mini-player titles and the podcast list rows so they can't drift.
+ * source for the now-playing/mini-player titles and the podcast list rows/cards so they can't drift.
  *
- * Wrap a focusable row/card's title in [RefocusableMarqueeTitle] to re-arm the glide on focus.
+ * [focused] is the owning row/card's D-pad focus state. A one-shot glide fires ~once after the row
+ * first composes, so a D-pad/TV user who navigates onto a long title later would otherwise never see
+ * it scroll (against the full-D-pad-navigability mandate); passing focus here re-arms the glide
+ * promptly on every focus GAIN. The marquee node restarts whenever its params change, so the re-arm
+ * is pure param plumbing - see [gentleMarqueeParams] (JVM-tested) for the exact rules, including why
+ * a focus LOSS must DISABLE the glide rather than fall back to the resting params. Touch sessions
+ * never focus a row, so the default stays the calm appear-once glide - no change there.
  */
 @Composable
-fun Modifier.gentleMarquee(): Modifier =
-    this.basicMarquee(
-        iterations = 1,
-        initialDelayMillis = if (LocalMarqueeTitleFocused.current) 600 else 3000,
+fun Modifier.gentleMarquee(focused: Boolean = false): Modifier {
+    var everFocused by remember { mutableStateOf(false) }
+    if (focused && !everFocused) {
+        // Latch after the frame lands - the focused branch already governs this frame's params.
+        SideEffect { everFocused = true }
+    }
+    val params = gentleMarqueeParams(focused = focused, everFocused = everFocused)
+    return basicMarquee(
+        iterations = params.iterations,
+        initialDelayMillis = params.initialDelayMillis,
         velocity = 30.dp,
     )
+}
+
+/** Animation params for [gentleMarquee]; a pure holder so the decision below is JVM-testable. */
+data class GentleMarqueeParams(val iterations: Int, val initialDelayMillis: Int)
 
 /**
- * Wraps a [gentleMarquee] title so the one-shot glide RE-ARMS each time the row/card gains focus.
+ * The pure param spec behind [gentleMarquee]. The marquee node restarts its animation on ANY param
+ * change (verified against Compose Foundation's MarqueeModifierNode.update), which is both the
+ * re-arm mechanism and the trap the states below are shaped around:
  *
- * A one-shot marquee fires ~once after the row first composes and then snaps back to the clipped
- * start, so a D-pad/TV user who navigates onto a long title later never sees it scroll (against the
- * full-D-pad-navigability mandate). Passing the row's own [focused] state here re-keys the title on
- * every focus gain (replaying the glide) and shortens its settle delay so the re-arm is prompt.
- * Touch sessions never focus a row, so [focused] stays false and the behavior is the calm
- * appear-once glide - no change there.
- *
- * The caller supplies the actual `Text(..., Modifier.gentleMarquee())` as [content]; this owns only
- * the focus re-arm so the row/card composables don't each re-roll it.
+ * - Never focused: one glide after a long settle - the calm appear-once default (and the only state
+ *   a touch session ever sees; its params never change, so it never restarts).
+ * - Focused: one glide after a short settle. Reached from either other state it is always a param
+ *   change, so every focus gain replays the glide promptly.
+ * - Focus lost after a visit: iterations = 0 (basicMarquee's documented "no animation" - the node
+ *   restarts but runs nothing, snapping the title back to its clipped start). Falling back to the
+ *   resting params instead would BE a param change and replay the glide on every row a D-pad user
+ *   leaves - a trailing cascade of gliding titles behind the cursor.
  */
-@Composable
-fun RefocusableMarqueeTitle(focused: Boolean, content: @Composable () -> Unit) {
-    var generation by remember { mutableIntStateOf(0) }
-    LaunchedEffect(focused) { if (focused) generation++ }
-    key(generation) {
-        CompositionLocalProvider(LocalMarqueeTitleFocused provides focused) {
-            content()
-        }
-    }
+fun gentleMarqueeParams(focused: Boolean, everFocused: Boolean): GentleMarqueeParams = when {
+    focused -> GentleMarqueeParams(iterations = 1, initialDelayMillis = 600)
+    everFocused -> GentleMarqueeParams(iterations = 0, initialDelayMillis = 600)
+    else -> GentleMarqueeParams(iterations = 1, initialDelayMillis = 3000)
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt
@@ -1,0 +1,16 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * A calm, one-shot title marquee: sit still for a moment, glide through the overflow once at a gentle
+ * speed, then stop. Unlike the default [basicMarquee] (immediate, infinite loop), it reads as a hint
+ * that there is more text rather than constant motion - the right feel for a column of list rows.
+ *
+ * Titles that already fit are unaffected (a marquee only animates on overflow). This is the shared
+ * source for the now-playing/mini-player titles and the podcast list rows so they can't drift.
+ */
+fun Modifier.gentleMarquee(): Modifier =
+    this.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -96,6 +96,7 @@ import com.jtech.zemer.utils.rememberPreference
 import androidx.compose.ui.graphics.toArgb
 import kotlinx.coroutines.launch
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.gentleMarquee
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import androidx.compose.ui.res.stringResource
@@ -542,7 +543,7 @@ private fun NewMiniPlayer(
                                 fontWeight = FontWeight.Medium,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp),
+                                modifier = Modifier.gentleMarquee(),
                             )
                         }
 
@@ -566,7 +567,7 @@ private fun NewMiniPlayer(
                                         style = MaterialTheme.typography.bodySmall,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp),
+                                        modifier = Modifier.gentleMarquee(),
                                     )
                                 }
                             }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -1074,7 +1075,9 @@ private fun LegacyMiniMediaInfo(
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.gentleMarquee(),
+                    // Deliberately the default marquee (3 loops, ~1.2s in), NOT gentleMarquee: the
+                    // legacy mini bar is glanced at briefly, so a 3s one-shot would never be seen.
+                    modifier = Modifier.basicMarquee(),
                 )
             }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -1075,7 +1074,7 @@ private fun LegacyMiniMediaInfo(
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.basicMarquee(),
+                    modifier = Modifier.gentleMarquee(),
                 )
             }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -15,7 +15,6 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -109,6 +108,7 @@ import com.jtech.zemer.LocalPlayerConnection
 import com.jtech.zemer.R
 import com.jtech.zemer.playback.PlayerConnection
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.gentleMarquee
 import com.jtech.zemer.constants.DarkModeKey
 import com.jtech.zemer.constants.FloatingMiniPlayerKey
 import com.jtech.zemer.constants.PlayerBackgroundStyle
@@ -627,7 +627,7 @@ fun BottomSheetPlayer(
                                 color = TextBackgroundColor,
                                 modifier =
                                 Modifier
-                                    .basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp)
+                                    .gentleMarquee()
                                     .combinedClickable(
                                         enabled = true,
                                         indication = null,
@@ -676,7 +676,7 @@ fun BottomSheetPlayer(
                                 .fillMaxWidth()
                                 .border(2.dp, artistBorderColor.value, RoundedCornerShape(4.dp))
                                 .padding(4.dp)
-                                .basicMarquee(iterations = 1, initialDelayMillis = 3000, velocity = 30.dp)
+                                .gentleMarquee()
                                 .focusable()
                                 .onFocusChanged { artistFocused.value = it.isFocused }
                         ) {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt
@@ -26,7 +26,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -292,11 +295,8 @@ fun LibraryPodcastsScreen(
                         PodcastArtistChannelItem(
                             thumbnailUrl = channel.thumbnailUrl,
                             channelName = channel.name,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .focusBorder()
-                                .clickable { navController.navigateToArtist(channel.id, isPodcastChannel = true) }
-                                .animateItem(),
+                            onClick = { navController.navigateToArtist(channel.id, isPodcastChannel = true) },
+                            modifier = Modifier.animateItem(),
                         )
                     }
 
@@ -363,7 +363,6 @@ fun LibraryPodcastsScreen(
                             showInLibraryIcon = false,
                             showLikedIcon = false,
                             showDownloadIcon = true,
-                            titleMarquee = true,
                             isActive = episode.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             trailingContent = {
@@ -486,9 +485,12 @@ private fun AutoPlaylistCard(
     // look), instead of the first episode's thumbnail — theme-aware (seeded from the chosen accent).
     gradientCover: Boolean = false,
 ) {
+    // Observed BEFORE focusBorder (whose focusable is the row's focus target) so the title glide
+    // re-arms when a D-pad user focuses the row - a bare gentleMarquee would fire once and never again.
+    var focused by remember { mutableStateOf(false) }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.fillMaxWidth().focusBorder().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 10.dp),
+        modifier = modifier.fillMaxWidth().onFocusChanged { focused = it.isFocused }.focusBorder().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 10.dp),
     ) {
         if (gradientCover) {
             Box(
@@ -512,7 +514,7 @@ private fun AutoPlaylistCard(
         }
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee())
+            Text(text = title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee(focused = focused))
             Text(
                 text = buildString {
                     append(stringResource(R.string.auto_playlist))
@@ -538,14 +540,16 @@ private fun PodcastEpisodePlaylistItem(
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Same focus wiring as AutoPlaylistCard - re-arm the title glide when the row gains D-pad focus.
+    var focused by remember { mutableStateOf(false) }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.focusBorder().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier = modifier.onFocusChanged { focused = it.isFocused }.focusBorder().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         PodcastRowThumbnail(podcast.thumbnailUrl)
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = podcast.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee())
+            Text(text = podcast.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee(focused = focused))
             if (!podcast.author.isNullOrBlank()) {
                 Text(
                     text = podcast.author,
@@ -591,16 +595,27 @@ private fun PodcastEpisodePlaylistMenu(
     Spacer(Modifier.size(12.dp))
 }
 
-/** A podcast host channel row shown in the Channels tab. */
+/**
+ * A podcast host channel row shown in the Channels tab. Owns its focusBorder + click chain like its
+ * sibling rows (AutoPlaylistCard / PodcastEpisodePlaylistItem) so it can observe its own focus and
+ * re-arm the title glide on D-pad focus - a caller-side focusBorder would be invisible to it.
+ */
 @Composable
 private fun PodcastArtistChannelItem(
     thumbnailUrl: String?,
     channelName: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var focused by remember { mutableStateOf(false) }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { focused = it.isFocused }
+            .focusBorder()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         AsyncImage(
             model = thumbnailUrl,
@@ -614,7 +629,7 @@ private fun PodcastArtistChannelItem(
             style = MaterialTheme.typography.bodyLarge,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f).gentleMarquee(),
+            modifier = Modifier.weight(1f).gentleMarquee(focused = focused),
         )
     }
 }
@@ -637,7 +652,6 @@ private fun EpisodeSongListItem(
         showLikedIcon = false,
         showInLibraryIcon = false,
         showDownloadIcon = true,
-        titleMarquee = true,
         isActive = isActive,
         isPlaying = isPlaying,
         trailingContent = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt
@@ -68,6 +68,7 @@ import com.jtech.zemer.ui.component.LibraryFilterChip
 import com.jtech.zemer.ui.component.EmptyPlaceholder
 import com.jtech.zemer.ui.component.HideOnScrollFAB
 import com.jtech.zemer.ui.component.focusBorder
+import com.jtech.zemer.ui.component.gentleMarquee
 import com.jtech.zemer.ui.component.LocalMenuState
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
@@ -362,6 +363,7 @@ fun LibraryPodcastsScreen(
                             showInLibraryIcon = false,
                             showLikedIcon = false,
                             showDownloadIcon = true,
+                            titleMarquee = true,
                             isActive = episode.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             trailingContent = {
@@ -510,7 +512,7 @@ private fun AutoPlaylistCard(
         }
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(text = title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee())
             Text(
                 text = buildString {
                     append(stringResource(R.string.auto_playlist))
@@ -543,7 +545,7 @@ private fun PodcastEpisodePlaylistItem(
         PodcastRowThumbnail(podcast.thumbnailUrl)
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = podcast.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(text = podcast.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.gentleMarquee())
             if (!podcast.author.isNullOrBlank()) {
                 Text(
                     text = podcast.author,
@@ -612,7 +614,7 @@ private fun PodcastArtistChannelItem(
             style = MaterialTheme.typography.bodyLarge,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).gentleMarquee(),
         )
     }
 }
@@ -635,6 +637,7 @@ private fun EpisodeSongListItem(
         showLikedIcon = false,
         showInLibraryIcon = false,
         showDownloadIcon = true,
+        titleMarquee = true,
         isActive = isActive,
         isPlaying = isPlaying,
         trailingContent = {

--- a/app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt
@@ -1,0 +1,42 @@
+package com.jtech.zemer.ui.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Pins the pure param spec behind the shared one-shot title marquee ([gentleMarqueeParams]). The
+ * marquee node restarts its animation on ANY param change, so these params ARE the behavior: a
+ * focus gain must always be a param change (the D-pad re-arm), and a focus loss must land on the
+ * no-animation state (iterations = 0) - falling back to the resting params would itself be a param
+ * change and replay the glide behind the D-pad cursor on every row the user leaves.
+ */
+class GentleMarqueeTest {
+
+    @Test
+    fun `never focused is the calm appear-once default`() {
+        assertEquals(
+            GentleMarqueeParams(iterations = 1, initialDelayMillis = 3000),
+            gentleMarqueeParams(focused = false, everFocused = false),
+        )
+    }
+
+    @Test
+    fun `focus gain re-arms promptly and is a param change from both unfocused states`() {
+        val focusedParams = gentleMarqueeParams(focused = true, everFocused = false)
+        assertEquals(GentleMarqueeParams(iterations = 1, initialDelayMillis = 600), focusedParams)
+        // focused dominates the latch, so a re-gain after a loss lands on the same params...
+        assertEquals(focusedParams, gentleMarqueeParams(focused = true, everFocused = true))
+        // ...and they differ from BOTH unfocused states, so every focus gain restarts the node.
+        assertNotEquals(focusedParams, gentleMarqueeParams(focused = false, everFocused = false))
+        assertNotEquals(focusedParams, gentleMarqueeParams(focused = false, everFocused = true))
+    }
+
+    @Test
+    fun `focus loss disables the glide instead of replaying it`() {
+        val afterLoss = gentleMarqueeParams(focused = false, everFocused = true)
+        assertEquals(0, afterLoss.iterations)
+        // It must NOT equal the resting params - that fallback is exactly the replay-on-loss bug.
+        assertNotEquals(gentleMarqueeParams(focused = false, everFocused = false), afterLoss)
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -255,13 +255,13 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 | `com.jtech.zemer.ui.component` | yes | 41 | 9 | androidx.annotation, androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 | `com.jtech.zemer.ui.component` | yes | 24 | 1 | androidx.annotation, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1780 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1799 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 | `com.jtech.zemer.ui.component` | yes | 37 | 23 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 | `com.jtech.zemer.ui.component` | yes | 41 | 12 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 | `com.jtech.zemer.ui.component` | yes | 13 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 | `com.jtech.zemer.ui.component` | yes | 117 | 107 | android.annotation, android.content, android.os, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 16 | `com.jtech.zemer.ui.component` | no | 3 | 1 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 64 | `com.jtech.zemer.ui.component` | yes | 12 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 | `com.jtech.zemer.ui.component` | yes | 36 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 | `com.jtech.zemer.ui.component` | yes | 13 | 2 | androidx.compose |
@@ -330,7 +330,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 | `com.jtech.zemer.ui.player` | yes | 26 | 12 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 | `com.jtech.zemer.ui.player` | no | 1 | 7 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 | `com.jtech.zemer.ui.player` | yes | 92 | 30 | android.app, android.content, android.view, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, dagger.hilt, kotlinx.coroutines, me.saket |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1108 | `com.jtech.zemer.ui.player` | yes | 99 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 | `com.jtech.zemer.ui.player` | yes | 98 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 | `com.jtech.zemer.ui.player` | yes | 9 | 5 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 | `com.jtech.zemer.ui.player` | yes | 156 | 114 | android.annotation, android.app, android.content, androidx.compose, androidx.core, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines, me.saket |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -255,13 +255,13 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 | `com.jtech.zemer.ui.component` | yes | 41 | 9 | androidx.annotation, androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 | `com.jtech.zemer.ui.component` | yes | 24 | 1 | androidx.annotation, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1799 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1808 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 | `com.jtech.zemer.ui.component` | yes | 37 | 23 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 | `com.jtech.zemer.ui.component` | yes | 41 | 12 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 | `com.jtech.zemer.ui.component` | yes | 13 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 | `com.jtech.zemer.ui.component` | yes | 117 | 107 | android.annotation, android.content, android.os, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 64 | `com.jtech.zemer.ui.component` | yes | 12 | 4 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 | `com.jtech.zemer.ui.component` | yes | 9 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 | `com.jtech.zemer.ui.component` | yes | 36 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 | `com.jtech.zemer.ui.component` | yes | 13 | 2 | androidx.compose |
@@ -330,7 +330,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 | `com.jtech.zemer.ui.player` | yes | 26 | 12 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 | `com.jtech.zemer.ui.player` | no | 1 | 7 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 | `com.jtech.zemer.ui.player` | yes | 92 | 30 | android.app, android.content, android.view, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, dagger.hilt, kotlinx.coroutines, me.saket |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 | `com.jtech.zemer.ui.player` | yes | 98 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1110 | `com.jtech.zemer.ui.player` | yes | 99 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 | `com.jtech.zemer.ui.player` | yes | 9 | 5 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 | `com.jtech.zemer.ui.player` | yes | 156 | 114 | android.annotation, android.app, android.content, androidx.compose, androidx.core, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines, me.saket |
@@ -380,7 +380,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryArtistsScreen.kt` | 295 | `com.jtech.zemer.ui.screens.library` | yes | 64 | 18 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 785 | `com.jtech.zemer.ui.screens.library` | yes | 99 | 38 | androidx.compose, androidx.hilt, androidx.navigation, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 543 | `com.jtech.zemer.ui.screens.library` | yes | 76 | 31 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 655 | `com.jtech.zemer.ui.screens.library` | yes | 83 | 32 | androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 669 | `com.jtech.zemer.ui.screens.library` | yes | 86 | 35 | androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 103 | `com.jtech.zemer.ui.screens.library` | yes | 17 | 8 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 317 | `com.jtech.zemer.ui.screens.library` | yes | 69 | 22 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 145 | `com.jtech.zemer.ui.screens.library` | yes | 39 | 9 | androidx.compose, androidx.hilt, androidx.navigation |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` - a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline - they are not duplicated here.
 
-## `app` Kotlin files (680)
+## `app` Kotlin files (681)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -255,12 +255,13 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 | `com.jtech.zemer.ui.component` | yes | 41 | 9 | androidx.annotation, androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 | `com.jtech.zemer.ui.component` | yes | 24 | 1 | androidx.annotation, androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1766 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1780 | `com.jtech.zemer.ui.component` | yes | 116 | 104 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 | `com.jtech.zemer.ui.component` | yes | 37 | 23 | androidx.compose, kotlin.math |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 522 | `com.jtech.zemer.ui.component` | yes | 41 | 12 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 | `com.jtech.zemer.ui.component` | yes | 41 | 12 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 | `com.jtech.zemer.ui.component` | yes | 13 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 | `com.jtech.zemer.ui.component` | yes | 117 | 107 | android.annotation, android.content, android.os, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 16 | `com.jtech.zemer.ui.component` | no | 3 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 | `com.jtech.zemer.ui.component` | yes | 36 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 | `com.jtech.zemer.ui.component` | yes | 13 | 2 | androidx.compose |
@@ -329,7 +330,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 | `com.jtech.zemer.ui.player` | yes | 26 | 12 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 | `com.jtech.zemer.ui.player` | no | 1 | 7 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 | `com.jtech.zemer.ui.player` | yes | 92 | 30 | android.app, android.content, android.view, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, coil3.compose, dagger.hilt, kotlinx.coroutines, me.saket |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 | `com.jtech.zemer.ui.player` | yes | 98 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1108 | `com.jtech.zemer.ui.player` | yes | 99 | 111 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 | `com.jtech.zemer.ui.player` | yes | 9 | 5 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 | `com.jtech.zemer.ui.player` | yes | 156 | 114 | android.annotation, android.app, android.content, androidx.compose, androidx.core, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines, me.saket |
@@ -379,7 +380,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryArtistsScreen.kt` | 295 | `com.jtech.zemer.ui.screens.library` | yes | 64 | 18 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 785 | `com.jtech.zemer.ui.screens.library` | yes | 99 | 38 | androidx.compose, androidx.hilt, androidx.navigation, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 543 | `com.jtech.zemer.ui.screens.library` | yes | 76 | 31 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 652 | `com.jtech.zemer.ui.screens.library` | yes | 82 | 32 | androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, coil3.compose, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 655 | `com.jtech.zemer.ui.screens.library` | yes | 83 | 32 | androidx.compose, androidx.hilt, androidx.lifecycle, androidx.navigation, coil3.compose, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 103 | `com.jtech.zemer.ui.screens.library` | yes | 17 | 8 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 317 | `com.jtech.zemer.ui.screens.library` | yes | 69 | 22 | androidx.activity, androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 145 | `com.jtech.zemer.ui.screens.library` | yes | 39 | 9 | androidx.compose, androidx.hilt, androidx.navigation |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 1512 lines | text `.md` |
+| `AGENTS.md` | 1519 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 1512 lines | `.md` |
+| `AGENTS.md` | 1519 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -415,13 +415,13 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1799 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1808 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 64 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 lines | `.kt` |
@@ -490,7 +490,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1110 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 lines | `.kt` |
@@ -540,7 +540,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryArtistsScreen.kt` | 295 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 785 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 543 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 655 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 669 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 103 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 317 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 145 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,12 +77,12 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1221`
+- Files counted: `1217`
 - By extension:
   - `.kt`: `773`
   - `.xml`: `196`
   - `.mjs`: `77`
-  - `.md`: `75`
+  - `.md`: `71`
   - `.json`: `37`
   - `.webp`: `15`
   - `[none]`: `7`
@@ -1107,8 +1107,6 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
 | `docs/reference/kotlin-files.md` | 796 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 387 lines | `.md` |
-| `docs/reference/non-kotlin-files.md` | 387 lines | `.md` |
-| `docs/reference/non-kotlin-files.md` | 387 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
 | `docs/remote_cipher_config/02-file-format.md` | 116 lines | `.md` |
@@ -1118,9 +1116,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1331 lines | `.md` |
-| `docs/repository-map.md` | 1331 lines | `.md` |
-| `docs/repository-map.md` | 1331 lines | `.md` |
+| `docs/repository-map.md` | 1327 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -415,13 +415,13 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1780 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1799 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 16 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 64 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 lines | `.kt` |
@@ -490,7 +490,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1108 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1215`
+- Files counted: `1216`
 - By extension:
-  - `.kt`: `771`
+  - `.kt`: `772`
   - `.xml`: `196`
   - `.mjs`: `77`
   - `.md`: `71`
@@ -415,12 +415,13 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1766 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1780 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 522 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 524 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 956 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 16 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/MediaLoadingSpinner.kt` | 66 lines | `.kt` |
@@ -489,7 +490,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/CastButton.kt` | 93 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/EpisodeSpeed.kt` | 35 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/LyricsScreen.kt` | 751 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1107 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 1108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1551 lines | `.kt` |
@@ -539,7 +540,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryArtistsScreen.kt` | 295 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryMixScreen.kt` | 785 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPlaylistsScreen.kt` | 543 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 652 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryPodcastsScreen.kt` | 655 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryScreen.kt` | 103 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibrarySongsScreen.kt` | 317 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/library/LibraryVideosScreen.kt` | 145 lines | `.kt` |
@@ -1103,7 +1104,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 794 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 795 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 387 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -1114,7 +1115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1325 lines | `.md` |
+| `docs/repository-map.md` | 1326 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |


### PR DESCRIPTION
Closes #462.

Long podcast show and episode titles were clipped to one line, so the full title could not be read. They now gently scroll: a title too wide to fit sits still briefly, glides through once, then stops (the same one-glide behavior as the now-playing title).

Surfaces covered:
- Podcast browse grid and list
- Podcast card shelves on the Podcasts Home tab, their see-all grids, and the genre grids
- Show screen episode list
- Search podcast/episode rows
- Library podcast tabs (episodes, channels, downloaded, saved-for-later), including the auto-playlist, saved-show, and channel rows
- Episode rows rendered through the generic song row (downloaded-episodes auto-playlist, history) - the marquee is derived from `isEpisode` inside `SongListItem`, so no per-call-site flag

Music rows are unchanged; the marquee only animates when a title actually overflows its width.

D-pad/TV behavior: a one-shot glide fires once after a row composes, so a D-pad user who focuses a long title later would never see it scroll. Every marqueed row/card observes its own focus (`onFocusChanged` before `focusable`, the `FocusBorder.kt` order) and passes it to `gentleMarquee(focused)`: a focus gain re-arms the glide with a short settle, and a focus loss disables it (`iterations = 0`) rather than replaying it behind the cursor. The marquee node restarts on any param change, so this is pure param plumbing - no re-keying, no CompositionLocal, and the param spec is a pure function pinned by a JVM test (`GentleMarqueeTest`).

Also extracts the one-glide marquee timing into a shared `gentleMarquee()` modifier and points the existing mini-player and full-player titles at it, so the values live in one place instead of being copied inline. The legacy mini player keeps its default marquee (its bar is glanced at briefly; a 3s one-shot would never be seen). `gentleMarquee` is listed in the AGENTS.md shared-components roster.

Verified with a debug build, the UI audit, and the new JVM regression test.
