### PR TITLE
feat(whitelist): clean artist display names and both-script library artist search

### DIFF
--- a/app/schemas/com.jtech.zemer.db.InternalDatabase/35.json
+++ b/app/schemas/com.jtech.zemer.db.InternalDatabase/35.json
@@ -1,0 +1,1378 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 35,
+    "identityHash": "baa1326134388717da3ab9e008e00bbb",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `lastPositionMs` INTEGER NOT NULL DEFAULT 0, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `mediaStoreUri` TEXT DEFAULT NULL, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT 0, `isEpisode` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPositionMs",
+            "columnName": "lastPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaStoreUri",
+            "columnName": "mediaStoreUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isEpisode",
+            "columnName": "isEpisode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_song_inLibrary",
+            "unique": false,
+            "columnNames": [
+              "inLibrary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_inLibrary` ON `${TABLE_NAME}` (`inLibrary`)"
+          },
+          {
+            "name": "index_song_liked",
+            "unique": false,
+            "columnNames": [
+              "liked"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_liked` ON `${TABLE_NAME}` (`liked`)"
+          },
+          {
+            "name": "index_song_isVideo",
+            "unique": false,
+            "columnNames": [
+              "isVideo"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_isVideo` ON `${TABLE_NAME}` (`isVideo`)"
+          },
+          {
+            "name": "index_song_isEpisode",
+            "unique": false,
+            "columnNames": [
+              "isEpisode"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_isEpisode` ON `${TABLE_NAME}` (`isEpisode`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isPodcastChannel` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isPodcastChannel",
+            "columnName": "isPodcastChannel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `playbackUrl` TEXT, `streamClient` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamClient",
+            "columnName": "streamClient",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_event_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "artist_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistId` TEXT NOT NULL, `artistName` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `source` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `isFemale` INTEGER NOT NULL, `isChasid` INTEGER NOT NULL, `isGenZ` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `isKidZone` INTEGER NOT NULL, `displayName` TEXT, `altName` TEXT, PRIMARY KEY(`artistId`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFemale",
+            "columnName": "isFemale",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isChasid",
+            "columnName": "isChasid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenZ",
+            "columnName": "isGenZ",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKidZone",
+            "columnName": "isKidZone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "altName",
+            "columnName": "altName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `thumbnailUrl` TEXT, `artistIds` TEXT NOT NULL, `recognizedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistIds",
+            "columnName": "artistIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_recognition_history_recognizedAt",
+            "unique": false,
+            "columnNames": [
+              "recognizedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_recognizedAt` ON `${TABLE_NAME}` (`recognizedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `isFemale` INTEGER NOT NULL, `isKidZone` INTEGER NOT NULL, `isVerified` INTEGER NOT NULL, `showCount` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isFemale",
+            "columnName": "isFemale",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKidZone",
+            "columnName": "isKidZone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVerified",
+            "columnName": "isVerified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showCount",
+            "columnName": "showCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "podcast",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `thumbnailUrl` TEXT, `channelId` TEXT, `bookmarkedAt` INTEGER, `lastUpdateTime` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'baa1326134388717da3ab9e008e00bbb')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt
@@ -92,6 +92,11 @@ val LastNightlyAnnouncedKey = stringPreferencesKey("lastNightlyAnnounced")
 val UpdateNotificationsEnabledKey = booleanPreferencesKey("updateNotifications")
 val InstallerTypeKey = intPreferencesKey("installerType") // InstallerType ordinal
 val LastWhitelistVersionKey = longPreferencesKey("lastWhitelistVersion")
+// One-time gate: false until a full whitelist fetch has populated the v35 displayName/altName columns
+// (MIGRATION_34_35 adds them NULL). While false, the sync bypasses the version-gated fast path so an
+// already-synced install backfills the split names on its first sync after updating, without waiting
+// for a server whitelist-version bump.
+val DisplayNamesBackfilledKey = booleanPreferencesKey("displayNamesBackfilled")
 val LastPodcastWhitelistSyncTimeKey = longPreferencesKey("lastPodcastWhitelistSyncTime")
 val LastPodcastWhitelistVersionKey = longPreferencesKey("lastPodcastWhitelistVersion")
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -1272,10 +1272,15 @@ interface DatabaseDao {
     // whitelisted row: devices can hold a generated local row AND the whitelisted channel row under
     // the same name, and resolving to the local one maps content outside every whitelist-joined
     // query — the confirmed cause of the infinite album skeleton (zemer-app-album-open-stuck-skeleton).
+    // Matches the whitelist doc's artistName/displayName/altName too, not just the row name: the
+    // server keeps serving the legacy dual "English - עברית" credit while the local row is renamed
+    // to the clean displayName, so a name-only wire credit must still land on the whitelisted row
+    // (missing it mints a generated duplicate — the same skeleton bug class the ordering fixed).
     @Transaction
     @Query(
         "SELECT artist.* FROM artist LEFT JOIN artist_whitelist ON artist.id = artist_whitelist.artistId " +
-            "WHERE artist.name = :name " +
+            "WHERE artist.name = :name OR artist_whitelist.artistName = :name " +
+            "OR artist_whitelist.displayName = :name OR artist_whitelist.altName = :name " +
             "ORDER BY CASE WHEN artist_whitelist.artistId IS NULL THEN 1 ELSE 0 END, artist.rowid LIMIT 1"
     )
     fun artistByName(name: String): ArtistEntity?
@@ -1469,12 +1474,23 @@ interface DatabaseDao {
     fun updateArtistThumbnailUrl(artistId: String, thumbnailUrl: String)
 
     /**
-     * Renames a whitelist-seeded artist row to the clean [displayName] — guarded on the row still
-     * holding the legacy whitelist [legacyName] (the dual dash form), so a name since resolved from
-     * YTM (or edited any other way) is never overwritten.
+     * Makes the curated whitelist `displayName` AUTHORITATIVE for its artist row, in one set-based
+     * statement: only split docs carry a displayName (the ~50 dual dash-form artists), and for those
+     * the curator's clean name always wins — over the legacy whitelist seed AND over a YTM-resolved
+     * dual title (the raw channel title IS the dash form the curator split). Idempotent and
+     * self-terminating (matches zero rows once names agree), so a later server-side displayName
+     * correction lands on already-renamed installs too. Run after insertWhitelist on every full fetch.
      */
-    @Query("UPDATE artist SET name = :displayName WHERE id = :artistId AND name = :legacyName")
-    fun renameArtistFromWhitelist(artistId: String, legacyName: String, displayName: String)
+    @Query(
+        "UPDATE artist SET name = (SELECT w.displayName FROM artist_whitelist w WHERE w.artistId = artist.id) " +
+            "WHERE id IN (SELECT artistId FROM artist_whitelist WHERE displayName IS NOT NULL AND displayName != '') " +
+            "AND name != (SELECT w.displayName FROM artist_whitelist w WHERE w.artistId = artist.id)"
+    )
+    fun applyWhitelistDisplayNames()
+
+    /** The whitelist doc's curated displayName for [artistId] (null when absent/not a split doc). */
+    @Query("SELECT displayName FROM artist_whitelist WHERE artistId = :artistId")
+    fun whitelistDisplayNameSync(artistId: String): String?
 
     /** Overwrite the artist image unconditionally — for the fallback resolver replacing a dead URL. */
     @Query("UPDATE artist SET thumbnailUrl = :thumbnailUrl WHERE id = :artistId")
@@ -1494,9 +1510,13 @@ interface DatabaseDao {
         artist: ArtistEntity,
         artistPage: ArtistPage
     ) {
+        // A split whitelist doc's curated displayName beats the YTM channel title — for those ~50
+        // artists the raw title IS the dual dash form the curator cleaned, and taking it here made
+        // the >10-day stale refresh revert the clean name (oscillating with the whitelist sync).
+        val curatedName = whitelistDisplayNameSync(artist.id)?.takeIf { it.isNotBlank() }
         update(
             artist.copy(
-                name = artistPage.artist.title,
+                name = curatedName ?: artistPage.artist.title,
                 thumbnailUrl = artistPage.artist.thumbnail?.resize(544, 544),
                 lastUpdateTime = LocalDateTime.now()
             )

--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -1113,7 +1113,7 @@ interface DatabaseDao {
     @Transaction
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
     @Query(
-        "SELECT artist.*, (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE song_artist_map.artistId = artist.id AND song.inLibrary IS NOT NULL AND song.isEpisode = 0) AS songCount FROM artist INNER JOIN artist_whitelist ON artist.id = artist_whitelist.artistId WHERE artist.name LIKE '%' || :query || '%' AND songCount > 0 LIMIT :previewSize",
+        "SELECT artist.*, (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE song_artist_map.artistId = artist.id AND song.inLibrary IS NOT NULL AND song.isEpisode = 0) AS songCount FROM artist INNER JOIN artist_whitelist ON artist.id = artist_whitelist.artistId WHERE (artist.name LIKE '%' || :query || '%' OR artist_whitelist.altName LIKE '%' || :query || '%') AND songCount > 0 LIMIT :previewSize",
     )
     fun searchArtists(
         query: String,
@@ -1467,6 +1467,14 @@ interface DatabaseDao {
      */
     @Query("UPDATE artist SET thumbnailUrl = :thumbnailUrl WHERE id = :artistId AND (thumbnailUrl IS NULL OR thumbnailUrl = '')")
     fun updateArtistThumbnailUrl(artistId: String, thumbnailUrl: String)
+
+    /**
+     * Renames a whitelist-seeded artist row to the clean [displayName] — guarded on the row still
+     * holding the legacy whitelist [legacyName] (the dual dash form), so a name since resolved from
+     * YTM (or edited any other way) is never overwritten.
+     */
+    @Query("UPDATE artist SET name = :displayName WHERE id = :artistId AND name = :legacyName")
+    fun renameArtistFromWhitelist(artistId: String, legacyName: String, displayName: String)
 
     /** Overwrite the artist image unconditionally — for the fallback resolver replacing a dead URL. */
     @Query("UPDATE artist SET thumbnailUrl = :thumbnailUrl WHERE id = :artistId")

--- a/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt
@@ -97,7 +97,7 @@ class MusicDatabase(
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -142,7 +142,7 @@ abstract class InternalDatabase : RoomDatabase() {
             val builtDb = try {
                 Room
                     .databaseBuilder(context, InternalDatabase::class.java, DB_NAME)
-                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_33_34)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_33_34, MIGRATION_34_35)
                     .setJournalMode(JournalMode.TRUNCATE)
                     .enableMultiInstanceInvalidation()
                     .build().also {
@@ -465,6 +465,16 @@ val MIGRATION_33_34 =
 
             // Flags a bookmarked artist row as a podcast host channel (for the Channels library tab).
             db.execSQL("ALTER TABLE artist ADD COLUMN isPodcastChannel INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
+val MIGRATION_34_35 =
+    object : Migration(34, 35) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Display-name split: the clean single-script name (displayName) + the other-script name
+            // (altName) served by the whitelist; artistName keeps the legacy (possibly dual-form) value.
+            db.execSQL("ALTER TABLE artist_whitelist ADD COLUMN displayName TEXT")
+            db.execSQL("ALTER TABLE artist_whitelist ADD COLUMN altName TEXT")
         }
     }
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
@@ -1,6 +1,7 @@
 package com.jtech.zemer.db.entities
 
 import androidx.compose.runtime.Immutable
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -18,7 +19,12 @@ data class ArtistWhitelistEntity(
     val isChasid: Boolean = false,
     val isGenZ: Boolean = false,
     val isKids: Boolean = false,
-    val isKidZone: Boolean = false
+    val isKidZone: Boolean = false,
+    // Display-name split: artistName keeps the legacy value (may be the dual "English - עברית" dash
+    // form); displayName is the clean single-script name to render, altName the other-script name
+    // (matched by Library artist search). Both null on docs that predate the split.
+    @ColumnInfo(name = "displayName") val displayName: String? = null,
+    @ColumnInfo(name = "altName") val altName: String? = null,
 ) {
     // Transient (NOT a column — no migration): the artist's channel image carried in from the whitelist
     // sync, used to populate Artist.thumbnailUrl. Room ignores it; equals/hashCode/copy don't include it.

--- a/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt
@@ -22,7 +22,8 @@ data class ArtistWhitelistEntity(
     val isKidZone: Boolean = false,
     // Display-name split: artistName keeps the legacy value (may be the dual "English - עברית" dash
     // form); displayName is the clean single-script name to render, altName the other-script name
-    // (matched by Library artist search). Both null on docs that predate the split.
+    // (matched by Library artist search, the Artists/KidZone browse filters, and artistByName's
+    // wire-credit resolution). Both null on docs that predate the split.
     @ColumnInfo(name = "displayName") val displayName: String? = null,
     @ColumnInfo(name = "altName") val altName: String? = null,
 ) {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -949,12 +949,11 @@ class SyncUtils @Inject constructor(
                     artistThumbnailUpdates(whitelistEntries, existingArtistIds).forEach { (artistId, thumb) ->
                         updateArtistThumbnailUrl(artistId, thumb)
                     }
-                    // Repair pre-split seeds: an existing artist row still carrying the legacy whitelist
-                    // name (the dual dash form) is renamed to the clean displayName. Guarded in the DAO
-                    // query (name must still equal the legacy value), so a YTM-resolved name never changes.
-                    artistDisplayNameUpdates(whitelistEntries, existingArtistIds).forEach { (artistId, legacyName, displayName) ->
-                        renameArtistFromWhitelist(artistId, legacyName, displayName)
-                    }
+                    // The curated displayName is authoritative for its artist row (split docs only —
+                    // one set-based, idempotent, self-terminating statement): repairs pre-split
+                    // seeds, re-applies after a stale YTM refresh restored the dual title, and lands
+                    // later server-side displayName corrections. See the DAO doc.
+                    applyWhitelistDisplayNames()
                 }
                 WhitelistCache.updateAll(whitelistEntries)
                 refreshBlockedIds()
@@ -969,7 +968,11 @@ class SyncUtils @Inject constructor(
                     remoteVersion?.let { settings[LastWhitelistVersionKey] = it }
                     // A full fetch just ran insertWhitelist with the split names, so the one-time
                     // backfill is done — subsequent syncs may take the version-gated fast path again.
-                    settings[DisplayNamesBackfilledKey] = true
+                    // Gated on the fetch actually CARRYING split names: a pre-split payload (stale
+                    // mirror snapshot) must not burn the one-time flag with all-NULL columns.
+                    if (whitelistCarriesDisplayNames(whitelistEntries)) {
+                        settings[DisplayNamesBackfilledKey] = true
+                    }
                 }
             } catch (e: Exception) {
                 _whitelistSyncProgress.value = WhitelistSyncProgress(isComplete = true)
@@ -1175,17 +1178,11 @@ internal fun artistThumbnailUpdates(
     }
 
 /**
- * Which (artistId, legacyName, displayName) renames the whitelist sync applies to EXISTING artist rows —
- * pure so the rules are regression-tested: only entries with a clean [displayName] that differs from the
- * legacy [artistName] qualify (new rows get the displayName via their insert), and only rows already in
- * the artist table are targeted. The never-clobber guard (the row's name must still equal the legacy
- * value, i.e. it was seeded from the whitelist and not since resolved from YTM) lives in the DAO query.
+ * Whether a fetched whitelist payload carries the v35 split display names at all — the gate that
+ * lets a completed full fetch set [DisplayNamesBackfilledKey]. Pure so the rule is regression-
+ * tested: a pre-split payload (every displayName null/blank) must NOT burn the one-time backfill
+ * flag, or the split names would never arrive without an unrelated version bump.
  */
-internal fun artistDisplayNameUpdates(
+internal fun whitelistCarriesDisplayNames(
     entries: List<com.jtech.zemer.db.entities.ArtistWhitelistEntity>,
-    existingArtistIds: Set<String>,
-): List<Triple<String, String, String>> =
-    entries.mapNotNull { entry ->
-        val display = entry.displayName?.takeIf { it.isNotBlank() && it != entry.artistName } ?: return@mapNotNull null
-        if (entry.artistId in existingArtistIds) Triple(entry.artistId, entry.artistName, display) else null
-    }
+): Boolean = entries.any { !it.displayName.isNullOrBlank() }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.datastore.preferences.core.edit
 import com.jtech.zemer.constants.BlockedContentIdsKey
+import com.jtech.zemer.constants.DisplayNamesBackfilledKey
 import com.jtech.zemer.constants.LastWhitelistVersionKey
 import com.jtech.zemer.constants.LastPodcastWhitelistVersionKey
 import com.jtech.zemer.constants.LastPodcastWhitelistSyncTimeKey
@@ -879,8 +880,21 @@ class SyncUtils @Inject constructor(
                 val manyThumbsMissing = !localEmpty &&
                     database.getWhitelistedArtistIdsMissingThumb(MISSING_THUMB_BOOTSTRAP_THRESHOLD).size >= MISSING_THUMB_BOOTSTRAP_THRESHOLD
 
+                // One-time backfill of the v35 displayName/altName columns (added NULL by the migration):
+                // while unset, take the full-fetch path so an already-synced install picks up the split
+                // names on its first sync after updating, instead of waiting for a server version bump.
+                val displayNamesBackfilled = context.dataStore.get(DisplayNamesBackfilledKey, false)
+
                 // Always fetch at least once per version (including version 1). Subsequent runs skip if already synced.
-                if (!forceSync && remoteVersion != null && remoteVersion <= localVersion && !localEmpty && !manyThumbsMissing) {
+                if (whitelistFastPathEligible(
+                        forceSync = forceSync,
+                        remoteVersion = remoteVersion,
+                        localVersion = localVersion,
+                        localEmpty = localEmpty,
+                        manyThumbsMissing = manyThumbsMissing,
+                        displayNamesBackfilled = displayNamesBackfilled,
+                    )
+                ) {
                     runCatching { WhitelistCache.updateAll(database.getWhitelistEntriesSync()) }
                     refreshBlockedIds()
                     _whitelistSyncProgress.value = WhitelistSyncProgress(isComplete = true)
@@ -953,6 +967,9 @@ class SyncUtils @Inject constructor(
 
                 context.dataStore.edit { settings ->
                     remoteVersion?.let { settings[LastWhitelistVersionKey] = it }
+                    // A full fetch just ran insertWhitelist with the split names, so the one-time
+                    // backfill is done — subsequent syncs may take the version-gated fast path again.
+                    settings[DisplayNamesBackfilledKey] = true
                 }
             } catch (e: Exception) {
                 _whitelistSyncProgress.value = WhitelistSyncProgress(isComplete = true)
@@ -1115,6 +1132,32 @@ class SyncUtils @Inject constructor(
  * handful of artists that legitimately have no server thumbnail, so a bootstrapped install skips again.
  */
 internal const val MISSING_THUMB_BOOTSTRAP_THRESHOLD = 25
+
+/**
+ * Whether the whitelist sync may take the version-gated FAST PATH (skip the full fetch) instead of
+ * fetching the whole allow-set. Pure so the gate is regression-tested. The fast path is eligible only
+ * when a full fetch is genuinely unnecessary: the caller did not force a sync, the server version
+ * probe succeeded and is not newer than the local version, the local table is non-empty, thumbnails
+ * are not being bootstrapped ([MISSING_THUMB_BOOTSTRAP_THRESHOLD]), AND the one-time display-name
+ * backfill has run. That last gate makes the v35 displayName/altName columns (added NULL by
+ * MIGRATION_34_35) populate on the first sync after an update, so both-script Library search and the
+ * legacy-name cleanup reach already-synced installs without a coordinated server version bump; once a
+ * full fetch has run it is set and the fast path is available again.
+ */
+internal fun whitelistFastPathEligible(
+    forceSync: Boolean,
+    remoteVersion: Long?,
+    localVersion: Long,
+    localEmpty: Boolean,
+    manyThumbsMissing: Boolean,
+    displayNamesBackfilled: Boolean,
+): Boolean =
+    !forceSync &&
+        remoteVersion != null &&
+        remoteVersion <= localVersion &&
+        !localEmpty &&
+        !manyThumbsMissing &&
+        displayNamesBackfilled
 
 /**
  * Which (artistId, thumbnailUrl) pairs the whitelist sync writes onto EXISTING artist rows — pure so

--- a/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt
@@ -924,7 +924,7 @@ class SyncUtils @Inject constructor(
                     val existingArtistIds = getAllArtistIdsSync().toSet()
                     val missingArtists = whitelistEntries
                         .filter { it.artistId !in existingArtistIds }
-                        .map { ArtistEntity(id = it.artistId, name = it.artistName, thumbnailUrl = it.thumbnailUrl) }
+                        .map { ArtistEntity(id = it.artistId, name = it.displayName ?: it.artistName, thumbnailUrl = it.thumbnailUrl) }
                     if (missingArtists.isNotEmpty()) {
                         insertArtists(missingArtists)
                     }
@@ -934,6 +934,12 @@ class SyncUtils @Inject constructor(
                     // never wipes an existing one, and a device-resolved image is never overwritten.
                     artistThumbnailUpdates(whitelistEntries, existingArtistIds).forEach { (artistId, thumb) ->
                         updateArtistThumbnailUrl(artistId, thumb)
+                    }
+                    // Repair pre-split seeds: an existing artist row still carrying the legacy whitelist
+                    // name (the dual dash form) is renamed to the clean displayName. Guarded in the DAO
+                    // query (name must still equal the legacy value), so a YTM-resolved name never changes.
+                    artistDisplayNameUpdates(whitelistEntries, existingArtistIds).forEach { (artistId, legacyName, displayName) ->
+                        renameArtistFromWhitelist(artistId, legacyName, displayName)
                     }
                 }
                 WhitelistCache.updateAll(whitelistEntries)
@@ -1123,4 +1129,20 @@ internal fun artistThumbnailUpdates(
     entries.mapNotNull { entry ->
         val thumb = entry.thumbnailUrl?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
         if (entry.artistId in existingArtistIds) entry.artistId to thumb else null
+    }
+
+/**
+ * Which (artistId, legacyName, displayName) renames the whitelist sync applies to EXISTING artist rows —
+ * pure so the rules are regression-tested: only entries with a clean [displayName] that differs from the
+ * legacy [artistName] qualify (new rows get the displayName via their insert), and only rows already in
+ * the artist table are targeted. The never-clobber guard (the row's name must still equal the legacy
+ * value, i.e. it was seeded from the whitelist and not since resolved from YTM) lives in the DAO query.
+ */
+internal fun artistDisplayNameUpdates(
+    entries: List<com.jtech.zemer.db.entities.ArtistWhitelistEntity>,
+    existingArtistIds: Set<String>,
+): List<Triple<String, String, String>> =
+    entries.mapNotNull { entry ->
+        val display = entry.displayName?.takeIf { it.isNotBlank() && it != entry.artistName } ?: return@mapNotNull null
+        if (entry.artistId in existingArtistIds) Triple(entry.artistId, entry.artistName, display) else null
     }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt
@@ -59,6 +59,8 @@ object WhitelistFetcher {
                                 isGenZ = doc.isGenZ ?: false,
                                 isKids = doc.isKids ?: false,
                                 isKidZone = doc.isKidZone ?: false,
+                                displayName = doc.displayName?.takeIf { it.isNotBlank() },
+                                altName = doc.altName?.takeIf { it.isNotBlank() },
                             ).also { it.thumbnailUrl = doc.thumbnail?.takeIf { t -> t.isNotBlank() } }
                         )
                     }
@@ -98,7 +100,9 @@ object WhitelistFetcher {
                                 isChasid = isChasid,
                                 isGenZ = isGenZ,
                                 isKids = isKids,
-                                isKidZone = isKidZone
+                                isKidZone = isKidZone,
+                                displayName = doc.getString("displayName")?.takeIf { it.isNotBlank() },
+                                altName = doc.getString("altName")?.takeIf { it.isNotBlank() },
                             ).also { it.thumbnailUrl = thumbnailUrl }
                         )
                         processed++

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
@@ -205,7 +205,9 @@ data class ContentWhitelistDoc(
     @SerialName("artistName") val artistName: String? = null,
     // Additive display-name split (2026-08-21): `name` keeps the legacy value (for ~49 artists a dual
     // "English - עברית" dash form) so old installs are untouched; `displayName` is the clean
-    // single-script name to render, `altName` the same name in the other script (Library search).
+    // single-script name to render, `altName` the same name in the other script (matched by Library
+    // search, the browse filters, and artistByName). Contract:
+    // handoff-docs/zemer-whitelist-display-names.md.
     val displayName: String? = null,
     val altName: String? = null,
     val isFemale: Boolean? = null,

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt
@@ -203,6 +203,11 @@ data class ContentWhitelistDoc(
     @SerialName("artistId") val artistId: String? = null,
     val name: String? = null,
     @SerialName("artistName") val artistName: String? = null,
+    // Additive display-name split (2026-08-21): `name` keeps the legacy value (for ~49 artists a dual
+    // "English - עברית" dash form) so old installs are untouched; `displayName` is the clean
+    // single-script name to render, `altName` the same name in the other script (Library search).
+    val displayName: String? = null,
+    val altName: String? = null,
     val isFemale: Boolean? = null,
     val isChasid: Boolean? = null,
     val isGenZ: Boolean? = null,

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt
@@ -6,6 +6,7 @@ import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.Artist
 import com.jtech.zemer.utils.ArtistThumbResolver
 import com.jtech.zemer.utils.SyncUtils
+import com.jtech.zemer.utils.WhitelistCache
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +44,11 @@ constructor(
             Timber.d("KidZoneVM: Total kids artists from DB: ${artists.size}, Search query: '$query'")
             val filteredByQuery =
                 if (query.isBlank()) artists
-                else artists.filter { artist -> artist.artist.name.contains(query, ignoreCase = true) }
+                // Match the other-script altName too (see WhitelistedArtistsViewModel).
+                else artists.filter { artist ->
+                    artist.artist.name.contains(query, ignoreCase = true) ||
+                        WhitelistCache.get(artist.id)?.altName?.contains(query, ignoreCase = true) == true
+                }
 
             Timber.d("KidZoneVM: Filtered result: ${filteredByQuery.size} artists")
             filteredByQuery

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt
@@ -44,7 +44,13 @@ constructor(
             }
             val filteredByQuery =
                 if (query.isBlank()) filteredByToggle
-                else filteredByToggle.filter { artist -> artist.artist.name.contains(query, ignoreCase = true) }
+                // Match the other-script altName too: the row name is single-script since the
+                // displayName split, so "רזאל" must still find Aaron Razel here (parity with the
+                // library search DAO's altName clause).
+                else filteredByToggle.filter { artist ->
+                    artist.artist.name.contains(query, ignoreCase = true) ||
+                        WhitelistCache.get(artist.id)?.altName?.contains(query, ignoreCase = true) == true
+                }
 
             Timber.d("WhitelistedArtistsVM: Filtered result: ${filteredByQuery.size} artists")
             filteredByQuery

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
@@ -87,4 +87,57 @@ class ArtistThumbResolverTest {
         )
         assertEquals(listOf(Triple("existing", "E - ע", "E")), updates)
     }
+
+    // --- whitelistFastPathEligible (version-gate + one-time display-name backfill) ---
+
+    // Baseline args describe an already-synced, backfilled install on the current version — the one
+    // state where the fast path is eligible; each test flips a single input.
+    private fun fastPath(
+        forceSync: Boolean = false,
+        remoteVersion: Long? = 5L,
+        localVersion: Long = 5L,
+        localEmpty: Boolean = false,
+        manyThumbsMissing: Boolean = false,
+        displayNamesBackfilled: Boolean = true,
+    ) = whitelistFastPathEligible(
+        forceSync, remoteVersion, localVersion, localEmpty, manyThumbsMissing, displayNamesBackfilled,
+    )
+
+    @Test
+    fun `fast path is eligible when synced, backfilled, and the version is not newer`() {
+        assertTrue(fastPath())
+        assertTrue(fastPath(remoteVersion = 4L)) // older remote (never downgrade-fetch)
+    }
+
+    @Test
+    fun `forceSync always does a full fetch`() {
+        assertFalse(fastPath(forceSync = true))
+    }
+
+    @Test
+    fun `a newer server version does a full fetch`() {
+        assertFalse(fastPath(remoteVersion = 6L))
+    }
+
+    @Test
+    fun `a failed version probe does a full fetch`() {
+        assertFalse(fastPath(remoteVersion = null))
+    }
+
+    @Test
+    fun `an empty local table does a full fetch`() {
+        assertFalse(fastPath(localEmpty = true))
+    }
+
+    @Test
+    fun `missing thumbnails force a bootstrap fetch`() {
+        assertFalse(fastPath(manyThumbsMissing = true))
+    }
+
+    @Test
+    fun `an un-backfilled display-name column forces the one-time fetch`() {
+        // The v35 migration case: columns added NULL, flag still false -> full fetch even though the
+        // version is unchanged, so already-synced installs pick up the split names.
+        assertFalse(fastPath(displayNamesBackfilled = false))
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
@@ -59,4 +59,32 @@ class ArtistThumbResolverTest {
         )
         assertEquals(listOf("existing" to "https://yt3/x"), updates)
     }
+
+    // --- artistDisplayNameUpdates (display-name split rename rules) ---
+
+    private fun named(id: String, legacy: String, display: String?) =
+        ArtistWhitelistEntity(artistId = id, artistName = legacy, displayName = display)
+
+    @Test
+    fun `only entries with a clean displayName differing from the legacy name qualify`() {
+        val updates = artistDisplayNameUpdates(
+            listOf(
+                named("a", "Aaron Razel - אהרן רזאל", "Aaron Razel"), // real split -> renamed
+                named("b", "Plain Name", null),                        // pre-split doc -> untouched
+                named("c", "Same Name", "Same Name"),                  // no-op rename -> skipped
+                named("d", "Legacy", "   "),                           // blank -> skipped
+            ),
+            existingArtistIds = setOf("a", "b", "c", "d"),
+        )
+        assertEquals(listOf(Triple("a", "Aaron Razel - אהרן רזאל", "Aaron Razel")), updates)
+    }
+
+    @Test
+    fun `rename targets only rows already in the artist table (new rows insert the displayName directly)`() {
+        val updates = artistDisplayNameUpdates(
+            listOf(named("existing", "E - ע", "E"), named("new", "N - נ", "N")),
+            existingArtistIds = setOf("existing"),
+        )
+        assertEquals(listOf(Triple("existing", "E - ע", "E")), updates)
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt
@@ -60,32 +60,29 @@ class ArtistThumbResolverTest {
         assertEquals(listOf("existing" to "https://yt3/x"), updates)
     }
 
-    // --- artistDisplayNameUpdates (display-name split rename rules) ---
+    // --- whitelistCarriesDisplayNames (the one-time backfill flag's payload gate) ---
 
     private fun named(id: String, legacy: String, display: String?) =
         ArtistWhitelistEntity(artistId = id, artistName = legacy, displayName = display)
 
     @Test
-    fun `only entries with a clean displayName differing from the legacy name qualify`() {
-        val updates = artistDisplayNameUpdates(
-            listOf(
-                named("a", "Aaron Razel - אהרן רזאל", "Aaron Razel"), // real split -> renamed
-                named("b", "Plain Name", null),                        // pre-split doc -> untouched
-                named("c", "Same Name", "Same Name"),                  // no-op rename -> skipped
-                named("d", "Legacy", "   "),                           // blank -> skipped
+    fun `a payload with at least one split displayName marks the backfill done`() {
+        assertEquals(
+            true,
+            whitelistCarriesDisplayNames(
+                listOf(named("a", "Plain Name", null), named("b", "Aaron Razel - אהרן רזאל", "Aaron Razel")),
             ),
-            existingArtistIds = setOf("a", "b", "c", "d"),
         )
-        assertEquals(listOf(Triple("a", "Aaron Razel - אהרן רזאל", "Aaron Razel")), updates)
     }
 
     @Test
-    fun `rename targets only rows already in the artist table (new rows insert the displayName directly)`() {
-        val updates = artistDisplayNameUpdates(
-            listOf(named("existing", "E - ע", "E"), named("new", "N - נ", "N")),
-            existingArtistIds = setOf("existing"),
+    fun `a pre-split payload (all displayNames null or blank) must not burn the one-time flag`() {
+        assertEquals(
+            false,
+            whitelistCarriesDisplayNames(
+                listOf(named("a", "Plain Name", null), named("b", "Legacy", "   ")),
+            ),
         )
-        assertEquals(listOf(Triple("existing", "E - ע", "E")), updates)
     }
 
     // --- whitelistFastPathEligible (version-gate + one-time display-name backfill) ---

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt
@@ -51,6 +51,24 @@ class ZemerContentClientTest {
     }
 
     @Test
+    fun `whitelist doc reads displayName and altName when present, null when absent (pre-split docs)`() {
+        val split = json.decodeFromString(
+            ContentWhitelistDoc.serializer(),
+            """{"id":"UC1","name":"Aaron Razel - אהרן רזאל","displayName":"Aaron Razel","altName":"אהרן רזאל"}""",
+        )
+        assertEquals("Aaron Razel - אהרן רזאל", split.name) // legacy value untouched
+        assertEquals("Aaron Razel", split.displayName)
+        assertEquals("אהרן רזאל", split.altName)
+
+        val preSplit = json.decodeFromString(
+            ContentWhitelistDoc.serializer(),
+            """{"id":"UC2","name":"Plain"}""",
+        )
+        assertNull(preSplit.displayName)
+        assertNull(preSplit.altName)
+    }
+
+    @Test
     fun `whitelist doc reads the thumbnail when present, null when absent`() {
         val withThumb = json.decodeFromString(
             ContentWhitelistDoc.serializer(),

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -21,10 +21,10 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 14 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 | `com.jtech.zemer.constants` | no | 2 | 14 | android.os, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 601 | `com.jtech.zemer.constants` | no | 9 | 177 | androidx.annotation, androidx.datastore, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 606 | `com.jtech.zemer.constants` | no | 9 | 178 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1763 | `com.jtech.zemer.db` | no | 65 | 241 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 642 | `com.jtech.zemer.db` | no | 44 | 80 | android.annotation, android.content, android.database, androidx.core, androidx.room, androidx.sqlite, java.time, java.util, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1771 | `com.jtech.zemer.db` | no | 65 | 242 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 652 | `com.jtech.zemer.db` | no | 44 | 82 | android.annotation, android.content, android.database, androidx.core, androidx.room, androidx.sqlite, java.time, java.util, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 | `com.jtech.zemer.db.entities` | no | 1 | 3 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 | `com.jtech.zemer.db.entities` | no | 4 | 8 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumArtistMap.kt` | 29 | `com.jtech.zemer.db.entities` | no | 3 | 4 | androidx.room |
@@ -32,7 +32,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 | `com.jtech.zemer.db.entities` | no | 4 | 4 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 7 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 60 | `com.jtech.zemer.db.entities` | no | 13 | 13 | androidx.compose, androidx.room, java.time, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 27 | `com.jtech.zemer.db.entities` | no | 5 | 12 | androidx.compose, androidx.room, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 33 | `com.jtech.zemer.db.entities` | no | 6 | 14 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 | `com.jtech.zemer.db.entities` | no | 7 | 5 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 | `com.jtech.zemer.db.entities` | no | 3 | 3 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 11 | androidx.room |
@@ -484,7 +484,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt` | 32 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 51 | `com.jtech.zemer.utils` | no | 1 | 8 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1126 | `com.jtech.zemer.utils` | no | 48 | 137 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1191 | `com.jtech.zemer.utils` | no | 49 | 141 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 | `com.jtech.zemer.utils` | no | 17 | 65 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
@@ -492,10 +492,10 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoLinkBuilder.kt` | 36 | `com.jtech.zemer.utils` | no | 0 | 8 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoMuxer.kt` | 138 | `com.jtech.zemer.utils` | no | 7 | 22 | android.media, java.io, java.nio, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt` | 40 | `com.jtech.zemer.utils` | no | 1 | 9 |  |
-| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 226 | `com.jtech.zemer.utils` | no | 7 | 50 | com.google, java.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 230 | `com.jtech.zemer.utils` | no | 7 | 50 | com.google, java.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 | `com.jtech.zemer.utils` | no | 10 | 32 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 814 | `com.jtech.zemer.utils` | no | 34 | 102 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 250 | `com.jtech.zemer.utils` | no | 21 | 63 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 255 | `com.jtech.zemer.utils` | no | 21 | 65 | io.ktor, java.io, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 | `com.jtech.zemer.utils.sabr` | no | 17 | 37 | android.content, android.net, android.webkit, com.zemer, java.io, kotlin.coroutines, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 | `com.jtech.zemer.utils.sabr` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 | `com.jtech.zemer.utils.updater` | yes | 15 | 15 | androidx.activity, androidx.compose, java.io, kotlinx.coroutines |
@@ -668,7 +668,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StatusNavigationTest.kt` | 17 | `com.jtech.zemer.ui.utils` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 | `com.jtech.zemer.ui.utils` | no | 3 | 2 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 | `com.jtech.zemer.ui.utils` | no | 2 | 10 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 62 | `com.jtech.zemer.utils` | no | 5 | 6 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 143 | `com.jtech.zemer.utils` | no | 5 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 | `com.jtech.zemer.utils` | no | 5 | 7 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt` | 46 | `com.jtech.zemer.utils` | no | 2 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 | `com.jtech.zemer.utils` | no | 6 | 6 | org.junit, timber.log |
@@ -681,7 +681,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 | `com.jtech.zemer.utils` | no | 4 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 69 | `com.jtech.zemer.utils` | no | 3 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 | `com.jtech.zemer.utils` | no | 2 | 1 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 | `com.jtech.zemer.utils` | no | 7 | 11 | kotlinx.coroutines, kotlinx.serialization, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 | `com.jtech.zemer.utils` | no | 7 | 13 | kotlinx.coroutines, kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 | `com.jtech.zemer.viewmodels` | no | 7 | 11 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -23,7 +23,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 606 | `com.jtech.zemer.constants` | no | 9 | 178 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1771 | `com.jtech.zemer.db` | no | 65 | 242 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1791 | `com.jtech.zemer.db` | no | 65 | 244 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 652 | `com.jtech.zemer.db` | no | 44 | 82 | android.annotation, android.content, android.database, androidx.core, androidx.room, androidx.sqlite, java.time, java.util, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 | `com.jtech.zemer.db.entities` | no | 1 | 3 | java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 | `com.jtech.zemer.db.entities` | no | 4 | 8 | androidx.compose, androidx.room |
@@ -32,7 +32,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 | `com.jtech.zemer.db.entities` | no | 4 | 4 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 7 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 60 | `com.jtech.zemer.db.entities` | no | 13 | 13 | androidx.compose, androidx.room, java.time, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 33 | `com.jtech.zemer.db.entities` | no | 6 | 14 | androidx.compose, androidx.room, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 34 | `com.jtech.zemer.db.entities` | no | 6 | 14 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 | `com.jtech.zemer.db.entities` | no | 7 | 5 | androidx.compose, androidx.room, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 | `com.jtech.zemer.db.entities` | no | 3 | 3 | androidx.compose, androidx.room |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 | `com.jtech.zemer.db.entities` | no | 2 | 11 | androidx.room |
@@ -484,7 +484,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt` | 32 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 51 | `com.jtech.zemer.utils` | no | 1 | 8 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1191 | `com.jtech.zemer.utils` | no | 49 | 141 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1188 | `com.jtech.zemer.utils` | no | 49 | 140 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 | `com.jtech.zemer.utils` | no | 17 | 65 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
@@ -495,7 +495,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 230 | `com.jtech.zemer.utils` | no | 7 | 50 | com.google, java.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 | `com.jtech.zemer.utils` | no | 10 | 32 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 814 | `com.jtech.zemer.utils` | no | 34 | 102 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 255 | `com.jtech.zemer.utils` | no | 21 | 65 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 | `com.jtech.zemer.utils` | no | 21 | 65 | io.ktor, java.io, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 | `com.jtech.zemer.utils.sabr` | no | 17 | 37 | android.content, android.net, android.webkit, com.zemer, java.io, kotlin.coroutines, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 | `com.jtech.zemer.utils.sabr` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 | `com.jtech.zemer.utils.updater` | yes | 15 | 15 | androidx.activity, androidx.compose, java.io, kotlinx.coroutines |
@@ -518,7 +518,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 | `com.jtech.zemer.viewmodels` | no | 14 | 38 | androidx.annotation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 993 | `com.jtech.zemer.viewmodels` | no | 57 | 199 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 55 | `com.jtech.zemer.viewmodels` | no | 15 | 10 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 60 | `com.jtech.zemer.viewmodels` | no | 16 | 10 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 41 | `com.jtech.zemer.viewmodels` | no | 13 | 8 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryViewModels.kt` | 572 | `com.jtech.zemer.viewmodels` | no | 69 | 84 | android.content, androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
@@ -543,7 +543,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StoryViewModel.kt` | 120 | `com.jtech.zemer.viewmodels` | no | 25 | 17 | android.content, android.graphics, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 | `com.jtech.zemer.viewmodels` | no | 14 | 4 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt` | 96 | `com.jtech.zemer.viewmodels` | no | 24 | 18 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 64 | `com.jtech.zemer.viewmodels` | no | 17 | 12 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 70 | `com.jtech.zemer.viewmodels` | no | 17 | 12 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedPodcastsViewModel.kt` | 86 | `com.jtech.zemer.viewmodels` | no | 20 | 15 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistViewModel.kt` | 72 | `com.jtech.zemer.viewmodels` | no | 17 | 14 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistsViewModel.kt` | 81 | `com.jtech.zemer.viewmodels` | no | 20 | 10 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -668,7 +668,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StatusNavigationTest.kt` | 17 | `com.jtech.zemer.ui.utils` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 | `com.jtech.zemer.ui.utils` | no | 3 | 2 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 | `com.jtech.zemer.ui.utils` | no | 2 | 10 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 143 | `com.jtech.zemer.utils` | no | 5 | 10 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 140 | `com.jtech.zemer.utils` | no | 5 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 | `com.jtech.zemer.utils` | no | 5 | 7 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt` | 46 | `com.jtech.zemer.utils` | no | 2 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 | `com.jtech.zemer.utils` | no | 6 | 6 | org.junit, timber.log |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -1,6 +1,6 @@
 # Non-Kotlin file reference
 
-Every tracked non-Kotlin path outside `docs/` is listed. Text files report line counts; binary files report byte counts; gitlinks are recorded as non-file tracked paths. Total paths: `378`.
+Every tracked non-Kotlin path outside `docs/` is listed. Text files report line counts; binary files report byte counts; gitlinks are recorded as non-file tracked paths. Total paths: `379`.
 
 | Path | Size/status | Type metadata |
 | --- | ---: | --- |
@@ -46,6 +46,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/32.json` | 1156 lines | text `.json`; JSON keys `formatVersion, database` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/33.json` | 1229 lines | text `.json`; JSON keys `formatVersion, database` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/34.json` | 1368 lines | text `.json`; JSON keys `formatVersion, database` |
+| `app/schemas/com.jtech.zemer.db.InternalDatabase/35.json` | 1378 lines | text `.json`; JSON keys `formatVersion, database` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/4.json` | 744 lines | text `.json`; JSON keys `formatVersion, database` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/5.json` | 748 lines | text `.json`; JSON keys `formatVersion, database` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/6.json` | 712 lines | text `.json`; JSON keys `formatVersion, database` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -185,7 +185,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 606 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1771 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1791 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 652 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 lines | `.kt` |
@@ -194,7 +194,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 60 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 33 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 34 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 lines | `.kt` |
@@ -646,7 +646,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 51 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1191 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1188 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
@@ -657,7 +657,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 230 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 814 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 255 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 lines | `.kt` |
@@ -680,7 +680,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 993 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 55 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 60 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 41 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryViewModels.kt` | 572 lines | `.kt` |
@@ -705,7 +705,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/StoryViewModel.kt` | 120 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/TopPlaylistViewModel.kt` | 38 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/VideoHomeRowsViewModel.kt` | 96 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 64 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedArtistsViewModel.kt` | 70 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/WhitelistedPodcastsViewModel.kt` | 86 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistViewModel.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerCuratedPlaylistsViewModel.kt` | 81 lines | `.kt` |
@@ -1038,7 +1038,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StatusNavigationTest.kt` | 17 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 143 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 140 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt` | 46 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,13 +77,13 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1212`
+- Files counted: `1213`
 - By extension:
   - `.kt`: `771`
   - `.xml`: `192`
   - `.mjs`: `77`
   - `.md`: `71`
-  - `.json`: `37`
+  - `.json`: `38`
   - `.webp`: `15`
   - `[none]`: `7`
   - `.kts`: `6`
@@ -151,6 +151,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/32.json` | 1156 lines | `.json` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/33.json` | 1229 lines | `.json` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/34.json` | 1368 lines | `.json` |
+| `app/schemas/com.jtech.zemer.db.InternalDatabase/35.json` | 1378 lines | `.json` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/4.json` | 744 lines | `.json` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/5.json` | 748 lines | `.json` |
 | `app/schemas/com.jtech.zemer.db.InternalDatabase/6.json` | 712 lines | `.json` |
@@ -182,10 +183,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/LibraryFilter.kt` | 14 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/MediaSessionConstants.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 601 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 606 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1763 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 642 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1771 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 652 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Album.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumArtistMap.kt` | 29 lines | `.kt` |
@@ -193,7 +194,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/AlbumWithSongs.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Artist.kt` | 19 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistEntity.kt` | 60 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 27 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/entities/ArtistWhitelistEntity.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/Event.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/EventWithSong.kt` | 17 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/FormatEntity.kt` | 19 lines | `.kt` |
@@ -645,7 +646,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RankedContentGate.kt` | 32 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 51 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1126 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1191 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
@@ -653,10 +654,10 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoLinkBuilder.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/VideoMuxer.kt` | 138 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistCache.kt` | 40 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 226 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFetcher.kt` | 230 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 814 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 250 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 255 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/EjsNTransformSolver.kt` | 307 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/sabr/SabrException.kt` | 3 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 lines | `.kt` |
@@ -1037,7 +1038,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StatusNavigationTest.kt` | 17 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/StringUtilsTest.kt` | 21 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/utils/YouTubeUtilsTest.kt` | 76 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 62 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ArtistThumbResolverTest.kt` | 143 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BlockedIdsCacheTest.kt` | 62 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/BottomNavItemsTest.kt` | 46 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/CrashReportingTreeTest.kt` | 64 lines | `.kt` |
@@ -1050,7 +1051,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 69 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 97 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 lines | `.kt` |
@@ -1103,7 +1104,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
 | `docs/reference/kotlin-files.md` | 794 lines | `.md` |
-| `docs/reference/non-kotlin-files.md` | 384 lines | `.md` |
+| `docs/reference/non-kotlin-files.md` | 385 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
 | `docs/remote_cipher_config/02-file-format.md` | 116 lines | `.md` |
@@ -1113,7 +1114,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1323 lines | `.md` |
+| `docs/repository-map.md` | 1324 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |


### PR DESCRIPTION
## What

The whitelist now serves two additive fields alongside the legacy `name`: `displayName` (the clean single-script name the artist is actually known by, e.g. "Aaron Razel" / "עדי גביסון") and `altName` (the same name in the other script). For ~50 artists the legacy `name` is a dual "English - עברית" dash form; that field is untouched, so pre-patch installs keep their exact prior behavior. This patch makes the app display the clean name and match artist search in either script - everywhere.

## How

- **`ContentWhitelistDoc`**: additive `displayName`/`altName` wire fields (content.zemer.io and Firestore already serve them; live: displayName appears ONLY on the ~50 split docs, which the design leans on).
- **`artist_whitelist`**: two nullable TEXT columns; Room v34 -> v35 via two additive `ALTER TABLE`s (the same pattern as the isKids/isKidZone migrations). No data transform; the table is rebuilt on every whitelist sync anyway.
- **`WhitelistFetcher`**: both the mirror and Firestore paths carry the new fields, blank coerced to null.
- **The curated displayName is AUTHORITATIVE for its artist row**: one set-based, idempotent, self-terminating DAO UPDATE (`applyWhitelistDisplayNames`) runs after every full whitelist fetch - it repairs pre-split seeds, re-applies after a stale YTM refresh restored the dual title, and lands later server-side displayName corrections on already-renamed installs. New artist rows seed with `displayName ?: name` directly. The >10-day stale library-artist refresh also prefers the whitelist displayName over the raw YTM channel title (which IS the dual dash form for these artists), so the clean name sticks.
- **`artistByName` matches all three whitelist names** (`artistName`/`displayName`/`altName`): wire credits from zemer-search may still carry the legacy dual name, and the name-keyed credit resolution must keep landing on the whitelisted row after the rename (missing it would mint a generated duplicate - the infinite-album-skeleton class).
- **Search in either script, everywhere**: `searchArtists` (library + Android Auto) matches `altName` in SQL, and the Artists browse + KidZone search pills match it via `WhitelistCache`.
- **One-time backfill gate**: `DisplayNamesBackfilledKey` re-enables the version-gated fast path only after a full fetch whose payload actually carried split names (a stale pre-split mirror snapshot cannot burn the flag).

## Testing

- Full unit suite green: wire-field coverage (split + pre-split docs keep null semantics) and the pure payload gate (`whitelistCarriesDisplayNames`).
- Debug + R8 release builds green; exported Room schema `35.json` verified to carry both columns. The DAO SQL (authoritative rename, three-name artistByName) has no JVM-testable seam without Robolectric, so it is covered by compile + schema export + on-device verification.
- Worth an on-device pass: search "razel" and "רזאל" in the library AND the Artists browse pill (both should return Aaron Razel, shown clean); play a song of a split artist from Zemer search and confirm the artist page opens from the player (the wire credit still carries the dual name); and a whitelist sync on an upgraded install renaming a previously dash-form artist.

