### PR TITLE
Lyrics: audio-verified LRCLIB source in the Zemer provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -584,7 +584,9 @@ The rules that must not regress:
 
 `lyrics/LyricsHelper.kt` runs the providers in order: **Zemer resolver first** (`lyrics/zemer/`; the search
 server's `/lyrics/resolve` returns source POINTERS, the app fetches Jyrics/Shironet/jkaraoke itself through
-golden-pinned parser ports of the server's parsers — `JyricsParser`, `ShironetParser`, `JkaraokeLrc`), then
+golden-pinned parser ports of the server's parsers — `JyricsParser`, `ShironetParser`, `JkaraokeLrc` — and an
+audio-verified LRCLIB record by id, `ZemerLyricsClient.lrclibBody`, which the server hands out only for rows its
+audio check confirmed; ranked with the plain sources, below jkaraoke), then
 SimpMusic (videoId-keyed; synced bodies only within 1 s), LrcLib (identity-gated: title AND artist must agree; a
 duration-only match once served a Japanese song), **Musixmatch on-device** (`lyrics/musixmatch/MusixmatchLyrics.kt`:
 the catalog behind Spotify's lyrics, reached with one desktop-API token per phone — the server stores none of its

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import com.jtech.zemer.lyrics.LyricsUtils
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
@@ -45,6 +46,15 @@ object ZemerLyricsClient {
     data class Resolved(val videoId: String, val lang: String? = null, val verified: Boolean = false, val hasSynced: Boolean = false, val sources: List<Source> = emptyList())
 
     internal val json = Json { ignoreUnknownKeys = true; isLenient = true; explicitNulls = false }
+
+    /** One LRCLIB record (`https://lrclib.net/api/get/<id>`); the server hands out the id of a duration-matched row. */
+    @Serializable
+    data class LrcLibTrack(val id: Long = 0, val syncedLyrics: String? = null, val plainLyrics: String? = null, val instrumental: Boolean = false)
+
+    /** LRC when LRCLIB has line times, else the plain text; null for an instrumental or an empty record. */
+    fun lrclibBody(body: String): String? = runCatching { json.decodeFromString<LrcLibTrack>(body) }.getOrNull()
+        ?.takeUnless { it.instrumental }
+        ?.let { t -> t.syncedLyrics?.takeIf { it.isNotBlank() } ?: t.plainLyrics?.takeIf(LyricsUtils::hasLyricBody) }
 
     private val client by lazy {
         HttpClient(CIO) {

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
@@ -38,6 +38,7 @@ object ZemerLyricsProvider : LyricsProvider {
                 "jyrics" -> s.url?.let { fetch(it) }?.let { JyricsParser.parse(it).plain.takeIf(LyricsUtils::hasLyricBody) }
                 "shironet" -> s.url?.let { fetch(it) }?.let { ShironetParser.parse(it).plain.takeIf(LyricsUtils::hasLyricBody) }
                 "zingmusic" -> s.trackId?.let { zing(it) }?.let { ZingParser.toPlain(it).takeIf(LyricsUtils::hasLyricBody) }
+                "lrclib" -> s.trackId?.let { fetch("https://lrclib.net/api/get/$it") }?.let { ZemerLyricsClient.lrclibBody(it) }
                 "booklet", "manual", "canonical" -> s.syncedLrc?.takeIf { it.isNotBlank() } ?: s.plain?.takeIf { it.isNotBlank() }
                 else -> null
             }
@@ -46,7 +47,7 @@ object ZemerLyricsProvider : LyricsProvider {
         return out
     }
 
-    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
+    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "lrclib" -> 1; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
 
     /** "Zemer · jkaraoke": the sub-source matters for provenance. Verification is a server fact, not shown in the label. */
     fun label(source: String, @Suppress("UNUSED_PARAMETER") verified: Boolean): String = "$name · $source"

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt
@@ -50,6 +50,19 @@ class ZemerLyricsProviderTest {
     }
 
     @Test
+    fun `lrclib source fetches the record by id and prefers its LRC while instrumental and thin records yield nothing`() = runBlocking {
+        val resolved = ZemerLyricsClient.Resolved(videoId = "lr1", hasSynced = true, sources = listOf(ZemerLyricsClient.Source(type = "lrclib", trackId = 1234, synced = true)))
+        val synced = ZemerLyricsProvider.bodies(resolved, fetch = { url -> if (url == "https://lrclib.net/api/get/1234") """{"id":1234,"trackName":"Miracle","plainLyrics":"a\nb\nc\nd","syncedLyrics":"[00:01.00] a\n[00:02.00] b","instrumental":false}""" else null })
+        assertEquals(listOf("lrclib"), synced.map { it.first })
+        assertTrue(synced[0].second.startsWith("[00:01.00]"))
+        val plainOnly = ZemerLyricsProvider.bodies(resolved, fetch = { """{"id":1234,"plainLyrics":"a\nb\nc\nd","syncedLyrics":null}""" })
+        assertEquals("a\nb\nc\nd", plainOnly[0].second)
+        assertTrue(ZemerLyricsProvider.bodies(resolved, fetch = { """{"id":1234,"instrumental":true,"plainLyrics":"a\nb\nc\nd"}""" }).isEmpty())
+        assertTrue(ZemerLyricsProvider.bodies(resolved, fetch = { """{"id":1234,"plainLyrics":"too\nshort"}""" }).isEmpty())
+        assertTrue(ZemerLyricsProvider.bodies(resolved, fetch = { "not json" }).isEmpty())
+    }
+
+    @Test
     fun `label is one string for both the auto-fetch and picker paths`() {
         assertEquals("Zemer · jkaraoke", ZemerLyricsProvider.label("jkaraoke", verified = true))
         assertEquals("Zemer · jyrics", ZemerLyricsProvider.label("jyrics", verified = false))

--- a/docs/lyrics/README.md
+++ b/docs/lyrics/README.md
@@ -20,7 +20,9 @@ providers by `MediaMetadata.id` (never `setVideoId`, which is a playlist-entry t
   (BuildConfig; gradle `-PzemerLyricsBaseUrl=`; default `https://search.zemer.io`). The server returns SOURCE
   POINTERS, not third-party text; the app fetches each source itself: jkaraoke feed page → `JkaraokeLrc`
   (line-synced LRC, measured times), Jyrics page → `JyricsParser` (plain), Shironet page → `ShironetParser`
-  (plain), Zing track → `ZingParser` (plain), booklet/manual/canonical text inline. The page parsers are
+  (plain), Zing track → `ZingParser` (plain), LRCLIB record by id → `ZemerLyricsClient.lrclibBody` (the server
+  hands out `lrclib:<id>` only for rows its audio check confirmed; LRC preferred, plain as fallback, instrumental
+  or thin records yield nothing; `ZemerLyricsProviderTest`), booklet/manual/canonical text inline. The page parsers are
   byte-identical ports of the server's, pinned by golden files under `app/src/test/resources/lyrics/`
   (`JyricsParserGoldenTest`, `ShironetParserGoldenTest`, `ZingParserGoldenTest`, `JkaraokeLrcGoldenTest`,
   `SyncIntegrationTest`); they share `HtmlEntities.unescape` and the `LyricsUtils.hasLyricBody` body gate (four

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -105,8 +105,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/JyricsParser.kt` | 47 | `com.jtech.zemer.lyrics.zemer` | no | 0 | 23 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/LyricsFeedback.kt` | 36 | `com.jtech.zemer.lyrics.zemer` | no | 5 | 11 | kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ShironetParser.kt` | 39 | `com.jtech.zemer.lyrics.zemer` | no | 0 | 20 |  |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt` | 112 | `com.jtech.zemer.lyrics.zemer` | no | 19 | 39 | io.ktor, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt` | 71 | `com.jtech.zemer.lyrics.zemer` | no | 5 | 15 |  |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt` | 122 | `com.jtech.zemer.lyrics.zemer` | no | 20 | 45 | io.ktor, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt` | 72 | `com.jtech.zemer.lyrics.zemer` | no | 5 | 15 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZingParser.kt` | 33 | `com.jtech.zemer.lyrics.zemer` | no | 0 | 12 |  |
 | `app/src/main/kotlin/com/jtech/zemer/models/DpadDirection.kt` | 27 | `com.jtech.zemer.models` | no | 9 | 5 | android.view, androidx.annotation, androidx.datastore |
 | `app/src/main/kotlin/com/jtech/zemer/models/ItemsPage.kt` | 8 | `com.jtech.zemer.models` | no | 1 | 3 |  |
@@ -616,7 +616,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ShironetParserGoldenTest.kt` | 35 | `com.jtech.zemer.lyrics.zemer` | no | 6 | 6 | kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/SyncIntegrationTest.kt` | 38 | `com.jtech.zemer.lyrics.zemer` | no | 7 | 7 | kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClientParseTest.kt` | 43 | `com.jtech.zemer.lyrics.zemer` | no | 6 | 6 | kotlinx.serialization, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt` | 57 | `com.jtech.zemer.lyrics.zemer` | no | 4 | 11 | kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt` | 70 | `com.jtech.zemer.lyrics.zemer` | no | 4 | 14 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZingParserGoldenTest.kt` | 28 | `com.jtech.zemer.lyrics.zemer` | no | 6 | 3 | kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/models/MediaMetadataNavResolutionTest.kt` | 82 | `com.jtech.zemer.models` | no | 7 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/models/PersistPlayerStateCompatTest.kt` | 87 | `com.jtech.zemer.models` | no | 7 | 6 | java.io, org.junit |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -268,8 +268,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/JyricsParser.kt` | 47 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/LyricsFeedback.kt` | 36 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ShironetParser.kt` | 39 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt` | 112 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt` | 71 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt` | 122 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZingParser.kt` | 33 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/DpadDirection.kt` | 27 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/models/ItemsPage.kt` | 8 lines | `.kt` |
@@ -987,7 +987,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ShironetParserGoldenTest.kt` | 35 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/SyncIntegrationTest.kt` | 38 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClientParseTest.kt` | 43 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt` | 57 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt` | 70 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZingParserGoldenTest.kt` | 28 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/models/MediaMetadataNavResolutionTest.kt` | 82 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/models/PersistPlayerStateCompatTest.kt` | 87 lines | `.kt` |


### PR DESCRIPTION
The server now runs an LRCLIB pass over uncovered tracks (strict artist + title + duration lookup only). Because LRCLIB is user-uploaded, no hit enters the store on the match alone: each is checked against the recording by the audio verifier and adopted only when the transcript agrees (first dry run: "Freeze Dance" adopted at 1.00 overlap, a wrong text under an instrumental rejected at 0.00). Confirmed rows carry the pointer `lrclib:<id>`.

App side, this PR teaches the Zemer provider that pointer:
- `ZemerLyricsClient.lrclibBody` parses one LRCLIB record, preferring its LRC over the plain text and dropping instrumentals and thin records.
- `ZemerLyricsProvider` fetches `https://lrclib.net/api/get/<id>` for a `lrclib` source; ranked with the other curated text sources, after jkaraoke.
- Unit test covers synced, plain-only, instrumental, thin and non-JSON records.

Local CI: unit tests (app, innertube, simpmusic, cipher), UI audit, download unification, dead resources, docs regenerated.