### PR TITLE
feat(lyrics): new source in the Zemer provider chain

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/LyricsTranslateParser.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/LyricsTranslateParser.kt
@@ -1,0 +1,36 @@
+package com.jtech.zemer.lyrics.zemer
+
+/**
+ * Port of zemer-search `harvester/lyricstranslate-harvest.mjs#songBody` (lyricstranslate.com). The song page
+ * carries the ORIGINAL-language text in `<div class="translate__text ..." lang="xx" id="song-body">`
+ * (translations live on separate pages and are never fetched); the body nests further divs, so the extent is
+ * found by depth-aware div scanning, not a lazy match. A Cloudflare challenge page has no `#song-body`
+ * and parses to null, which the provider chain treats like any dead source (next provider).
+ */
+object LyricsTranslateParser {
+    private val OPEN = Regex("""<div class="translate__text[^"]*"[^>]*lang="[^"]*"[^>]*id="song-body">""")
+    private val OPEN_ANY = Regex("""<div[^>]*id="song-body"[^>]*>""")
+    private val DIV = Regex("""<div[\s>]|</div>""")
+    private val BR = Regex("""<br[^>]*/?>""", RegexOption.IGNORE_CASE)
+    private val BLOCK_CLOSE = Regex("""</(?:p|div)>""", RegexOption.IGNORE_CASE)
+    private val TAG = Regex("""<[^>]+>""")
+    private val TRAIL = Regex("""[ \t]+\n""")
+    private val LEAD = Regex("""\n[ \t]+""")
+    private val BLANKS = Regex("""\n{3,}""")
+
+    fun parse(html: String): String? {
+        val open = OPEN.find(html) ?: OPEN_ANY.find(html) ?: return null
+        val start = open.range.last + 1
+        var depth = 1
+        var body: String? = null
+        var m = DIV.find(html, start)
+        while (m != null) {
+            if (m.value == "</div>") { depth--; if (depth == 0) { body = html.substring(start, m.range.first); break } }
+            else depth++
+            m = m.next()
+        }
+        val text = HtmlEntities.unescape((body ?: return null).replace(BR, "\n").replace(BLOCK_CLOSE, "\n").replace(TAG, ""))
+            .replace(TRAIL, "\n").replace(LEAD, "\n").replace(BLANKS, "\n\n").trim()
+        return text.ifEmpty { null }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/zemer/ZemerLyricsProvider.kt
@@ -9,8 +9,8 @@ import com.jtech.zemer.lyrics.model.LyricsUnavailableException
 /**
  * First provider in the chain. Resolves the videoId through the Zemer server, then fetches the text from
  * the sources the server vouches for — in this preference order:
- *   jkaraoke (line-synced LRC, timings gated by duration on the server) > jyrics / shironet (curated plain) >
- *   operator-hosted booklet/manual text.
+ *   jkaraoke (line-synced LRC, timings gated by duration on the server) > jyrics / shironet /
+ *   lyricstranslate (audio-verified plain) > operator-hosted booklet/manual text.
  * Every body goes through the same parser the server used to verify it (golden-pinned ports), so what the
  * user sees is exactly what was cross-checked.
  */
@@ -37,6 +37,10 @@ object ZemerLyricsProvider : LyricsProvider {
                 "jkaraoke" -> s.feedUrl?.let { fetch(it) }?.let { page -> s.songId?.let { id -> JkaraokeLrc.fromFeedPage(page, id)?.synced } }
                 "jyrics" -> s.url?.let { fetch(it) }?.let { JyricsParser.parse(it).plain.takeIf(LyricsUtils::hasLyricBody) }
                 "shironet" -> s.url?.let { fetch(it) }?.let { ShironetParser.parse(it).plain.takeIf(LyricsUtils::hasLyricBody) }
+                // Server-inlined (the site's Cloudflare challenge blocks on-device fetches); the page fetch is
+                // a fallback in case an older server serves the pointer form without text.
+                "lyricstranslate" -> s.plain?.takeIf(LyricsUtils::hasLyricBody)
+                    ?: s.url?.let { fetch(it) }?.let { LyricsTranslateParser.parse(it)?.takeIf(LyricsUtils::hasLyricBody) }
                 "zingmusic" -> s.trackId?.let { zing(it) }?.let { ZingParser.toPlain(it).takeIf(LyricsUtils::hasLyricBody) }
                 "lrclib" -> s.trackId?.let { fetch("https://lrclib.net/api/get/$it") }?.let { ZemerLyricsClient.lrclibBody(it) }
                 "kugou" -> s.hash?.let { h -> s.krcId?.let { id -> fetch(KugouLrc.searchUrl(h))?.let { KugouLrc.accessKey(it, id) }?.let { key -> fetch(KugouLrc.downloadUrl(id, key))?.let { KugouLrc.lrc(it) } } } }
@@ -48,7 +52,7 @@ object ZemerLyricsProvider : LyricsProvider {
         return out
     }
 
-    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "lrclib" -> 1; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "kugou" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
+    private fun rank(s: ZemerLyricsClient.Source) = when (s.type) { "jkaraoke" -> 0; "lrclib" -> 1; "jyrics" -> 1; "shironet" -> 1; "zingmusic" -> 1; "kugou" -> 1; "lyricstranslate" -> 1; "booklet" -> 2; "manual" -> 2; "canonical" -> 3; else -> 9 }
 
     /** "Zemer · jkaraoke": the sub-source matters for provenance. Verification is a server fact, not shown in the label. */
     fun label(source: String, @Suppress("UNUSED_PARAMETER") verified: Boolean): String = "$name · $source"

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/LyricsTranslateParserTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/zemer/LyricsTranslateParserTest.kt
@@ -1,0 +1,61 @@
+package com.jtech.zemer.lyrics.zemer
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsTranslateParserTest {
+    private val page = """
+        <html><head><title>Yaakov Shwekey - רחם (Rachem) lyrics</title></head><body>
+        <div class="song-node-info">ignored</div>
+        <div class="translate__text ltf-hide-original" lang="he" id="song-body">
+          <div class="par">
+            <div>רחם בחסדך<br>על עמך צורנו</div>
+          </div>
+          <div class="par">
+            <div>על ציון משכן כבודך<br>זבול בית תפארתנו</div>
+          </div>
+        </div>
+        <div class="translate__bottom">also ignored</div>
+        </body></html>
+    """.trimIndent()
+
+    @Test
+    fun `extracts the original-language body from nested divs, breaks on br, and ignores siblings`() {
+        val text = LyricsTranslateParser.parse(page)!!
+        val lines = text.lines().filter { it.isNotEmpty() }
+        assertEquals(listOf("רחם בחסדך", "על עמך צורנו", "על ציון משכן כבודך", "זבול בית תפארתנו"), lines)
+        assertTrue(!text.contains("ignored"))
+    }
+
+    @Test
+    fun `a page without song-body (Cloudflare challenge, 404 shell) parses to null`() {
+        assertNull(LyricsTranslateParser.parse("<html><head><title>Just a moment...</title></head><body>challenge-platform</body></html>"))
+        assertNull(LyricsTranslateParser.parse("<html><body><div>no lyrics here</div></body></html>"))
+    }
+
+    @Test
+    fun `provider serves server-inlined lyricstranslate text without fetching, page-parses as fallback, skips when both die`() = runBlocking {
+        // Normal path: the server inlines the audio-verified text (the site's Cloudflare wall blocks
+        // on-device fetches), so no network call is made at all.
+        val inlined = ZemerLyricsClient.Resolved(
+            videoId = "GJOY8rXS9Yc", verified = true,
+            sources = listOf(ZemerLyricsClient.Source(type = "lyricstranslate", url = "https://lyricstranslate.com/en/yaakov-shwekey-rachem-lyrics.html", plain = "רחם בחסדך\nעל עמך צורנו\nעל ציון משכן כבודך\nזבול בית תפארתנו")),
+        )
+        val fetched = ArrayList<String>()
+        val bodies = ZemerLyricsProvider.bodies(inlined, fetch = { fetched += it; page })
+        assertEquals(listOf("lyricstranslate"), bodies.map { it.first })
+        assertEquals("רחם בחסדך", bodies[0].second.lines().first())
+        assertEquals("inlined text is served without a network fetch", 0, fetched.size)
+        // Pointer-only form (older server): falls back to fetching + parsing the page; a dead fetch skips.
+        val pointer = ZemerLyricsClient.Resolved(
+            videoId = "GJOY8rXS9Yc", verified = true,
+            sources = listOf(ZemerLyricsClient.Source(type = "lyricstranslate", url = "https://lyricstranslate.com/en/yaakov-shwekey-rachem-lyrics.html")),
+        )
+        val parsed = ZemerLyricsProvider.bodies(pointer, fetch = { page })
+        assertEquals("רחם בחסדך", parsed[0].second.lines().first())
+        assertTrue(ZemerLyricsProvider.bodies(pointer, fetch = { null }).isEmpty())
+    }
+}


### PR DESCRIPTION
Adds a new lyrics source to the Zemer provider chain:

- New parser: port of the server-side extraction - the original-language body (depth-aware nested-div scan), `<br>`/block closes to newlines, entities unescaped, leading/trailing line whitespace stripped.
- Wired into `ZemerLyricsProvider` at the plain-text tier (same rank as the other plain sources), body gated by `hasLyricBody` (>= 4 lines). Server-provided text preferred, page parse as fallback; a dead source just moves the chain to the next provider.

Tests: parser extraction, empty/404 page -> null, provider wiring + dead-fetch skip. Full `lyrics.zemer` suite green (26 tests).