### PR TITLE
fix(ui): smooth the hero carousel swipe by honoring fling velocity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1139,8 +1139,11 @@ can't ride the shared signal). The **in-player VIDEO buffering** spinner is deli
 CONTAINED, theme-colored `ZemerLoadingIndicator` (bigger, exactly the Home pull-to-refresh look - a video
 buffer is a content load), NOT the small neutral card spinner. The two full-bleed **carousel heroes**
 (Latest Releases + Featured Videos) share their focus ring + `ui/component/HeroTitleOverlay` (the bottom
-gradient title/subtitle, with an optional badges slot) and advance ONE item per swipe at a fixed speed
-(`CarouselDefaults.singleAdvanceFlingBehavior` + a fixed `tween`, so a fling never scrolls many items). A
+gradient title/subtitle, with an optional badges slot) and advance ONE item per swipe through the shared
+`heroCarouselFlingBehavior` (`ui/component/CarouselHeroFrame.kt`): `singleAdvanceFlingBehavior` with its
+DEFAULT spring snap - single advance comes from the behavior's internal `PagerSnapDistance.atMost(1)`, and
+the spring consumes the fling's release velocity for a continuous hand-off. Do NOT pass a fixed-duration
+`tween` snap (a tween ignores that velocity and hitches on every swipe - the choppy-carousel bug). A
 separate **Enable high refresh rate** setting (Appearance ->
 Theme, default on; `MainActivity` sets the window's `preferredDisplayModeId`/`preferredRefreshRate` via the
 pure, unit-tested `utils/RefreshRateSelection` - `preferredDisplayModeId(target)` maps a null selection to

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt
@@ -12,13 +12,16 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.TargetedFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.carousel.CarouselDefaults
 import androidx.compose.material3.carousel.CarouselItemScope
+import androidx.compose.material3.carousel.CarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +36,18 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+
+/**
+ * The ONE fling behavior for the full-bleed hero carousels (Latest Releases + the video hero):
+ * [CarouselDefaults.singleAdvanceFlingBehavior] with its DEFAULT spring snap. Single advance comes
+ * from the behavior's internal PagerSnapDistance.atMost(1), NOT from the animation spec; the default
+ * spring is deliberate - it consumes the fling's release velocity for a continuous finger-to-animation
+ * hand-off and settles proportionally to the remaining distance. Do NOT pass a fixed-duration tween
+ * snap here: a tween ignores that velocity and hitches on every swipe (the "choppy carousel" bug).
+ */
+@Composable
+fun heroCarouselFlingBehavior(state: CarouselState): TargetedFlingBehavior =
+    CarouselDefaults.singleAdvanceFlingBehavior(state)
 
 /**
  * The shared frame for a full-bleed carousel HERO - the Latest Releases hero and the Trending/Featured

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.carousel.CarouselDefaults
 import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
 import androidx.compose.material3.carousel.rememberCarouselState
-import androidx.compose.animation.core.tween
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.LoadingIndicator
 import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
@@ -741,13 +741,12 @@ fun HomeScreen(
                             state = latestCarouselState,
                             preferredItemWidth = 180.dp,
                             itemSpacing = 8.dp,
-                            // Advance ONE item per swipe at a FIXED animation speed, so the carousel moves
-                            // the same regardless of how hard it is flung (no velocity-scaled multi-item
-                            // fling).
-                            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(
-                                latestCarouselState,
-                                tween(durationMillis = 400),
-                            ),
+                            // Advance ONE item per swipe (the behavior's PagerSnapDistance.atMost(1) -
+                            // never a velocity-scaled multi-item fling). The DEFAULT spring snap is
+                            // deliberate: it consumes the fling's release velocity, so finger-up hands
+                            // off continuously - the old fixed-duration tween ignored that velocity and
+                            // hitched on every swipe (the "choppy carousel" bug).
+                            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(latestCarouselState),
                             contentPadding = WindowInsets.systemBars
                                 .only(WindowInsetsSides.Horizontal)
                                 .asPaddingValues(),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.carousel.CarouselDefaults
 import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
 import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.LoadingIndicator
@@ -91,6 +90,7 @@ import com.jtech.zemer.ui.component.AlbumGridItem
 import com.jtech.zemer.ui.component.ArtistGridItem
 import com.jtech.zemer.ui.component.LocalBottomSheetPageState
 import com.jtech.zemer.ui.component.LocalMenuState
+import com.jtech.zemer.ui.component.heroCarouselFlingBehavior
 import com.jtech.zemer.ui.component.MoreVertMenuButton
 import com.jtech.zemer.extensions.toMediaItem
 import com.jtech.zemer.playback.queues.ListQueue
@@ -741,12 +741,8 @@ fun HomeScreen(
                             state = latestCarouselState,
                             preferredItemWidth = 180.dp,
                             itemSpacing = 8.dp,
-                            // Advance ONE item per swipe (the behavior's PagerSnapDistance.atMost(1) -
-                            // never a velocity-scaled multi-item fling). The DEFAULT spring snap is
-                            // deliberate: it consumes the fling's release velocity, so finger-up hands
-                            // off continuously - the old fixed-duration tween ignored that velocity and
-                            // hitched on every swipe (the "choppy carousel" bug).
-                            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(latestCarouselState),
+                            // One item per swipe; the spec + rationale live in heroCarouselFlingBehavior.
+                            flingBehavior = heroCarouselFlingBehavior(latestCarouselState),
                             contentPadding = WindowInsets.systemBars
                                 .only(WindowInsetsSides.Horizontal)
                                 .asPaddingValues(),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.carousel.CarouselDefaults
 import androidx.compose.material3.carousel.CarouselItemScope
 import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
 import androidx.compose.material3.carousel.rememberCarouselState
@@ -38,6 +37,7 @@ import com.jtech.zemer.playback.queues.ZemerRadioQueue
 import com.jtech.zemer.tracking.Tracker
 import com.jtech.zemer.ui.component.CarouselHeroFrame
 import com.jtech.zemer.ui.component.HeroTitleOverlay
+import com.jtech.zemer.ui.component.heroCarouselFlingBehavior
 import com.jtech.zemer.ui.component.MenuState
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.PreparingOverlay
@@ -103,10 +103,8 @@ fun LazyListScope.videoHeroCarousel(
             state = carouselState,
             itemWidth = heroW.dp,
             itemSpacing = 8.dp,
-            // One item per swipe, matching the Latest Releases carousel. The DEFAULT spring snap is
-            // deliberate: it consumes the fling's release velocity for a continuous hand-off - the old
-            // fixed-duration tween ignored it and hitched on every swipe (the "choppy carousel" bug).
-            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(carouselState),
+            // One item per swipe, matching Latest Releases; spec + rationale live in heroCarouselFlingBehavior.
+            flingBehavior = heroCarouselFlingBehavior(carouselState),
             contentPadding = PaddingValues(horizontal = 12.dp),
             modifier = Modifier
                 .padding(vertical = 12.dp)

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt
@@ -6,7 +6,6 @@
 
 package com.jtech.zemer.ui.screens
 
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
@@ -104,11 +103,10 @@ fun LazyListScope.videoHeroCarousel(
             state = carouselState,
             itemWidth = heroW.dp,
             itemSpacing = 8.dp,
-            // One item per swipe at a fixed speed, matching the Latest Releases carousel.
-            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(
-                carouselState,
-                tween(durationMillis = 400),
-            ),
+            // One item per swipe, matching the Latest Releases carousel. The DEFAULT spring snap is
+            // deliberate: it consumes the fling's release velocity for a continuous hand-off - the old
+            // fixed-duration tween ignored it and hitched on every swipe (the "choppy carousel" bug).
+            flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(carouselState),
             contentPadding = PaddingValues(horizontal = 12.dp),
             modifier = Modifier
                 .padding(vertical = 12.dp)

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -234,7 +234,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetMenu.kt` | 87 | `com.jtech.zemer.ui.component` | yes | 23 | 8 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetPage.kt` | 166 | `com.jtech.zemer.ui.component` | yes | 47 | 10 | androidx.activity, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BrowseScreenScaffold.kt` | 593 | `com.jtech.zemer.ui.component` | yes | 62 | 46 | androidx.compose, androidx.navigation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt` | 99 | `com.jtech.zemer.ui.component` | yes | 27 | 4 | androidx.compose, coil3.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt` | 114 | `com.jtech.zemer.ui.component` | yes | 30 | 5 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/CastVolumeKeyHandler.kt` | 71 | `com.jtech.zemer.ui.component` | yes | 13 | 6 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ChartRankCell.kt` | 231 | `com.jtech.zemer.ui.component` | yes | 29 | 23 | androidx.compose, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 129 | `com.jtech.zemer.ui.component` | yes | 38 | 8 | androidx.compose, kotlinx.coroutines |
@@ -352,7 +352,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 | `com.jtech.zemer.ui.screens` | no | 0 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 106 | `com.jtech.zemer.ui.screens` | yes | 33 | 4 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 | `com.jtech.zemer.ui.screens` | yes | 31 | 8 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1536 | `com.jtech.zemer.ui.screens` | yes | 150 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1531 | `com.jtech.zemer.ui.screens` | yes | 150 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 | `com.jtech.zemer.ui.screens` | yes | 68 | 31 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 | `com.jtech.zemer.ui.screens` | yes | 18 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 28 | `com.jtech.zemer.ui.screens` | yes | 7 | 1 | androidx.compose, androidx.hilt, androidx.navigation |
@@ -367,7 +367,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/PodcastGenresScreen.kt` | 95 | `com.jtech.zemer.ui.screens` | yes | 26 | 3 | androidx.compose, androidx.hilt, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 67 | `com.jtech.zemer.ui.screens` | no | 4 | 13 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 166 | `com.jtech.zemer.ui.screens` | yes | 42 | 5 | android.graphics, androidx.compose, com.airbnb |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt` | 228 | `com.jtech.zemer.ui.screens` | yes | 44 | 14 | androidx.compose, androidx.navigation, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt` | 224 | `com.jtech.zemer.ui.screens` | yes | 43 | 14 | androidx.compose, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedArtistsScreen.kt` | 110 | `com.jtech.zemer.ui.screens` | yes | 21 | 6 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedPodcastsScreen.kt` | 341 | `com.jtech.zemer.ui.screens` | yes | 57 | 16 | androidx.compose, androidx.hilt, androidx.navigation, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt` | 72 | `com.jtech.zemer.ui.screens` | yes | 26 | 2 | android.net, androidx.compose, androidx.hilt, androidx.navigation |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -11,7 +11,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 50 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 6 lines | text `[none]` |
-| `AGENTS.md` | 1541 lines | text `.md` |
+| `AGENTS.md` | 1544 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 19 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -116,7 +116,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 50 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 6 lines | `[none]` |
-| `AGENTS.md` | 1541 lines | `.md` |
+| `AGENTS.md` | 1544 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 19 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -395,7 +395,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetMenu.kt` | 87 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BottomSheetPage.kt` | 166 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/BrowseScreenScaffold.kt` | 593 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt` | 99 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/CarouselHeroFrame.kt` | 114 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/CastVolumeKeyHandler.kt` | 71 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ChartRankCell.kt` | 231 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ChipsRow.kt` | 129 lines | `.kt` |
@@ -513,7 +513,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 106 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1536 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1531 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 28 lines | `.kt` |
@@ -528,7 +528,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/PodcastGenresScreen.kt` | 95 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/Screens.kt` | 67 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/SplashScreen.kt` | 166 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt` | 228 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/VideoHeroCarousel.kt` | 224 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedArtistsScreen.kt` | 110 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/WhitelistedPodcastsScreen.kt` | 341 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/ZemerPlaylistsScreen.kt` | 72 lines | `.kt` |


### PR DESCRIPTION
## What

Fix the choppy feel when swiping through the Home hero carousels (Latest Releases and the Videos-tab hero).

## Why

Both carousels snapped with a fixed `tween(400ms)`. A tween ignores the fling's release velocity, so the content's speed jumped discontinuously the frame the finger lifted - a visible hitch on every swipe. Its fixed duration also made a barely-nudged card crawl for the same 400ms as a full-width advance, so quick successive swipes felt gated and rubbery.

## How

Use `CarouselDefaults.singleAdvanceFlingBehavior`'s default spring snap (`spring(stiffness = 400f)`, verified from the material3 1.5.0-alpha18 implementation): it consumes the release velocity for a continuous finger-to-animation hand-off and settles proportionally to the remaining distance.

One-item-per-swipe is unchanged - that constraint comes from the behavior's internal `PagerSnapDistance.atMost(1)`, not from the animation spec. Comments at both call sites now say why the default is deliberate.

## Verification

- UI audit passed; debug build compiles.
- Gesture-feel change with no pure logic to pin: a regression test would need Compose UI-test infrastructure the project does not have, so verification is on-device by feel.