### PR TITLE
fix(density): survive configuration changes without an app restart

### DIFF
--- a/app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt
+++ b/app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt
@@ -41,6 +41,17 @@ abstract class ActivityLifecycleManager : BaseLifecycleContentProvider() {
     protected open val activityTimerDelayMillis: Int
         get() = 3000
 
+    /** Runs [action] on every currently-resumed activity, isolating per-activity failures. */
+    protected fun forEachActiveActivity(action: (Activity) -> Unit) {
+        activeActivities.forEach { activity ->
+            try {
+                action(activity)
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Error applying action to active activity")
+            }
+        }
+    }
+
     protected open fun onActivityTimer(activity: Activity) {}
 
     override fun onCreate(): Boolean {

--- a/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
+++ b/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
@@ -2,7 +2,6 @@ package com.dpi
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.ComponentCallbacks
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -17,25 +16,33 @@ import timber.log.Timber
  * WIPES on every system configuration delivery — including the rotation caused by the fullscreen
  * video player's forced landscape (issue #521, where MainActivity handles `configChanges` so no
  * lifecycle event fires to heal it). Re-application is therefore:
- * - IDEMPOTENT ([DensityMath.targetDpi]): safe from any hook, any number of times, and correct when
- *   the device's real density changes (the last-applied value is the only state; the incoming dpi is
- *   always treated as the current native base — never a value captured once at startup);
+ * - STATELESS and idempotent ([DensityMath.targetDpi]): the target is always the CURRENT native
+ *   density (from `Resources.getSystem()`, which the framework owns and keeps updated) times the
+ *   scale, applied only when the Resources isn't already there — safe from any hook, any number of
+ *   times, per Resources object, and correct across genuine system density changes;
  * - always computed on a COPY of the configuration: mutating the live `resources.configuration` in
  *   place makes `updateConfiguration` diff the incoming object against itself, see no change, and
  *   silently skip the metrics update (the original "broken until app restart" half of #521);
- * - EVENT-DRIVEN: activity lifecycle hooks cover recreated activities, an application-level
- *   [ComponentCallbacks] covers the app resources, and `MainActivity.onConfigurationChanged`
- *   (the one activity that opts into `configChanges`) calls [applyDensityToActivity] via
- *   [DensityScaler.reapply] BEFORE dispatching to its views, so Compose re-reads the scaled metrics.
+ * - EVENT-DRIVEN, no polling: activity lifecycle hooks cover recreated activities;
+ *   [onSystemConfigurationChanged] — forwarded from the [DensityScaler] ContentProvider, which the
+ *   framework dispatches to right after resetting the app Resources — re-applies to the app
+ *   resources AND every active activity, so any `configChanges`-handling activity is covered
+ *   generically; `MainActivity.onConfigurationChanged` additionally calls
+ *   [applyDensityToActivity] (via [DensityScaler.reapply]) BEFORE dispatching to its views, so the
+ *   view tree deterministically re-reads the scaled metrics during that dispatch.
+ *
+ * Known limitation (accepted): the native base is the DEFAULT display's density, so an activity
+ * shown on a secondary display (DeX/external) scales relative to the primary panel. Stateless-ness
+ * keeps even that case stable — a wrong-but-constant target, never a compounding one.
  */
 internal class DensityConfiguration(
     private val densityScale: Float
 ) : ActivityLifecycleManager() {
 
-    private var lastAppliedDpi: Int? = null
+    private var appContext: Context? = null
 
     /**
-     * Applies the density scaling to the application context and registers the re-application
+     * Applies the density scaling to the application context and registers the activity lifecycle
      * hooks. This method should be called once during initialization.
      */
     @SuppressLint("LogNotTimber")
@@ -43,31 +50,34 @@ internal class DensityConfiguration(
         if (densityScale == 1.0f) return
 
         try {
+            appContext = context.applicationContext
             onCreate()
             updateDensityDpi(context.resources)
-            // The framework resets the app Resources' configuration on system config changes; this
-            // callback re-applies right after (the per-activity resources ride the activity hooks).
-            context.applicationContext.registerComponentCallbacks(object : ComponentCallbacks {
-                override fun onConfigurationChanged(newConfig: Configuration) {
-                    updateDensityDpi(context.applicationContext.resources)
-                }
-
-                override fun onLowMemory() {}
-            })
         } catch (e: Exception) {
             Log.w(TAG, "Failed to apply configuration", e)
         }
     }
 
     /**
-     * Recomputes and applies the scaled density to [resources] — a no-op when the scale is already
-     * in place (see [DensityMath.targetDpi]). Always works on a COPY of the configuration.
+     * A system configuration change landed (forwarded from the [DensityScaler] provider, which the
+     * framework calls right after resetting the app Resources): re-apply to the app resources and
+     * to every active activity's resources. Idempotent, so sweeping activities the framework did
+     * not touch (or that MainActivity's own hook already healed) is a strict no-op.
+     */
+    fun onSystemConfigurationChanged() {
+        appContext?.let { runCatching { updateDensityDpi(it.resources) } }
+        forEachActiveActivity { applyDensityToActivity(it) }
+    }
+
+    /**
+     * Recomputes and applies the scaled density to [resources] — a no-op when [resources] already
+     * sits at the target (see [DensityMath.targetDpi]). Always works on a COPY of the configuration.
      */
     private fun updateDensityDpi(resources: Resources) {
+        val nativeDpi = Resources.getSystem().configuration.densityDpi
         val config = Configuration(resources.configuration)
-        val target = DensityMath.targetDpi(config.densityDpi, lastAppliedDpi, densityScale) ?: return
+        val target = DensityMath.targetDpi(config.densityDpi, nativeDpi, densityScale) ?: return
         config.densityDpi = target
-        lastAppliedDpi = target
         Timber.tag(TAG).i("Updated densityDpi to: $target")
         @Suppress("DEPRECATION")
         resources.updateConfiguration(config, resources.displayMetrics)

--- a/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
+++ b/app/src/main/kotlin/com/dpi/DensityConfiguration.kt
@@ -2,26 +2,41 @@ package com.dpi
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.ComponentCallbacks
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.util.Log
 import timber.log.Timber
-import kotlin.math.roundToInt
 
 /**
  * Configuration class for adjusting screen density dynamically.
  * Applies density scaling to the entire application and maintains it across activity lifecycle events.
+ *
+ * The override rides the deprecated `Resources.updateConfiguration`, which the framework silently
+ * WIPES on every system configuration delivery — including the rotation caused by the fullscreen
+ * video player's forced landscape (issue #521, where MainActivity handles `configChanges` so no
+ * lifecycle event fires to heal it). Re-application is therefore:
+ * - IDEMPOTENT ([DensityMath.targetDpi]): safe from any hook, any number of times, and correct when
+ *   the device's real density changes (the last-applied value is the only state; the incoming dpi is
+ *   always treated as the current native base — never a value captured once at startup);
+ * - always computed on a COPY of the configuration: mutating the live `resources.configuration` in
+ *   place makes `updateConfiguration` diff the incoming object against itself, see no change, and
+ *   silently skip the metrics update (the original "broken until app restart" half of #521);
+ * - EVENT-DRIVEN: activity lifecycle hooks cover recreated activities, an application-level
+ *   [ComponentCallbacks] covers the app resources, and `MainActivity.onConfigurationChanged`
+ *   (the one activity that opts into `configChanges`) calls [applyDensityToActivity] via
+ *   [DensityScaler.reapply] BEFORE dispatching to its views, so Compose re-reads the scaled metrics.
  */
 internal class DensityConfiguration(
     private val densityScale: Float
 ) : ActivityLifecycleManager() {
 
-    private var originalDensityDpi: Int = 0
+    private var lastAppliedDpi: Int? = null
 
     /**
-     * Applies the density scaling to the application context.
-     * This method should be called once during initialization.
+     * Applies the density scaling to the application context and registers the re-application
+     * hooks. This method should be called once during initialization.
      */
     @SuppressLint("LogNotTimber")
     fun applyDensityScaling(context: Context) {
@@ -29,22 +44,31 @@ internal class DensityConfiguration(
 
         try {
             onCreate()
-            val resources = context.resources
-            val config = Configuration(resources.configuration)
-            originalDensityDpi = config.densityDpi
-            updateDensityDpi(config, resources)
+            updateDensityDpi(context.resources)
+            // The framework resets the app Resources' configuration on system config changes; this
+            // callback re-applies right after (the per-activity resources ride the activity hooks).
+            context.applicationContext.registerComponentCallbacks(object : ComponentCallbacks {
+                override fun onConfigurationChanged(newConfig: Configuration) {
+                    updateDensityDpi(context.applicationContext.resources)
+                }
+
+                override fun onLowMemory() {}
+            })
         } catch (e: Exception) {
             Log.w(TAG, "Failed to apply configuration", e)
         }
     }
 
     /**
-     * Updates the density DPI in the configuration and applies it to resources.
+     * Recomputes and applies the scaled density to [resources] — a no-op when the scale is already
+     * in place (see [DensityMath.targetDpi]). Always works on a COPY of the configuration.
      */
-    private fun updateDensityDpi(config: Configuration, resources: Resources) {
-        val newDensityDpi = (originalDensityDpi * densityScale).roundToInt()
-        config.densityDpi = newDensityDpi
-        Timber.tag(TAG).i("Updated densityDpi to: $newDensityDpi")
+    private fun updateDensityDpi(resources: Resources) {
+        val config = Configuration(resources.configuration)
+        val target = DensityMath.targetDpi(config.densityDpi, lastAppliedDpi, densityScale) ?: return
+        config.densityDpi = target
+        lastAppliedDpi = target
+        Timber.tag(TAG).i("Updated densityDpi to: $target")
         @Suppress("DEPRECATION")
         resources.updateConfiguration(config, resources.displayMetrics)
     }
@@ -73,9 +97,9 @@ internal class DensityConfiguration(
     /**
      * Applies the density configuration to a specific activity's resources.
      */
-    private fun applyDensityToActivity(activity: Activity) {
+    fun applyDensityToActivity(activity: Activity) {
         try {
-            updateDensityDpi(activity.resources.configuration, activity.resources)
+            updateDensityDpi(activity.resources)
         } catch (e: Exception) {
             Timber.tag(TAG).w(e, "Failed to update density for activity")
         }

--- a/app/src/main/kotlin/com/dpi/DensityMath.kt
+++ b/app/src/main/kotlin/com/dpi/DensityMath.kt
@@ -1,0 +1,26 @@
+package com.dpi
+
+import kotlin.math.roundToInt
+
+/**
+ * The pure density-scaling decision, extracted so it is unit-testable and IDEMPOTENT. The scaled
+ * density is applied via `Resources.updateConfiguration`, which the framework silently wipes on
+ * every system configuration delivery (rotation — including the fullscreen-video forced landscape —
+ * display-size changes, ...), so re-application must be safe to run at any time, from any hook:
+ *
+ * - the incoming dpi equal to the LAST APPLIED value means our scale is still in place -> no-op
+ *   (returning a value would compound the scale on every call);
+ * - any other incoming dpi is treated as the CURRENT NATIVE base — the startup value, a value the
+ *   framework just reset, or a genuinely new system density (user changed Display size) — and the
+ *   scale is computed from it, never from a density captured once at startup;
+ * - a scale that rounds to the incoming dpi itself is a no-op (avoids a pointless update).
+ */
+internal object DensityMath {
+    /** The dpi to apply now, or null when nothing should be written. */
+    fun targetDpi(currentDpi: Int, lastAppliedDpi: Int?, scale: Float): Int? {
+        if (currentDpi <= 0) return null
+        if (currentDpi == lastAppliedDpi) return null
+        val target = (currentDpi * scale).roundToInt()
+        return target.takeIf { it > 0 && it != currentDpi }
+    }
+}

--- a/app/src/main/kotlin/com/dpi/DensityMath.kt
+++ b/app/src/main/kotlin/com/dpi/DensityMath.kt
@@ -3,24 +3,23 @@ package com.dpi
 import kotlin.math.roundToInt
 
 /**
- * The pure density-scaling decision, extracted so it is unit-testable and IDEMPOTENT. The scaled
- * density is applied via `Resources.updateConfiguration`, which the framework silently wipes on
- * every system configuration delivery (rotation — including the fullscreen-video forced landscape —
- * display-size changes, ...), so re-application must be safe to run at any time, from any hook:
+ * The pure density-scaling decision — STATELESS, so it is trivially idempotent and cannot be
+ * corrupted. The scaled density is applied via `Resources.updateConfiguration`, which the framework
+ * silently wipes on every system configuration delivery (rotation — including the fullscreen-video
+ * forced landscape — display-size changes, ...), so re-application fires from several hooks and must
+ * be safe from any of them, any number of times.
  *
- * - the incoming dpi equal to the LAST APPLIED value means our scale is still in place -> no-op
- *   (returning a value would compound the scale on every call);
- * - any other incoming dpi is treated as the CURRENT NATIVE base — the startup value, a value the
- *   framework just reset, or a genuinely new system density (user changed Display size) — and the
- *   scale is computed from it, never from a density captured once at startup;
- * - a scale that rounds to the incoming dpi itself is a no-op (avoids a pointless update).
+ * There is no memory of what was applied: the target is always computed from the CURRENT native
+ * density (the caller reads it from `Resources.getSystem()`, which the framework owns, never lets
+ * an app override, and keeps updated on real density changes), and a write happens exactly when the
+ * Resources under repair isn't already at that target. A genuine system density change — including
+ * one that lands exactly on a previously applied value — therefore rescales by construction.
  */
 internal object DensityMath {
-    /** The dpi to apply now, or null when nothing should be written. */
-    fun targetDpi(currentDpi: Int, lastAppliedDpi: Int?, scale: Float): Int? {
-        if (currentDpi <= 0) return null
-        if (currentDpi == lastAppliedDpi) return null
-        val target = (currentDpi * scale).roundToInt()
+    /** The dpi to apply now, or null when [currentDpi] is already correct (or inputs are nonsense). */
+    fun targetDpi(currentDpi: Int, nativeDpi: Int, scale: Float): Int? {
+        if (currentDpi <= 0 || nativeDpi <= 0) return null
+        val target = (nativeDpi * scale).roundToInt()
         return target.takeIf { it > 0 && it != currentDpi }
     }
 }

--- a/app/src/main/kotlin/com/dpi/DensityScaler.kt
+++ b/app/src/main/kotlin/com/dpi/DensityScaler.kt
@@ -1,6 +1,8 @@
 package com.dpi
 
+import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import timber.log.Timber
 
 /**
@@ -14,6 +16,11 @@ import timber.log.Timber
  * - 0.75f (75%) - Compact
  * - 0.65f (65%) - Very Compact
  * - 0.55f (55%) - Ultra Compact
+ *
+ * As a manifest-installed ContentProvider this class is a ComponentCallbacks2 the framework
+ * dispatches [onConfigurationChanged] to right AFTER resetting the app Resources on a system
+ * configuration change — exactly the moment the density override gets wiped (issue #521) — so the
+ * re-application hook lives here, not on a hand-registered callback object.
  */
 class DensityScaler : BaseLifecycleContentProvider() {
 
@@ -21,9 +28,18 @@ class DensityScaler : BaseLifecycleContentProvider() {
         val context = context ?: return false
         val scaleFactor = getScaleFactorFromPreferences(context)
         val configuration = DensityConfiguration(scaleFactor)
-        active = configuration.takeIf { scaleFactor != 1.0f }
+        // Held unconditionally: at native scale every re-application is a strict no-op via
+        // DensityMath (the single gate), so callers never need to know whether scaling is on.
+        active = configuration
         configuration.applyDensityScaling(context)
         return true
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // The framework just reset the app Resources (and possibly activity Resources): re-apply to
+        // the app + every active activity. Idempotent, so over-covering is free.
+        active?.onSystemConfigurationChanged()
     }
 
     companion object {
@@ -38,10 +54,12 @@ class DensityScaler : BaseLifecycleContentProvider() {
          * Reapplies the density scale to [activity]'s resources — for an activity that handles its
          * own `configChanges` (MainActivity), whose resources the framework just reset WITHOUT any
          * lifecycle event firing (issue #521: the fullscreen video player's forced landscape).
-         * Idempotent and a strict no-op at native scale; call it from `onConfigurationChanged`
-         * BEFORE dispatching to super, so the view tree re-reads the already-rescaled metrics.
+         * Call it from `onConfigurationChanged` BEFORE dispatching to super, so the view tree
+         * re-reads the already-rescaled metrics; the provider-level sweep above also covers every
+         * active activity as a generic backstop. Stateless-idempotent — a strict no-op at native
+         * scale or when the resources already sit at the target.
          */
-        fun reapply(activity: android.app.Activity) {
+        fun reapply(activity: Activity) {
             active?.applyDensityToActivity(activity)
         }
 

--- a/app/src/main/kotlin/com/dpi/DensityScaler.kt
+++ b/app/src/main/kotlin/com/dpi/DensityScaler.kt
@@ -20,7 +20,9 @@ class DensityScaler : BaseLifecycleContentProvider() {
     override fun onCreate(): Boolean {
         val context = context ?: return false
         val scaleFactor = getScaleFactorFromPreferences(context)
-        DensityConfiguration(scaleFactor).applyDensityScaling(context)
+        val configuration = DensityConfiguration(scaleFactor)
+        active = configuration.takeIf { scaleFactor != 1.0f }
+        configuration.applyDensityScaling(context)
         return true
     }
 
@@ -28,6 +30,20 @@ class DensityScaler : BaseLifecycleContentProvider() {
         private const val PREFS_NAME = "metrolist_settings"
         private const val KEY_DENSITY_SCALE = "density_scale_factor"
         private const val DEFAULT_SCALE_FACTOR = 1.0f
+
+        @Volatile
+        private var active: DensityConfiguration? = null
+
+        /**
+         * Reapplies the density scale to [activity]'s resources — for an activity that handles its
+         * own `configChanges` (MainActivity), whose resources the framework just reset WITHOUT any
+         * lifecycle event firing (issue #521: the fullscreen video player's forced landscape).
+         * Idempotent and a strict no-op at native scale; call it from `onConfigurationChanged`
+         * BEFORE dispatching to super, so the view tree re-reads the already-rescaled metrics.
+         */
+        fun reapply(activity: android.app.Activity) {
+            active?.applyDensityToActivity(activity)
+        }
 
         /**
          * Reads the density scale factor from SharedPreferences.

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Intent
+import android.content.res.Configuration
 import android.content.ServiceConnection
 import android.os.Build
 import android.os.Bundle
@@ -164,6 +165,7 @@ import coil3.request.allowHardware
 import coil3.request.crossfade
 import coil3.toBitmap
 import com.google.firebase.auth.FirebaseAuth
+import com.dpi.DensityScaler
 import com.jtech.zemer.constants.AppBarHeight
 import com.jtech.zemer.constants.HomeContentTabKey
 import com.jtech.zemer.extensions.cookieHasSession
@@ -405,6 +407,16 @@ class MainActivity : ComponentActivity() {
             }
         }
         ButtonMapperBridge.register(this)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        // This Activity opts into configChanges (orientation|screenSize|...), so a rotation — incl.
+        // the fullscreen video player's forced landscape — delivers a fresh Configuration that WIPES
+        // the custom density override with no lifecycle event to heal it (#521). Reapply BEFORE
+        // dispatching to super: the view tree re-reads density from the resources during dispatch,
+        // so the order is what keeps Compose on the scaled metrics. Idempotent; no-op at native scale.
+        DensityScaler.reapply(this)
+        super.onConfigurationChanged(newConfig)
     }
 
     override fun onStop() {

--- a/app/src/test/kotlin/com/dpi/DensityMathTest.kt
+++ b/app/src/test/kotlin/com/dpi/DensityMathTest.kt
@@ -5,44 +5,65 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * Pins the density re-application decision (issue #521): it must be IDEMPOTENT (the framework wipes
- * the `updateConfiguration` override on every system config delivery, so re-application fires from
- * several hooks and must never compound), and it must treat any non-applied incoming dpi as the
- * CURRENT native base so a real system density change (Display size) rescales from the new value.
+ * Pins the STATELESS density re-application decision (issue #521): the framework wipes the
+ * `updateConfiguration` override on every system config delivery, so re-application fires from
+ * several hooks and must be idempotent — with no memory to corrupt, the target derives only from
+ * the CURRENT system-native dpi, so a genuine density change (Display size) rescales by
+ * construction, even to a value that equals a previously applied one.
  */
 class DensityMathTest {
 
     @Test
     fun `scales from the native dpi`() {
-        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = null, scale = 0.75f))
+        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, nativeDpi = 480, scale = 0.75f))
     }
 
     @Test
-    fun `already-applied dpi is a no-op - re-application never compounds the scale`() {
-        assertNull(DensityMath.targetDpi(currentDpi = 360, lastAppliedDpi = 360, scale = 0.75f))
+    fun `already at the target is a no-op - re-application never compounds the scale`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 360, nativeDpi = 480, scale = 0.75f))
     }
 
     @Test
     fun `a framework wipe back to native rescales`() {
-        // Applied 480 -> 360, then a config delivery reset the dpi to 480: scale again.
-        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = 360, scale = 0.75f))
+        // Applied 480 -> 360, then a config delivery reset the Resources to 480: scale again.
+        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, nativeDpi = 480, scale = 0.75f))
     }
 
     @Test
-    fun `a genuine system density change rescales from the NEW base, not the startup one`() {
-        // User changed Display size 480 -> 420 while our 360 was applied: 420 is the new native.
-        assertEquals(315, DensityMath.targetDpi(currentDpi = 420, lastAppliedDpi = 360, scale = 0.75f))
+    fun `a genuine system density change rescales from the NEW native base`() {
+        // User changed Display size 480 -> 420; the Resources still holds our old 360.
+        assertEquals(315, DensityMath.targetDpi(currentDpi = 360, nativeDpi = 420, scale = 0.75f))
     }
 
     @Test
-    fun `a scale that rounds to the incoming dpi is a no-op`() {
-        assertNull(DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = null, scale = 1.001f))
+    fun `a system density change landing exactly on the previously applied value still rescales`() {
+        // Native went 480 -> 360 (= the old applied value): the stateless target is 270, and the
+        // Resources at 360 is no longer "already correct" - the case one-field memory could not
+        // distinguish.
+        assertEquals(270, DensityMath.targetDpi(currentDpi = 360, nativeDpi = 360, scale = 0.75f))
+    }
+
+    @Test
+    fun `native scale is always a no-op once the Resources sits at native`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 480, nativeDpi = 480, scale = 1.0f))
+    }
+
+    @Test
+    fun `native scale restores a Resources stuck off-native`() {
+        // Scale switched back to 1.0 but a stale scaled config survived in some Resources: heal it.
+        assertEquals(480, DensityMath.targetDpi(currentDpi = 360, nativeDpi = 480, scale = 1.0f))
+    }
+
+    @Test
+    fun `a scale that rounds to the current dpi is a no-op`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 480, nativeDpi = 480, scale = 1.001f))
     }
 
     @Test
     fun `nonsense dpi values never produce a write`() {
-        assertNull(DensityMath.targetDpi(currentDpi = 0, lastAppliedDpi = null, scale = 0.75f))
-        assertNull(DensityMath.targetDpi(currentDpi = -160, lastAppliedDpi = null, scale = 0.75f))
-        assertNull(DensityMath.targetDpi(currentDpi = 1, lastAppliedDpi = null, scale = 0.1f))
+        assertNull(DensityMath.targetDpi(currentDpi = 0, nativeDpi = 480, scale = 0.75f))
+        assertNull(DensityMath.targetDpi(currentDpi = 480, nativeDpi = 0, scale = 0.75f))
+        assertNull(DensityMath.targetDpi(currentDpi = 480, nativeDpi = -160, scale = 0.75f))
+        assertNull(DensityMath.targetDpi(currentDpi = 1, nativeDpi = 1, scale = 0.1f))
     }
 }

--- a/app/src/test/kotlin/com/dpi/DensityMathTest.kt
+++ b/app/src/test/kotlin/com/dpi/DensityMathTest.kt
@@ -1,0 +1,48 @@
+package com.dpi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the density re-application decision (issue #521): it must be IDEMPOTENT (the framework wipes
+ * the `updateConfiguration` override on every system config delivery, so re-application fires from
+ * several hooks and must never compound), and it must treat any non-applied incoming dpi as the
+ * CURRENT native base so a real system density change (Display size) rescales from the new value.
+ */
+class DensityMathTest {
+
+    @Test
+    fun `scales from the native dpi`() {
+        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = null, scale = 0.75f))
+    }
+
+    @Test
+    fun `already-applied dpi is a no-op - re-application never compounds the scale`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 360, lastAppliedDpi = 360, scale = 0.75f))
+    }
+
+    @Test
+    fun `a framework wipe back to native rescales`() {
+        // Applied 480 -> 360, then a config delivery reset the dpi to 480: scale again.
+        assertEquals(360, DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = 360, scale = 0.75f))
+    }
+
+    @Test
+    fun `a genuine system density change rescales from the NEW base, not the startup one`() {
+        // User changed Display size 480 -> 420 while our 360 was applied: 420 is the new native.
+        assertEquals(315, DensityMath.targetDpi(currentDpi = 420, lastAppliedDpi = 360, scale = 0.75f))
+    }
+
+    @Test
+    fun `a scale that rounds to the incoming dpi is a no-op`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 480, lastAppliedDpi = null, scale = 1.001f))
+    }
+
+    @Test
+    fun `nonsense dpi values never produce a write`() {
+        assertNull(DensityMath.targetDpi(currentDpi = 0, lastAppliedDpi = null, scale = 0.75f))
+        assertNull(DensityMath.targetDpi(currentDpi = -160, lastAppliedDpi = null, scale = 0.75f))
+        assertNull(DensityMath.targetDpi(currentDpi = 1, lastAppliedDpi = null, scale = 0.1f))
+    }
+}

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -6,11 +6,11 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
-| `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 116 | `com.dpi` | no | 9 | 27 | android.annotation, android.app, android.os, java.util, timber.log |
+| `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 127 | `com.dpi` | no | 9 | 28 | android.annotation, android.app, android.os, java.util, timber.log |
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
-| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 111 | `com.dpi` | no | 8 | 14 | android.annotation, android.app, android.content, android.util, timber.log |
-| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 26 | `com.dpi` | no | 1 | 3 | kotlin.math |
-| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 62 | `com.dpi` | no | 2 | 12 | android.content, timber.log |
+| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 121 | `com.dpi` | no | 7 | 14 | android.annotation, android.app, android.content, android.util, timber.log |
+| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 | `com.dpi` | no | 1 | 3 | kotlin.math |
+| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 | `com.dpi` | no | 4 | 13 | android.app, android.content, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 492 | `com.jtech.zemer` | no | 69 | 48 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 | `com.jtech.zemer` | no | 312 | 243 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
@@ -558,7 +558,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 | `com.jtech.zemer.viewmodels` | no | 18 | 6 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
-| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 48 | `com.dpi` | no | 3 | 1 | org.junit |
+| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 69 | `com.dpi` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 | `com.jtech.zemer.constants` | no | 4 | 3 | androidx.datastore, java.lang, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/ContextExtLogicTest.kt` | 27 | `com.jtech.zemer.extensions` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/PlayerIconResTest.kt` | 42 | `com.jtech.zemer.extensions` | no | 4 | 2 | androidx.media3, org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,16 +2,17 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` - a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline - they are not duplicated here.
 
-## `app` Kotlin files (683)
+## `app` Kotlin files (685)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
 | `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 116 | `com.dpi` | no | 9 | 27 | android.annotation, android.app, android.os, java.util, timber.log |
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 | `com.dpi` | no | 4 | 7 | android.content, android.database, android.net |
-| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 | `com.dpi` | no | 8 | 13 | android.annotation, android.app, android.content, android.util, kotlin.math, timber.log |
-| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 | `com.dpi` | no | 2 | 9 | android.content, timber.log |
+| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 111 | `com.dpi` | no | 8 | 14 | android.annotation, android.app, android.content, android.util, timber.log |
+| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 26 | `com.dpi` | no | 1 | 3 | kotlin.math |
+| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 62 | `com.dpi` | no | 2 | 12 | android.content, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 492 | `com.jtech.zemer` | no | 69 | 48 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, io.ktor, java.util, javax.inject, kotlinx.coroutines, kotlinx.serialization, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2421 | `com.jtech.zemer` | no | 310 | 242 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 | `com.jtech.zemer` | no | 312 | 243 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 | `com.jtech.zemer.auth` | no | 0 | 13 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 | `com.jtech.zemer.auth` | no | 13 | 21 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -557,6 +558,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 | `com.jtech.zemer.viewmodels` | no | 18 | 6 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
+| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 48 | `com.dpi` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 | `com.jtech.zemer.constants` | no | 4 | 3 | androidx.datastore, java.lang, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/ContextExtLogicTest.kt` | 27 | `com.jtech.zemer.extensions` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/PlayerIconResTest.kt` | 42 | `com.jtech.zemer.extensions` | no | 4 | 2 | androidx.media3, org.junit |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1215`
+- Files counted: `1217`
 - By extension:
-  - `.kt`: `773`
+  - `.kt`: `775`
   - `.xml`: `192`
   - `.mjs`: `77`
   - `.md`: `71`
@@ -170,10 +170,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/jniLibs/armeabi-v7a/libcoverart.so` | 406200 bytes | `.so` |
 | `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 116 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
-| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 87 lines | `.kt` |
-| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 46 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 111 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 26 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 62 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 492 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2421 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 lines | `.kt` |
@@ -927,6 +928,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/xml/data_extraction_rules.xml` | 29 lines | `.xml` |
 | `app/src/main/res/xml/music_widget_info.xml` | 18 lines | `.xml` |
 | `app/src/main/res/xml/provider_paths.xml` | 12 lines | `.xml` |
+| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 48 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/ContextExtLogicTest.kt` | 27 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/PlayerIconResTest.kt` | 42 lines | `.kt` |
@@ -1105,7 +1107,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 796 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 798 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 385 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -1116,7 +1118,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1326 lines | `.md` |
+| `docs/repository-map.md` | 1328 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |
 | `docs/status/jewishstatus-api.md` | 162 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -168,11 +168,11 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/ic_launcher-playstore.png` | 23742 bytes | `.png` |
 | `app/src/main/jniLibs/arm64-v8a/libcoverart.so` | 644248 bytes | `.so` |
 | `app/src/main/jniLibs/armeabi-v7a/libcoverart.so` | 406200 bytes | `.so` |
-| `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 116 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/ActivityLifecycleManager.kt` | 127 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/BaseLifecycleContentProvider.kt` | 36 lines | `.kt` |
-| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 111 lines | `.kt` |
-| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 26 lines | `.kt` |
-| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 62 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 121 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 lines | `.kt` |
+| `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 492 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
@@ -928,7 +928,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/xml/data_extraction_rules.xml` | 29 lines | `.xml` |
 | `app/src/main/res/xml/music_widget_info.xml` | 18 lines | `.xml` |
 | `app/src/main/res/xml/provider_paths.xml` | 12 lines | `.xml` |
-| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 48 lines | `.kt` |
+| `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 69 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/ContextExtLogicTest.kt` | 27 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/extensions/PlayerIconResTest.kt` | 42 lines | `.kt` |


### PR DESCRIPTION
## Summary

Fixes #521: entering the fullscreen video player (or any rotation) reverted the custom density until an app restart.

## Root cause (two halves)

The custom density rides the deprecated `Resources.updateConfiguration`, which the framework silently wipes on every system configuration delivery. The fullscreen player forces landscape, and MainActivity handles `configChanges` - no recreate, so no lifecycle event fired to re-apply. And the heal path was itself broken: `applyDensityToActivity` mutated the activity's live `Configuration` in place, so `updateConfiguration` diffed the incoming object against itself, saw no change, and silently skipped the metrics update - which is why even background/return didn't recover and only a process restart (which uses a copy) did.

## The fix - stateless, event-driven re-application

- **`DensityMath.targetDpi` is STATELESS** (pure, unit-tested): the target is always the CURRENT system-native dpi (`Resources.getSystem()`, which the framework owns and keeps updated) times the scale, applied only when the Resources isn't already there. No last-applied memory means nothing to corrupt across Resources objects, re-application can never compound, and a genuine Display-size change rescales by construction - even to a value equal to a previously applied one.
- **Always a Configuration COPY** - never mutate the live object (the self-diff no-op above).
- **The hook lives where the framework already calls**: `DensityScaler` is a manifest-installed ContentProvider, so its own `onConfigurationChanged` fires right after the framework resets the app Resources; it re-applies to the app resources AND sweeps every active activity, covering any future `configChanges`-handling activity generically. `MainActivity.onConfigurationChanged` additionally reapplies BEFORE dispatching to super, so the view tree deterministically re-reads the scaled metrics during that dispatch. No polling, no timers, no hand-registered callback objects.
- One no-op gate (the pure decision), not three; the accepted secondary-display limitation is documented (wrong-but-stable, never compounding).

## Testing

- `DensityMathTest` (9): scale-from-native, idempotency, rescale-after-wipe, rescale-from-a-NEW-native-base (including one landing exactly on the previously applied value), native-scale no-op + heal, round-to-same no-op, nonsense-dpi guards.
- Full unit suite, `ui-audit.sh`, `:app:assembleDebug`, and the R8 release gate green.
- The `Configuration`/`Resources` plumbing has no JVM seam (no Robolectric in this repo); verified on-device: custom density held across fullscreen video enter/exit, rotation, and background/return.
