### PR TITLE
feat(ui): use shared loading spinner for song details, lyrics, and recognition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,8 +402,11 @@ sign-in card), `OnboardingStatusPill` (the Done/Needed · Active/Optional chip),
 below `OnboardingActionButton`'s `surfaceContainerHighest` so an in-card pill never blends into its card).
 The **loading + carousel-hero family** lives here too: `ZemerLoadingIndicator` (the CONTAINED M3 Expressive
 content/section spinner - Home pull-to-refresh look, video buffering, section loads; ratcheted by
-**R25**) and `MediaLoadingSpinner` (the BARE, neutral over-media spinner for a card cover's tap-to-play
-state; ratcheted by **R26**); `PreparingOverlay` (the scrim + `MediaLoadingSpinner` shown while a tapped
+**R25**), its inline convenience `ZemerLoadingSection` (that spinner centered in a full-width box with
+vertical padding - the drop-in "this section is loading" block inside a scrolling column, used by the
+song-details sheet + the lyrics list; a fixed-footprint slot like the recognition mic button centers the
+raw indicator itself) and `MediaLoadingSpinner` (the BARE, neutral over-media spinner for a card cover's
+tap-to-play state; ratcheted by **R26**); `PreparingOverlay` (the scrim + `MediaLoadingSpinner` shown while a tapped
 item resolves, shared by `ItemThumbnail` and the video hero); `HeroTitleOverlay` (the bottom gradient
 title/subtitle + optional badges slot) and `CarouselHeroFrame` (the ENTIRE full-bleed carousel-hero
 frame - `maskClip`/`maskBorder` D-pad focus ring, cover-crop artwork, now-playing scrim) shared by the

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
@@ -102,8 +102,6 @@ import com.jtech.zemer.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
 import com.jtech.zemer.lyrics.LyricsEntry
 import com.jtech.zemer.lyrics.LyricsUtils.findCurrentLineIndex
 import com.jtech.zemer.lyrics.LyricsUtils.parseLyrics
-import com.jtech.zemer.ui.component.shimmer.ShimmerHost
-import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
 import com.jtech.zemer.ui.screens.settings.DarkMode
 import com.jtech.zemer.ui.screens.settings.LyricsPosition
 import com.jtech.zemer.ui.utils.fadingEdge
@@ -426,21 +424,13 @@ fun Lyrics(
 
             if (lyrics == null) {
                 item {
-                    ShimmerHost {
-                        repeat(10) {
-                            Box(
-                                contentAlignment = when (lyricsTextPosition) {
-                                    LyricsPosition.LEFT -> Alignment.CenterStart
-                                    LyricsPosition.CENTER -> Alignment.Center
-                                    LyricsPosition.RIGHT -> Alignment.CenterEnd
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 24.dp, vertical = 4.dp)
-                            ) {
-                                TextPlaceholder()
-                            }
-                        }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        ZemerLoadingIndicator()
                     }
                 }
             } else {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt
@@ -424,14 +424,7 @@ fun Lyrics(
 
             if (lyrics == null) {
                 item {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        ZemerLoadingIndicator()
-                    }
+                    ZemerLoadingSection()
                 }
             } else {
                 itemsIndexed(

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt
@@ -1,10 +1,15 @@
 package com.jtech.zemer.ui.component
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 /**
  * The app's one content-loading spinner: the Material 3 Expressive [ContainedLoadingIndicator] (the
@@ -31,5 +36,25 @@ fun ZemerLoadingIndicator(
         ContainedLoadingIndicator(modifier = modifier)
     } else {
         ContainedLoadingIndicator(modifier = modifier, indicatorColor = color)
+    }
+}
+
+/**
+ * The shared inline "this section is loading" block: a [ZemerLoadingIndicator] centered in a full-width
+ * box with vertical breathing room, dropped in place of the content while it loads inside a scrolling
+ * column (the song-details sheet, the lyrics list). Use this instead of hand-rolling the centering box.
+ *
+ * A fixed-footprint loader that must occupy a specific slot (e.g. the recognition mic button's 112dp
+ * square) centers the raw [ZemerLoadingIndicator] itself - this helper is only for the full-width case.
+ */
+@Composable
+fun ZemerLoadingSection(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        ZemerLoadingIndicator()
     }
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/recognition/RecognizeMusicDialogActivity.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -58,6 +57,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.jtech.zemer.R
 import com.jtech.zemer.recognition.RecognitionAudioCapture
+import com.jtech.zemer.ui.component.ZemerLoadingIndicator
 import com.jtech.zemer.ui.theme.ZemerAppTheme
 import com.jtech.zemer.ui.utils.resize
 import com.jtech.zemer.viewmodels.RecognizeMusicViewModel
@@ -245,21 +245,26 @@ private fun DialogStatus(
         label = "dialog_mic_scale",
     )
 
-    Box(
-        modifier = Modifier
-            .size(112.dp)
-            .scale(if (listening) scale else 1f)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.primary)
-            .clickable(enabled = tappable, onClick = onAction),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (working) {
-            CircularProgressIndicator(
-                color = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(44.dp),
-            )
-        } else {
+    if (working) {
+        // Identifying/searching: show the app's shared content-loading spinner (the same reused
+        // pull-to-refresh / song-details indicator), in the mic button's 112dp footprint so the
+        // layout doesn't jump. No primary circle behind it - the contained indicator brings its own.
+        Box(
+            modifier = Modifier.size(112.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            ZemerLoadingIndicator()
+        }
+    } else {
+        Box(
+            modifier = Modifier
+                .size(112.dp)
+                .scale(if (listening) scale else 1f)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+                .clickable(enabled = tappable, onClick = onAction),
+            contentAlignment = Alignment.Center,
+        ) {
             Icon(
                 painter = painterResource(R.drawable.mic),
                 contentDescription = stringResource(R.string.recognize_music_mic_button),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
@@ -2,13 +2,11 @@ package com.jtech.zemer.ui.utils
 
 import android.text.format.Formatter
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -45,8 +43,7 @@ import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
-import com.jtech.zemer.ui.component.shimmer.ShimmerHost
-import com.jtech.zemer.ui.component.shimmer.TextPlaceholder
+import com.jtech.zemer.ui.component.ZemerLoadingIndicator
 import com.jtech.zemer.extensions.copyToClipboard
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.MediaInfo
@@ -98,15 +95,12 @@ fun ShowMediaInfo(videoId: String, isEpisodeHint: Boolean = false) {
             .padding(top = 8.dp, bottom = 16.dp),
     ) {
         // In DIRECT mode wait for the YouTube media info; in RELAY mode it may never load (filtered
-        // device), so render from local `song` + the relay info rather than shimmering forever.
+        // device), so render from local `song` + the relay info rather than spinning forever.
         if (info == null && !relayMode) {
-            ShimmerHost {
-                Row(
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth().padding(all = 16.dp),
-                ) { TextPlaceholder() }
-            }
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                contentAlignment = Alignment.Center,
+            ) { ZemerLoadingIndicator() }
             return
         }
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/ShowMediaInfo.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -43,7 +42,7 @@ import com.jtech.zemer.db.entities.Song
 import com.jtech.zemer.utils.rememberEnumPreference
 import com.jtech.zemer.ui.component.Material3MenuGroup
 import com.jtech.zemer.ui.component.Material3MenuItemData
-import com.jtech.zemer.ui.component.ZemerLoadingIndicator
+import com.jtech.zemer.ui.component.ZemerLoadingSection
 import com.jtech.zemer.extensions.copyToClipboard
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.MediaInfo
@@ -97,10 +96,7 @@ fun ShowMediaInfo(videoId: String, isEpisodeHint: Boolean = false) {
         // In DIRECT mode wait for the YouTube media info; in RELAY mode it may never load (filtered
         // device), so render from local `song` + the relay info rather than spinning forever.
         if (info == null && !relayMode) {
-            Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                contentAlignment = Alignment.Center,
-            ) { ZemerLoadingIndicator() }
+            ZemerLoadingSection()
             return
         }
 


### PR DESCRIPTION
## What

Adopt the shared `ZemerLoadingIndicator` (the contained M3 Expressive spinner, same look as Home pull-to-refresh) as the loading state in three spots that previously used shimmer placeholders or a plain progress arc:

- **Song details sheet** (`ui/utils/ShowMediaInfo.kt`): DIRECT-mode loading branch, was `ShimmerHost { TextPlaceholder() }`.
- **Lyrics loading** (`ui/component/Lyrics.kt`): was 10 shimmer text-line placeholders.
- **Recognition "Finding it on Zemer..." dialog** (`ui/screens/recognition/RecognizeMusicDialogActivity.kt`): the searching/identifying state, was a plain `CircularProgressIndicator` arc. The pink circle is dropped during that state (the contained spinner brings its own container), kept in the mic button's 112dp footprint so the layout does not jump.

## Why

The placeholder shimmer / plain arc looked out of place for these short fetches; the pull-to-refresh spinner is the app's standard content-loading treatment, and all three now share the one component.

## Details

- Reuses the shared component (R25-compliant), so no raw `ContainedLoadingIndicator`.
- Dropped the now-unused imports (`ShimmerHost`, `TextPlaceholder`, `Arrangement`, `Row`, `CircularProgressIndicator`).
- RELAY mode is untouched (it never shows the song-details spinner; it renders from the local song).

## Verification

- `scripts/ui-audit.sh`: passed, no new violations.
- `:app:assembleDebug`: compiles, APK produced.
