### PR TITLE
fix(watchtime): recover short offline plays as views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,8 @@ rules that must not regress:
   currentMediaId/hasCurrentMetadata/volume) are behind `playback/PlaybackProbe`, `MusicService` adapts
   the real `Player`, and `onPositionDiscontinuity` takes primitive params instead of `Player.PositionInfo`.
   `WatchTimeReporterTest` drives the whole machine with a pure fake probe (Unconfined scope) and asserts
-  via the observable offline-capture sink - played-range capture, seek exclusion, the ≥10s gate,
-  paused-at-start privacy, the teardown end-position, rebuffer-is-not-a-pause, and the relay exclusion.
+  via the observable offline-capture sink - played-range capture, seek exclusion, the sub-500ms jitter
+  floor, paused-at-start privacy, the teardown end-position, rebuffer-is-not-a-pause, and the relay exclusion.
   The extraction is behavior-preserving; keep the probe returning exactly the `Player` values.
 - **Boundary-capture hardening (never fabricate, never orphan) - these must not regress:**
   - On a track/queue CHANGE (a real transition, or `ensureSession` replacing a still-open session) the
@@ -210,7 +210,10 @@ rules that must not regress:
   and re-pushed on reconnect as a **deferred** stats session (fresh `/player` → fresh cpn → playback +
   `final=1` watchtime, the STORED real ranges). Same honesty rule (`rt` ≤ played time; `PauseListenHistory`
   suppresses capture with the SAME per-ping semantics as the live path - paused-at-start captures nothing,
-  and accumulation stops at the first paused ping), ≥10s gate, **never via the relay egress**. JSONL under
+  and accumulation stops at the first paused ping), the honest ≥500ms segment floor (NO minimum-duration
+  gate - since YouTube counts a view from the first frame as of 2026-08-24, any genuinely-watched offline
+  play (>=500ms real time) mints a view on reconnect, like the live path above that floor - only the
+  sub-500ms jitter window differs), **never via the relay egress**. JSONL under
   `filesDir` reusing `TrackingQueue` + `FlushSchedule` (no Room/migration); single-flight, connectivity-
   triggered, and self-rescheduling whenever work remains (after a RETRY-backoff, and after a full batch
   of `BATCH_SIZE`=20 with records still queued it waits a short `PACE_MS`) - so a backlog larger than one

--- a/app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt
@@ -368,7 +368,8 @@ class WatchTimeReporter(
         if (urls?.playbackUrl == null && urls?.watchtimeUrl == null) {
             // OFFLINE listen: no live URLs to beacon now. Accumulate the SAME real ranges the reporter
             // computed (the pings' st/et are honest deltas) and hand ONE record to the deferred sink to
-            // re-push on reconnect. Nothing is fabricated; a listen below the genuine-play gate is dropped.
+            // re-push on reconnect. Nothing is fabricated; a listen with no real watched range
+            // (< WatchTimeSegments.MIN_SEGMENT_MS) simply produces no record.
             // Privacy MUST match the live path exactly (a deferred beacon is still a beacon): the live
             // consumer opens nothing if paused at the Start ping, and silences forward pings once paused
             // mid-listen. Mirror both here — capture nothing if paused at start, and stop accumulating at
@@ -395,7 +396,13 @@ class WatchTimeReporter(
                     }
                 }
             }
-            if (!startedPaused && watchedMs >= MIN_DEFERRED_MS && st.isNotEmpty()) {
+            // No minimum-duration gate: since 2026-08-24 YouTube counts a view from the very first frame
+            // (it previously needed ~30s of engaged watching), so any genuinely-watched offline play mints a
+            // view on reconnect. st.isNotEmpty() means >= MIN_SEGMENT_MS of REAL watched media time (the
+            // segment layer drops sub-500ms jitter) — the honest floor to report on. This matches the live
+            // path for any real listen; only the sub-500ms jitter window differs (there the live playback
+            // ping still fires, while this branch has no watched range to defer). A private listen is never queued.
+            if (!startedPaused && st.isNotEmpty()) {
                 runCatching {
                     onOfflineListen(
                         DeferredStatsRecord(
@@ -480,9 +487,5 @@ class WatchTimeReporter(
         // enough that a normal next-track preload (played within minutes) is never rejected, tight
         // enough that an hours-later cache-served replay resolves fresh instead of beaconing a dead URL.
         private const val TRACKING_MAX_AGE_MS = 60 * 60 * 1000L
-
-        // The genuine-play gate for a DEFERRED offline capture — a listen shorter than this is not
-        // worth queuing (matches the ≥10s history threshold; a YouTube view qualifies around ~30s).
-        private const val MIN_DEFERRED_MS = 10_000L
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
  * Drives the [WatchTimeReporter] STATE MACHINE with a pure [PlaybackProbe] fake (no media3, no
  * Robolectric) and asserts via the observable OFFLINE-capture sink - which exercises the shared
  * session/segment/transition orchestration end to end: session open, segment accumulation, seek
- * exclusion, the genuine-play gate, the pause-history privacy semantics, the teardown end-position,
+ * exclusion, the sub-500ms jitter floor, the pause-history privacy semantics, the teardown end-position,
  * the buffering-is-not-a-pause rule, and the relay exclusion.
  *
  * The reporter's scope is Unconfined, so every `launch` (the ping consumer) runs synchronously and a
@@ -101,11 +101,31 @@ class WatchTimeReporterTest {
     }
 
     @Test
-    fun `a listen shorter than the genuine-play gate is dropped`() {
+    fun `a short offline listen still mints a view - no minimum-duration gate`() {
+        // Since 2026-08-24 YouTube counts a view from the very first frame (previously ~30s of engaged
+        // watching), so even a brief offline play is re-pushed on reconnect - the live path likewise
+        // fires its playback ping with no duration gate. A 5s play is well under the old 10s gate.
         val r = reporter()
         play(0)
         r.onIsPlayingChanged(true)
-        probe.positionMs = 5_000 // below the 10s gate
+        probe.positionMs = 5_000
+        r.onPlaybackEnded()
+
+        with(captured.single()) {
+            assertEquals("0.0", st)
+            assertEquals("5.0", et)
+            assertEquals("5.0", rt)
+        }
+    }
+
+    @Test
+    fun `a sub-500ms blip is dropped as jitter, not a listen`() {
+        // The honest floor that remains: below WatchTimeSegments.MIN_SEGMENT_MS nothing was genuinely
+        // watched (double events / rounding), so no view is minted.
+        val r = reporter()
+        play(0)
+        r.onIsPlayingChanged(true)
+        probe.positionMs = 300
         r.onPlaybackEnded()
 
         assertEquals(0, captured.size)

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -156,7 +156,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoQualityLogic.kt` | 204 | `com.jtech.zemer.playback` | no | 1 | 39 |  |
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoRendition.kt` | 95 | `com.jtech.zemer.playback` | no | 0 | 20 |  |
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoSongIds.kt` | 28 | `com.jtech.zemer.playback` | no | 0 | 6 |  |
-| `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt` | 488 | `com.jtech.zemer.playback` | no | 11 | 86 | androidx.media3, java.util, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt` | 491 | `com.jtech.zemer.playback` | no | 11 | 85 | androidx.media3, java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeSchedule.kt` | 41 | `com.jtech.zemer.playback` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeSegments.kt` | 117 | `com.jtech.zemer.playback` | no | 1 | 20 | java.util |
 | `app/src/main/kotlin/com/jtech/zemer/playback/queues/EmptyQueue.kt` | 14 | `com.jtech.zemer.playback.queues` | no | 2 | 5 | androidx.media3 |
@@ -604,7 +604,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoQualityLogicTest.kt` | 221 | `com.jtech.zemer.playback` | no | 5 | 23 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoRenditionTest.kt` | 87 | `com.jtech.zemer.playback` | no | 4 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoSongIdsTest.kt` | 45 | `com.jtech.zemer.playback` | no | 4 | 4 | java.util, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt` | 181 | `com.jtech.zemer.playback` | no | 8 | 28 | kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt` | 201 | `com.jtech.zemer.playback` | no | 8 | 29 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeScheduleTest.kt` | 59 | `com.jtech.zemer.playback` | no | 2 | 6 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeSegmentsTest.kt` | 161 | `com.jtech.zemer.playback` | no | 5 | 18 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/playback/relay/RelayDeviceIdTest.kt` | 82 | `com.jtech.zemer.playback.relay` | no | 6 | 4 | java.util, org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 1512 lines | text `.md` |
+| `AGENTS.md` | 1515 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -115,7 +115,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 1512 lines | `.md` |
+| `AGENTS.md` | 1515 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -316,7 +316,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoQualityLogic.kt` | 204 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoRendition.kt` | 95 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/VideoSongIds.kt` | 28 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt` | 488 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeReporter.kt` | 491 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeSchedule.kt` | 41 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/WatchTimeSegments.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/queues/EmptyQueue.kt` | 14 lines | `.kt` |
@@ -976,7 +976,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoQualityLogicTest.kt` | 221 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoRenditionTest.kt` | 87 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/playback/VideoSongIdsTest.kt` | 45 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt` | 181 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeReporterTest.kt` | 201 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeScheduleTest.kt` | 59 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/playback/WatchTimeSegmentsTest.kt` | 161 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/playback/relay/RelayDeviceIdTest.kt` | 82 lines | `.kt` |
@@ -1123,7 +1123,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/ui/README.md` | 321 lines | `.md` |
 | `docs/ui/standards.md` | 387 lines | `.md` |
 | `docs/video_quality/README.md` | 134 lines | `.md` |
-| `docs/watchtime/README.md` | 278 lines | `.md` |
+| `docs/watchtime/README.md` | 304 lines | `.md` |
 | `docs/whitelist/README.md` | 250 lines | `.md` |
 | `docs/zemer_playlists/README.md` | 110 lines | `.md` |
 | `gradle.properties` | 40 lines | `.properties` |

--- a/docs/watchtime/README.md
+++ b/docs/watchtime/README.md
@@ -18,6 +18,29 @@ durable; watch time from concentrated single-account testing is **retroactively 
 invalid traffic - expected, not a bug (see "what to expect" for why, and why real distributed
 users are the payoff).
 
+## View counting (first-frame, effective 2026-08-24)
+
+YouTube changed how public views are counted: from **2026-08-24** a view is counted **the moment a
+video begins to play - from the very first frame** (long-form previously needed roughly ~30s of
+engaged watching; first-frame counting is how Shorts already worked and now applies to all formats).
+The old "did they keep watching" number becomes **Engaged views** in Studio > Analytics > Advanced
+mode. Separately, YPP eligibility rose to **8000** qualified watch hours / 365 days (from 4000),
+effective 2027-02-01.
+
+Why this system needed almost no change:
+
+- **The view is minted by the playback ping** (`videostatsPlaybackUrl`, `cmt=<start>`, `final=0`),
+  which this system already fires at play START with **no duration gate** on the live path. A real
+  Zemer play credits a view from the first frame exactly as intended - the design was already aligned.
+- **Watch time matters more, not less.** It no longer gates the view, but it is what feeds Engaged
+  views AND the (now doubled) YPP qualified-watch-hours bar. The honest `WatchTimeSegments` reporting
+  is the payoff - and honesty stays the hard rule (fabricated watch time is invalid traffic).
+- **The one code change made for this:** the deferred *offline* path dropped its stale ≥10s
+  `MIN_DEFERRED_MS` gate (whose rationale was the old ~30s view threshold), so a short offline play now
+  also mints a first-frame view on reconnect - matching the live path for any genuinely-watched play. The
+  honest ≥500ms segment floor remains (only the sub-500ms jitter window still differs from the live
+  playback ping). See "Deferred offline recovery".
+
 ## The invariant that rules everything
 
 **Watch time reported MUST equal what the user actually played.** Fabricated watch time is invalid
@@ -228,7 +251,10 @@ The rules that must not regress:
 - **Honesty is the same hard rule.** The queued `st`/`et` are the SAME real ranges `WatchTimeSegments`
   computed for the listen (accumulated from the pings, `WatchTimeSegments.Drained.watchedMs` summed); `cmt`
   is the final position, `rt` the total real watched seconds (≤ played time ≤ duration). Nothing is
-  re-derived or fabricated. Gated at the ≥10s genuine-play threshold (`MIN_DEFERRED_MS`), and **the
+  re-derived or fabricated. Gated only at the honest ≥500ms floor (`st` non-empty - `WatchTimeSegments`
+  drops sub-`MIN_SEGMENT_MS` jitter); there is deliberately **no minimum-duration gate**, so a short
+  offline play mints a view on reconnect just as a live play does above that honest ≥500ms floor (below it
+  only the live playback ping fires; see "View counting" above). **The
   privacy switch (`PauseListenHistoryKey`) suppresses capture with the SAME per-ping semantics as the
   live path** - nothing is captured if history was paused at the Start ping, and accumulation stops at
   the first paused ping, so a mostly-private listen is never queued even if unpaused before it ends (a


### PR DESCRIPTION
## What

YouTube now counts a public view from the first frame of playback across all
formats (effective 2026-08-24), rather than after roughly 30s of engaged
watching for long-form. The deferred offline watch-time path gated capture
behind a 10s minimum (MIN_DEFERRED_MS), a threshold justified by that old view
bar, so short offline plays never re-pushed on reconnect and lost the view.

## Change

- Remove the MIN_DEFERRED_MS gate; gate offline capture only on the honest 500ms
  segment floor (st non-empty). A genuinely watched offline play now mints a
  first-frame view on reconnect, consistent with the live path (which already
  fires its playback ping with no duration gate).
- Watch time reporting is unchanged and stays strictly real (no fabrication).
  The live/online path was already correct and is untouched.

## Tests

- Reporter unit tests updated: a short offline play is now captured; a sub-500ms
  blip is still dropped as jitter.
- `./gradlew :app:testDebugUnitTest` for the watch-time + deferred-stats suite: green.

## Docs

- `docs/watchtime/README.md` (new "View counting" section) and `AGENTS.md` updated;
  generated reference docs regenerated.
