### PR TITLE
Tonal expressive Home genre chips

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package com.jtech.zemer.ui.component
 
 import androidx.compose.animation.core.Spring
@@ -5,14 +7,18 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.material3.TonalToggleButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -24,14 +30,20 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * A genre chip for the Home strip (owner direction, 2026-07-30 voice notes): the stock
- * [AssistChip], but SQUARISH (10dp corners, "do it more squarely") with its outline clearly
- * visible, and a small per-genre motif icon ([genreIcon]) tinted with the ONE theme accent —
- * monochrome everywhere else ("zero color, only nice accents"). Keyed off the server slug.
+ * A genre chip for the Home strip. Material 3 Expressive: a filled tonal [TonalToggleButton] — the SAME
+ * component the Home content-tab selector and the library filter chips render as — so a chip presses with
+ * the springy shape-morph (round → squarer) instead of sitting as a flat hollow outline. It is a
+ * navigation chip, not a real toggle, so it is permanently `checked = false` and its `onCheckedChange`
+ * just fires [onClick] (the [LibraryFilterChip] uses the mirror trick of a permanently-checked one).
  *
- * The 48dp minimum-interactive-size enforcement is disabled HERE ONLY: it wraps every 32dp chip in
- * ~8dp of invisible padding on all sides, which blew the rows apart with phantom gaps. A dense
- * chip strip is the platform convention; the chip itself remains its full stock height.
+ * The chip keeps its two hand-tuned notes: a small per-genre motif icon ([genreIcon]) tinted with the ONE
+ * theme accent (monochrome everywhere else), and that icon giving a springy little jump while pressed —
+ * the chip body stays put beyond the button's own shape morph. Keyed off the server slug. The mandatory
+ * D-pad focus treatment (docs/ui/standards.md §11) rides the chip's rounded shape.
+ *
+ * Deliberately SMALLER than the Home content-tab selector above it (which is the primary control): the
+ * 48dp minimum-interactive floor is lifted, content padding is tight, and the icon/label are compact, so
+ * a genre chip reads as a secondary strip instead of competing with the tab chips for attention.
  */
 @Composable
 fun GenreChip(
@@ -44,41 +56,42 @@ fun GenreChip(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
-    // The one playful note (owner ask: "do something cool with them"): the motif icon gives a
-    // springy little jump while the chip is pressed. Icon only — the chip body stays put.
     val iconScale by animateFloatAsState(
         targetValue = if (pressed) 1.35f else 1f,
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
         label = "genre_chip_icon_jump",
     )
+    // Lift the 48dp min-interactive floor so the chip can be a compact secondary control (the button
+    // still keeps its own visual height from the content padding below).
     CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
-        AssistChip(
-            onClick = onClick,
+        TonalToggleButton(
+            checked = false,
+            onCheckedChange = { onClick() },
             interactionSource = interactionSource,
-            shape = RoundedCornerShape(10.dp),
-            // A whisper of the accent on the outline (full-strength gold read as heavy next to the
-            // gold icon); the icon stays the accent's one loud note per chip.
-            border = AssistChipDefaults.assistChipBorder(
-                enabled = true,
-                borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
+            // Dim tonal fill (surfaceContainer, a step below the tab selector's) so the chip recedes
+            // against the near-black background instead of reading as heavy chrome.
+            colors = ToggleButtonDefaults.tonalToggleButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
             ),
-            label = { Text(title) },
-            // The mandatory D-pad treatment (docs/ui/standards.md §11) on the chip's own shape —
-            // the stock chip is focusable but paints no visible focus indication of its own.
-            modifier = modifier.focusBorder(RoundedCornerShape(10.dp)),
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(iconOverride ?: genreIcon(slug)),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .size(AssistChipDefaults.IconSize)
-                        .graphicsLayer {
-                            scaleX = iconScale
-                            scaleY = iconScale
-                        },
-                )
-            },
-        )
+            // Tight padding so the chip sits well below the full-size tab selector in the hierarchy.
+            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+            // The stock toggle paints no visible focus indication of its own; add the D-pad ring on the
+            // chip's rounded shape (the button's resting shape).
+            modifier = modifier.focusBorder(RoundedCornerShape(20.dp)),
+        ) {
+            Icon(
+                painter = painterResource(iconOverride ?: genreIcon(slug)),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(14.dp)
+                    .graphicsLayer {
+                        scaleX = iconScale
+                        scaleY = iconScale
+                    },
+            )
+            Spacer(Modifier.width(5.dp))
+            Text(title, style = MaterialTheme.typography.labelMedium)
+        }
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt
@@ -2,9 +2,12 @@
 
 package com.jtech.zemer.ui.component
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,8 +25,12 @@ import androidx.compose.material3.TonalToggleButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
@@ -61,6 +68,14 @@ fun GenreChip(
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
         label = "genre_chip_icon_jump",
     )
+    // D-pad focus ring the ChipsRow way (onFocusChanged + focusable + border, NO clip): focusBorder()
+    // opens with a STATIC clip, which slices the corners off TonalToggleButton's animated round->squarer
+    // press morph - the very animation this chip exists for. Border-only leaves the morph intact.
+    var isFocused by remember { mutableStateOf(false) }
+    val focusRingColor by animateColorAsState(
+        targetValue = if (isFocused && focusVisualsEnabled()) MaterialTheme.colorScheme.outline else Color.Transparent,
+        label = "genre_chip_focus_border",
+    )
     // Lift the 48dp min-interactive floor so the chip can be a compact secondary control (the button
     // still keeps its own visual height from the content padding below).
     CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
@@ -76,8 +91,11 @@ fun GenreChip(
             // Tight padding so the chip sits well below the full-size tab selector in the hierarchy.
             contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
             // The stock toggle paints no visible focus indication of its own; add the D-pad ring on the
-            // chip's rounded shape (the button's resting shape).
-            modifier = modifier.focusBorder(RoundedCornerShape(20.dp)),
+            // chip's rounded resting shape (border only - see the clip note above).
+            modifier = modifier
+                .onFocusChanged { isFocused = it.isFocused }
+                .focusable()
+                .border(width = 1.5.dp, color = focusRingColor, shape = RoundedCornerShape(20.dp)),
         ) {
             Icon(
                 painter = painterResource(iconOverride ?: genreIcon(slug)),

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -248,7 +248,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 93 | `com.jtech.zemer.ui.component` | yes | 22 | 8 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCard.kt` | 166 | `com.jtech.zemer.ui.component` | yes | 39 | 19 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCardGrid.kt` | 84 | `com.jtech.zemer.ui.component` | yes | 15 | 3 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 84 | `com.jtech.zemer.ui.component` | yes | 22 | 4 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 97 | `com.jtech.zemer.ui.component` | yes | 26 | 4 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreDetailHeader.kt` | 118 | `com.jtech.zemer.ui.component` | yes | 28 | 6 | androidx.annotation, androidx.compose, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreIcons.kt` | 85 | `com.jtech.zemer.ui.component` | no | 2 | 2 | androidx.annotation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HeroTitleOverlay.kt` | 65 | `com.jtech.zemer.ui.component` | yes | 17 | 1 | androidx.compose |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -248,7 +248,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 93 | `com.jtech.zemer.ui.component` | yes | 22 | 8 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCard.kt` | 166 | `com.jtech.zemer.ui.component` | yes | 39 | 19 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCardGrid.kt` | 84 | `com.jtech.zemer.ui.component` | yes | 15 | 3 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 97 | `com.jtech.zemer.ui.component` | yes | 26 | 4 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 115 | `com.jtech.zemer.ui.component` | yes | 33 | 6 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreDetailHeader.kt` | 118 | `com.jtech.zemer.ui.component` | yes | 28 | 6 | androidx.annotation, androidx.compose, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreIcons.kt` | 85 | `com.jtech.zemer.ui.component` | no | 2 | 2 | androidx.annotation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HeroTitleOverlay.kt` | 65 | `com.jtech.zemer.ui.component` | yes | 17 | 1 | androidx.compose |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -408,7 +408,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 93 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCard.kt` | 166 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCardGrid.kt` | 84 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 97 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 115 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreDetailHeader.kt` | 118 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreIcons.kt` | 85 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HeroTitleOverlay.kt` | 65 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -408,7 +408,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/FocusBorder.kt` | 93 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCard.kt` | 166 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreCardGrid.kt` | 84 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 84 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreChip.kt` | 97 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreDetailHeader.kt` | 118 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/GenreIcons.kt` | 85 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HeroTitleOverlay.kt` | 65 lines | `.kt` |


### PR DESCRIPTION
Restyles the Home genre chip strip (music + podcasts) from the hollow AssistChip outline to a compact filled tonal chip built on TonalToggleButton, matching the Home content-tab selector and library filter chips.

What changed:
- Filled tonal container (surfaceContainer) with the built-in springy round->square press morph, replacing the hollow accent outline.
- Kept the per-genre accent motif icon, its springy press-jump, and the D-pad focus ring.
- Sized deliberately smaller than the tab selector (48dp interactive floor lifted, tight 10x2dp padding, 14dp icon, labelMedium text) so the strip stays a secondary control and does not compete with the tab chips above it.

Scope is only GenreChip.kt, the shared strip used by both the music and podcast Home genre rows. Pure visual restyle with no navigation, slug, icon, or logic changes.
