### PR TITLE
feat: fetch KuGou lyrics via server-verified pointers

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/KugouLrc.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/KugouLrc.kt
@@ -1,0 +1,38 @@
+package com.jtech.zemer.lyrics.zemer
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.util.Base64
+
+/**
+ * Port of zemer-search `harvester/kugou-harvest.mjs`'s download path. The server verified WHICH KuGou
+ * lyric matches this recording (audio check) and serves a `kugou:<hash>:<krcId>` pointer; the app re-runs
+ * the krcs search by hash (the accesskey rotates, so it is never in the pointer), takes the candidate with
+ * that exact id — never another candidate's — and decodes the base64 `fmt=lrc` body.
+ */
+object KugouLrc {
+    @Serializable data class Candidate(val id: Long = 0, val accesskey: String? = null)
+    @Serializable data class Krcs(val candidates: List<Candidate> = emptyList())
+    @Serializable data class Download(val content: String? = null)
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; explicitNulls = false }
+    private val TIMED = Regex("""^\[\d{2}:\d{2}(?:\.\d{2,3})?\].*\S""")
+
+    fun searchUrl(hash: String) = "https://krcs.kugou.com/search?ver=1&man=yes&client=mobi&keyword=&hash=$hash"
+
+    fun downloadUrl(id: Long, accessKey: String) =
+        "https://lyrics.kugou.com/download?ver=1&client=pc&id=$id&accesskey=$accessKey&fmt=lrc&charset=utf8"
+
+    /** The accesskey of the server-vetted candidate id in a krcs search body. */
+    fun accessKey(krcsJson: String, krcId: Long): String? =
+        runCatching { json.decodeFromString(Krcs.serializer(), krcsJson) }.getOrNull()
+            ?.candidates?.firstOrNull { it.id == krcId }?.accesskey?.takeIf { it.isNotBlank() }
+
+    /** Line-synced LRC from a download body: timed lines only (metadata/credit tags dropped), >= 4 or null. */
+    fun lrc(downloadJson: String): String? {
+        val content = runCatching { json.decodeFromString(Download.serializer(), downloadJson) }.getOrNull()?.content ?: return null
+        val text = runCatching { Base64.getDecoder().decode(content).decodeToString() }.getOrNull() ?: return null
+        val lines = text.lines().map { it.trim() }.filter { TIMED.matches(it) }
+        return if (lines.size >= 4) lines.joinToString("\n") else null
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsClient.kt
@@ -37,6 +37,8 @@ object ZemerLyricsClient {
         val feedUrl: String? = null,
         val browseId: String? = null,     // youtube lyrics tab
         val trackId: Long? = null,        // zingmusic (server-vetted track id) / musixmatch
+        val hash: String? = null,         // kugou (audio hash; the app re-runs the krcs search with it)
+        val krcId: Long? = null,          // kugou (server-vetted krcs candidate id)
         val plain: String? = null,        // operator-hosted text (booklet/manual)
         val syncedLrc: String? = null,
         val synced: Boolean = false,

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
@@ -39,6 +39,7 @@ object ZemerLyricsProvider : LyricsProvider {
                 "shironet" -> s.url?.let { fetch(it) }?.let { ShironetParser.parse(it).plain.takeIf(LyricsUtils::hasLyricBody) }
                 "zingmusic" -> s.trackId?.let { zing(it) }?.let { ZingParser.toPlain(it).takeIf(LyricsUtils::hasLyricBody) }
                 "lrclib" -> s.trackId?.let { fetch("https://lrclib.net/api/get/$it") }?.let { ZemerLyricsClient.lrclibBody(it) }
+                "kugou" -> s.hash?.let { h -> s.krcId?.let { id -> fetch(KugouLrc.searchUrl(h))?.let { KugouLrc.accessKey(it, id) }?.let { key -> fetch(KugouLrc.downloadUrl(id, key))?.let { KugouLrc.lrc(it) } } } }
                 "booklet", "manual", "canonical" -> s.syncedLrc?.takeIf { it.isNotBlank() } ?: s.plain?.takeIf { it.isNotBlank() }
                 else -> null
             }
@@ -47,7 +48,7 @@ object ZemerLyricsProvider : LyricsProvider {
         return out
     }
 
-    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "lrclib" -> 1; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
+    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "lrclib" -> 1; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "kugou" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
 
     /** "Zemer · jkaraoke": the sub-source matters for provenance. Verification is a server fact, not shown in the label. */
     fun label(source: String, @Suppress("UNUSED_PARAMETER") verified: Boolean): String = "$name · $source"

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProviderTest.kt
@@ -63,6 +63,28 @@ class ZemerLyricsProviderTest {
     }
 
     @Test
+    fun `kugou source re-runs the krcs search by hash, takes only the vetted id, and decodes the LRC`() = runBlocking {
+        val lrcB64 = java.util.Base64.getEncoder().encodeToString("[ti:x]\n[00:01.00]one\n[00:02.00]two\n[00:03.00]three\n[00:04.00]four".toByteArray())
+        val hash = "959d52326c6c8b2919e80f8a40db48fc"
+        val resolved = ZemerLyricsClient.Resolved(videoId = "kg1", hasSynced = true, sources = listOf(ZemerLyricsClient.Source(type = "kugou", hash = hash, krcId = 439665416, synced = true)))
+        val fetch: suspend (String) -> String? = { url ->
+            when {
+                url == KugouLrc.searchUrl(hash) -> """{"candidates":[{"id":1,"accesskey":"OTHER"},{"id":439665416,"accesskey":"KEY"}]}"""
+                url == KugouLrc.downloadUrl(439665416, "KEY") -> """{"content":"$lrcB64"}"""
+                else -> null
+            }
+        }
+        val bodies = ZemerLyricsProvider.bodies(resolved, fetch)
+        assertEquals(listOf("kugou"), bodies.map { it.first })
+        assertEquals("[00:01.00]one", bodies[0].second.lines().first())      // metadata tag dropped, timed lines kept
+        // the vetted id missing from the candidates = no body (never another candidate's accesskey)
+        assertTrue(ZemerLyricsProvider.bodies(resolved, fetch = { url -> if (url == KugouLrc.searchUrl(hash)) """{"candidates":[{"id":1,"accesskey":"OTHER"}]}""" else null }).isEmpty())
+        // fewer than 4 timed lines = no body
+        val thinB64 = java.util.Base64.getEncoder().encodeToString("[00:01.00]one\n[00:02.00]two".toByteArray())
+        assertTrue(ZemerLyricsProvider.bodies(resolved, fetch = { url -> if (url == KugouLrc.searchUrl(hash)) """{"candidates":[{"id":439665416,"accesskey":"KEY"}]}""" else """{"content":"$thinB64"}""" }).isEmpty())
+    }
+
+    @Test
     fun `label is one string for both the auto-fetch and picker paths`() {
         assertEquals("Zemer · jkaraoke", ZemerLyricsProvider.label("jkaraoke", verified = true))
         assertEquals("Zemer · jyrics", ZemerLyricsProvider.label("jyrics", verified = false))


### PR DESCRIPTION
The Zemer lyrics server now audio-verifies KuGou lyric candidates against the actual recording and serves a `kugou:<hash>:<krcId>` pointer from `/lyrics/resolve` (never third-party text). This adds the app side of that walk:

- `KugouLrc.kt`: re-runs the krcs search by hash (the accesskey rotates, so it is never in the pointer), takes ONLY the server-vetted candidate id - never another candidate's accesskey - and decodes the base64 `fmt=lrc` body, keeping timed lines only (>= 4 or nothing).
- `ZemerLyricsClient.Source` gains `hash`/`krcId`; `ZemerLyricsProvider` walks `kugou` at the same rank as lrclib/jyrics/shironet/zingmusic.
- Unit test covers the full walk: search-by-hash, vetted-id-only selection, LRC decode, and the two refusal paths (vetted id missing from candidates, fewer than 4 timed lines).

Verified live end to end: the deployed resolver serves the pointer for an adopted track and the exact walk returns 54 correctly-timed LRC lines from KuGou.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving lyrics from KuGou.
  * KuGou lyric results are matched against verified track information before being displayed.
  * Downloaded lyric content is decoded and converted into timed lyric lines.

* **Bug Fixes**
  * Improved lyric quality by rejecting incomplete or invalid KuGou lyric results.
  * KuGou sources are now included alongside other secondary lyric providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->