### PR TITLE
fix(player): make the title/artist taps work on every queue surface

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt
@@ -71,6 +71,30 @@ data class MediaMetadata(
     }
 }
 
+/**
+ * Fill the NAVIGATION ids the wire item lacked from the played song's DB row, so the player's
+ * title/artist taps (and the player menu's View artist / View album rows) work on every surface.
+ * Several Zemer track payloads are name-only (curated playlists, community playlists, search rows) —
+ * their queue items carry no artist id / album ref, which left those taps as silent no-ops. Every
+ * play inserts the song resolving id-less credits via artistByName (whitelisted row preferred), so
+ * by the time the player is open [song] carries the resolved ids; take an artist id only from a
+ * name-matched row with a REAL channel id ([ArtistEntity.isYouTubeArtist]) — navigating a generated
+ * local id opens a dead "not available" page, worse than the no-op. Display fields are untouched.
+ */
+fun MediaMetadata.withResolvedNavIds(song: Song?): MediaMetadata {
+    song ?: return this
+    val resolvedArtists = artists.map { artist ->
+        if (!artist.id.isNullOrBlank()) artist
+        else song.artists.firstOrNull { it.name == artist.name && it.isYouTubeArtist }
+            ?.let { artist.copy(id = it.id) } ?: artist
+    }
+    val resolvedAlbum = album ?: song.song.albumId?.let {
+        MediaMetadata.Album(id = it, title = song.song.albumName.orEmpty())
+    }
+    return if (resolvedArtists == artists && resolvedAlbum == album) this
+    else copy(artists = resolvedArtists, album = resolvedAlbum)
+}
+
 fun Song.toMediaMetadata() =
     MediaMetadata(
         id = song.id,

--- a/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt
@@ -303,15 +303,24 @@ object ZemerResultMapper {
     ): ArtistPage {
         fun albumSection(list: List<ZemerAlbum>): List<AlbumItem> =
             list.filter { it.id.isNotBlank() }.map { it.toAlbumItem() }.distinctBy { it.id }.dropBlocked()
+        // The wire tracks carry no artist credit (the page IS the artist) — thread the page artist's
+        // name + id in, so a played track shows a (tappable) artist line in the player instead of
+        // none, the same threading toAlbumPage does for its album artist.
+        fun credited(tracks: List<ZemerTrack>): List<ZemerTrack> =
+            tracks.map { t ->
+                if (t.artist.isBlank()) {
+                    t.copy(artist = artist.name, artistId = t.artistId ?: artist.id.takeIf { it.isNotBlank() })
+                } else t
+            }
         // Section order mirrors the InnerTube artist page: Songs, Albums, Singles, Videos, Playlists.
         val sections = buildList {
-            songItems(songs).takeIf { it.isNotEmpty() }
+            songItems(credited(songs)).takeIf { it.isNotEmpty() }
                 ?.let { add(ArtistSection(TITLE_SONGS, it, null)) }
             albumSection(albums).takeIf { it.isNotEmpty() }
                 ?.let { add(ArtistSection(TITLE_ALBUMS, it, null)) }
             albumSection(singles).takeIf { it.isNotEmpty() }
                 ?.let { add(ArtistSection(TITLE_SINGLES, it, null)) }
-            songItems(videos, isVideo = true).takeIf { it.isNotEmpty() }
+            songItems(credited(videos), isVideo = true).takeIf { it.isNotEmpty() }
                 ?.let { add(ArtistSection(TITLE_VIDEOS, it, null)) }
             playlistItems(playlists, formatSongCount).takeIf { it.isNotEmpty() }
                 ?.let { add(ArtistSection(TITLE_PLAYLISTS, it, null)) }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt
@@ -126,6 +126,7 @@ import com.jtech.zemer.extensions.toggleRepeatMode
 import com.jtech.zemer.extensions.shareText
 import com.jtech.zemer.extensions.copyToClipboard
 import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.models.withResolvedNavIds
 import com.jtech.zemer.playback.PlayerVideoUiLogic
 import com.jtech.zemer.ui.component.DefaultDialog
 import com.jtech.zemer.ui.component.BottomSheet
@@ -215,8 +216,13 @@ fun BottomSheetPlayer(
     val playbackState by playerConnection.playbackState.collectAsState()
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val isCasting by playerConnection.isCasting.collectAsState()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val rawMediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    // Fill navigation ids (artist / album) the wire item lacked from the played song's DB row, so the
+    // title/artist taps and the player menu's view rows work on name-only Zemer surfaces too.
+    val mediaMetadata = remember(rawMediaMetadata, currentSong) {
+        rawMediaMetadata?.withResolvedNavIds(currentSong)
+    }
     val repeatMode by playerConnection.repeatMode.collectAsState()
     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()

--- a/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt
@@ -101,6 +101,7 @@ import com.jtech.zemer.extensions.shuffleIconRes
 import com.jtech.zemer.extensions.togglePlayPause
 import com.jtech.zemer.extensions.toggleRepeatMode
 import com.jtech.zemer.models.MediaMetadata
+import com.jtech.zemer.models.withResolvedNavIds
 import com.jtech.zemer.ui.component.ActionPromptDialog
 import com.jtech.zemer.ui.component.BottomSheet
 import com.jtech.zemer.ui.component.BottomSheetState
@@ -152,7 +153,12 @@ fun Queue(
     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
 
     val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val rawMediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    // Same nav-id fill as Player.kt: the queue bar's PlayerMenu needs resolved artist/album ids too.
+    val mediaMetadata = remember(rawMediaMetadata, currentSong) {
+        rawMediaMetadata?.withResolvedNavIds(currentSong)
+    }
 
     val selectedSongs = remember { mutableStateListOf<MediaMetadata>() }
     val selectedItems = remember { mutableStateListOf<Timeline.Window>() }

--- a/app/src/test/kotlin/com/jtech/zemer/models/MediaMetadataNavResolutionTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/models/MediaMetadataNavResolutionTest.kt
@@ -1,0 +1,82 @@
+package com.jtech.zemer.models
+
+import com.jtech.zemer.db.entities.ArtistEntity
+import com.jtech.zemer.db.entities.Song
+import com.jtech.zemer.db.entities.SongEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * [withResolvedNavIds] — the player's navigation-id fill for name-only Zemer queue items (curated
+ * playlists, community playlists, search rows), so the title/artist taps and the player menu's
+ * view rows stop being silent no-ops there (issue #519).
+ */
+class MediaMetadataNavResolutionTest {
+    private fun metadata(
+        artists: List<MediaMetadata.Artist> = listOf(MediaMetadata.Artist(id = null, name = "Ben Zur")),
+        album: MediaMetadata.Album? = null,
+    ) = MediaMetadata(id = "vid1", title = "Song", artists = artists, duration = 200, album = album)
+
+    private fun song(
+        artists: List<ArtistEntity> = emptyList(),
+        albumId: String? = null,
+        albumName: String? = null,
+    ) = Song(
+        song = SongEntity(id = "vid1", title = "Song", albumId = albumId, albumName = albumName),
+        artists = artists,
+    )
+
+    @Test
+    fun `blank artist id fills from a name-matched real channel row`() {
+        val resolved = metadata().withResolvedNavIds(
+            song(artists = listOf(ArtistEntity(id = "UCben", name = "Ben Zur"))),
+        )
+        assertEquals("UCben", resolved.artists.single().id)
+        assertEquals("Ben Zur", resolved.artists.single().name)
+    }
+
+    @Test
+    fun `generated local artist row never fills - a dead artist page is worse than the no-op`() {
+        val resolved = metadata().withResolvedNavIds(
+            song(artists = listOf(ArtistEntity(id = "LAABCDEFGH", name = "Ben Zur"))),
+        )
+        assertNull(resolved.artists.single().id)
+    }
+
+    @Test
+    fun `name mismatch does not fill`() {
+        val resolved = metadata().withResolvedNavIds(
+            song(artists = listOf(ArtistEntity(id = "UCother", name = "Someone Else"))),
+        )
+        assertNull(resolved.artists.single().id)
+    }
+
+    @Test
+    fun `existing wire id is never overwritten`() {
+        val resolved = metadata(artists = listOf(MediaMetadata.Artist(id = "UCwire", name = "Ben Zur")))
+            .withResolvedNavIds(song(artists = listOf(ArtistEntity(id = "UCdb", name = "Ben Zur"))))
+        assertEquals("UCwire", resolved.artists.single().id)
+    }
+
+    @Test
+    fun `missing album fills from the song row`() {
+        val resolved = metadata().withResolvedNavIds(song(albumId = "MPREb_x", albumName = "Album X"))
+        assertEquals(MediaMetadata.Album(id = "MPREb_x", title = "Album X"), resolved.album)
+    }
+
+    @Test
+    fun `existing album is never overwritten`() {
+        val album = MediaMetadata.Album(id = "MPREb_wire", title = "Wire Album")
+        val resolved = metadata(album = album).withResolvedNavIds(song(albumId = "MPREb_db"))
+        assertEquals(album, resolved.album)
+    }
+
+    @Test
+    fun `null song and no-op resolution return the same instance`() {
+        val m = metadata()
+        assertSame(m, m.withResolvedNavIds(null))
+        assertSame(m, m.withResolvedNavIds(song()))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt
@@ -472,6 +472,25 @@ class ZemerResultMapperTest {
         assertTrue(videos.single().isVideo)
     }
 
+    @Test
+    fun `artist page threads the page artist into credit-less tracks`() {
+        // The wire tracks carry no artist credit (the page IS the artist); without the threading a
+        // played track shows no (tappable) artist line in the player at all (issue #519).
+        val page = ZemerArtistResponse(
+            artist = ZemerArtist("UC1", "Page Artist"),
+            songs = listOf(ZemerTrack("s1", "Song")),
+            videos = listOf(ZemerTrack("v1", "Clip", artist = "Featured Guest", artistId = "UCg")),
+        ).toArtistPage()
+
+        val song = page.sections.first { it.title == "Songs" }.items.single() as SongItem
+        assertEquals("Page Artist", song.artists.single().name)
+        assertEquals("UC1", song.artists.single().id)
+        // An explicit wire credit is never overwritten.
+        val video = page.sections.first { it.title == "Videos" }.items.single() as SongItem
+        assertEquals("Featured Guest", video.artists.single().name)
+        assertEquals("UCg", video.artists.single().id)
+    }
+
     // --- /video-home-rows mapping (the Videos tab's ranked rows) ---
 
     @Test

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -92,7 +92,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/model/LyricsUnavailableException.kt` | 9 | `com.jtech.zemer.lyrics.model` | no | 0 | 2 |  |
 | `app/src/main/kotlin/com/jtech/zemer/models/DpadDirection.kt` | 27 | `com.jtech.zemer.models` | no | 9 | 5 | android.view, androidx.annotation, androidx.datastore |
 | `app/src/main/kotlin/com/jtech/zemer/models/ItemsPage.kt` | 8 | `com.jtech.zemer.models` | no | 1 | 3 |  |
-| `app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt` | 155 | `com.jtech.zemer.models` | no | 9 | 28 | androidx.compose, java.io, java.time |
+| `app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt` | 179 | `com.jtech.zemer.models` | no | 9 | 31 | androidx.compose, java.io, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistPlayerState.kt` | 19 | `com.jtech.zemer.models` | no | 1 | 10 | java.io |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistQueue.kt` | 91 | `com.jtech.zemer.models` | no | 1 | 41 | java.io |
 | `app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt` | 137 | `com.jtech.zemer.offline` | no | 23 | 28 | android.content, dagger.hilt, java.lang, javax.inject, kotlinx.coroutines |
@@ -184,7 +184,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 | `com.jtech.zemer.search` | no | 2 | 9 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 | `com.jtech.zemer.search` | no | 1 | 42 | kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 | `com.jtech.zemer.search` | no | 1 | 26 | kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 689 | `com.jtech.zemer.search` | no | 20 | 104 |  |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 698 | `com.jtech.zemer.search` | no | 20 | 105 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 71 | `com.jtech.zemer.search` | no | 1 | 14 |  |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 599 | `com.jtech.zemer.search` | no | 16 | 62 | io.ktor, java.io, javax.inject, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 416 | `com.jtech.zemer.search` | no | 2 | 158 | kotlinx.serialization |
@@ -335,11 +335,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 735 | `com.jtech.zemer.ui.player` | yes | 97 | 71 | android.annotation, android.content, androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 | `com.jtech.zemer.ui.player` | yes | 9 | 5 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 | `com.jtech.zemer.ui.player` | yes | 15 | 1 | androidx.compose, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1322 | `com.jtech.zemer.ui.player` | yes | 155 | 101 | android.annotation, android.app, android.content, androidx.compose, androidx.core, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines, me.saket |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1328 | `com.jtech.zemer.ui.player` | yes | 156 | 102 | android.annotation, android.app, android.content, androidx.compose, androidx.core, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines, me.saket |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerBackground.kt` | 116 | `com.jtech.zemer.ui.player` | yes | 19 | 11 | android.os, android.util, androidx.compose, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerVideoFullscreen.kt` | 317 | `com.jtech.zemer.ui.player` | yes | 58 | 18 | android.app, android.content, androidx.activity, androidx.compose, androidx.core, androidx.media3, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerVideoSurface.kt` | 111 | `com.jtech.zemer.ui.player` | yes | 27 | 12 | android.view, androidx.compose, androidx.media3 |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 938 | `com.jtech.zemer.ui.player` | yes | 121 | 49 | android.annotation, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines, sh.calvin |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 944 | `com.jtech.zemer.ui.player` | yes | 122 | 51 | android.annotation, androidx.activity, androidx.compose, androidx.media3, androidx.navigation, kotlin.math, kotlinx.coroutines, sh.calvin |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/StationLiveBar.kt` | 70 | `com.jtech.zemer.ui.player` | yes | 17 | 2 | androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 577 | `com.jtech.zemer.ui.player` | yes | 80 | 61 | androidx.compose, androidx.media3, coil3.compose, kotlin.math, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/VideoModePill.kt` | 139 | `com.jtech.zemer.ui.player` | yes | 30 | 7 | androidx.annotation, androidx.compose |
@@ -619,7 +619,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 | `com.jtech.zemer.search` | no | 8 | 15 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 | `com.jtech.zemer.search` | no | 5 | 24 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 | `com.jtech.zemer.search` | no | 14 | 19 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 710 | `com.jtech.zemer.search` | no | 18 | 83 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 729 | `com.jtech.zemer.search` | no | 18 | 86 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 75 | `com.jtech.zemer.search` | no | 3 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 | `com.jtech.zemer.search` | no | 3 | 10 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 | `com.jtech.zemer.search` | no | 2 | 4 | org.junit |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -253,7 +253,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/model/LyricsUnavailableException.kt` | 9 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/DpadDirection.kt` | 27 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/ItemsPage.kt` | 8 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt` | 155 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/models/MediaMetadata.kt` | 179 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistPlayerState.kt` | 19 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/PersistQueue.kt` | 91 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/offline/OfflineReadProvider.kt` | 137 lines | `.kt` |
@@ -345,7 +345,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/search/ResultDedupe.kt` | 78 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerGenresModels.kt` | 149 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerPodcastGenresModels.kt` | 81 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 689 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/search/ZemerResultMapper.kt` | 698 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerRoutes.kt` | 71 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchClient.kt` | 599 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/search/ZemerSearchModels.kt` | 416 lines | `.kt` |
@@ -496,11 +496,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/MiniPlayer.kt` | 735 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/OverMediaChrome.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlaybackError.kt` | 45 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1322 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Player.kt` | 1328 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerBackground.kt` | 116 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerVideoFullscreen.kt` | 317 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/PlayerVideoSurface.kt` | 111 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 938 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/player/Queue.kt` | 944 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/StationLiveBar.kt` | 70 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/Thumbnail.kt` | 577 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/player/VideoModePill.kt` | 139 lines | `.kt` |
@@ -988,7 +988,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerCuratedPlaylistsTest.kt` | 187 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerGenresTest.kt` | 272 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerPodcastMapperTest.kt` | 177 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 710 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/search/ZemerResultMapperTest.kt` | 729 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerRoutesTest.kt` | 75 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchJsonTest.kt` | 89 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/search/ZemerSearchParametersTest.kt` | 45 lines | `.kt` |


### PR DESCRIPTION
## Summary

Fixes #519: the full-screen player's title and artist taps (and the player menu's View artist / View album rows) were silent no-ops on every queue surface whose track payload is name-only - Zemer curated playlists (the reported case), community playlists, search-result seeds, the offline fallback, and artist-page tracks (which additionally arrive with no artist credit at all, hiding the player's artist line entirely). Verified per surface against the live server: `/zemer-playlists`, `/playlist` and `/search` song rows carry no `artistId`; `/radio`, `/genres`, home rows and stations already do.

## The fix (at the data seam, not per tap site)

- **`MediaMetadata.withResolvedNavIds(song)`** (pure, ~20 lines): fills a blank artist id from the played song's DB row - every play already inserts the song resolving id-less credits via `artistByName` (whitelisted row preferred) - but only from a name-matched row with a real channel id (`isYouTubeArtist`); a generated local id would navigate to a dead "not available" page, worse than the no-op. A missing album ref fills from `song.albumId`. Wire-provided ids are never overwritten.
- **Player + queue bar** apply it once where they collect `mediaMetadata` (3 lines each), so the title tap, the artist-annotation tap, the menu's view rows and the share link all inherit the fix on every surface with zero per-site changes.
- **`toArtistPage`** threads the page artist's name + id into credit-less tracks (the same threading `toAlbumPage` already does for its album artist), so a track played from an artist page shows a tappable artist line instead of none. Fixing this in the mapper covers the offline snapshot too - both paths share it.

## Tests

- `MediaMetadataNavResolutionTest` (7 JVM tests): the resolution ladder - fill from a real-channel name match, never from a generated local row, never overwrite a wire id, album fill, identity short-circuits.
- `ZemerResultMapperTest`: the artist-page credit threading (and that an explicit wire credit survives).
- Full unit suite, the three audit ratchets, and `:app:assembleDebug` all pass. The taps themselves are Compose UI (no Robolectric in this repo), so a quick on-device check is worthwhile: play from a Zemer playlist, tap the title and the artist name.
