### PR TITLE
perf(lyrics): prefetch on track start and walk the chain concurrently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,7 +612,12 @@ the token is brokered by the Zemer server (`ZemerLyricsClient.musixmatchToken`),
 YouTube lyrics tab. The pick rule is the pure, tested `lyrics/SyncedFirstPicker`: among TRUSTED providers a SYNCED
 body beats a higher provider's plain one, but the YouTube providers are `lowTrust` (an auto-caption transcript is
 timestamped but not identity-gated) and are served ONLY when no trusted provider answered — never over a curated
-Zemer plain body. `LrcLib.identityMatches` accepts ANY credited artist of a joined credit (`creditedArtists`), not
+Zemer plain body. The SCHEDULE is the pure, tested `lyrics/LyricsChainWalk` (never changes the answer, only the
+wait): the primary trusted provider alone (a synced answer ends the walk with no other request), then the other
+trusted providers CONCURRENTLY offered in priority order, then the low-trust ones only when nothing trusted
+answered — so they are deferred even when the user order lists them first. Lyrics are PREFETCHED on every track
+start (`LyricsStore.prefetch`: current song then the next queue item, 3 s deferred, skipped offline) so opening
+the pane is a Room read; never regress the pane-open path to a live chain walk. `LrcLib.identityMatches` accepts ANY credited artist of a joined credit (`creditedArtists`), not
 just the first. The chain reads ONE DataStore snapshot per walk (`LyricsHelper.enabledProviders(prefs)`: order +
 every `LyricsProvider.enabledKey`), never a blocking read per provider. Musixmatch's `cleanLrc` formats with
 `Locale.US` (a comma-decimal locale produced LRC nothing could parse). Users contribute through the lyrics menu:
@@ -626,16 +631,18 @@ timings (word sync renders only measured `<mm:ss.xx>` tags); lyrics start at the
 30%; `LyricsSyncOffsetKey` user offset. The lyrics view (`ui/player/LyricsScreen.kt`, hosted by `Player.kt`, toggled by the
 `ShowLyricsKey`/`showLyrics` preference) reuses the player's own transport, slider and identity row via the shared
 components in `ui/component/lyrics/LyricsComponents.kt`; never re-roll them. Cache policy lives in `LyricsEntity`
-(`needsFetch`/`resolved`), applied by the ONE fetch-and-persist path `lyrics/LyricsStore` (`ensure` for the
-`showLyrics`-gated service prefetch and `LyricsScreen`'s open-time fetch, `refetch` for the menu's explicit
+(`needsFetch`/`resolved`), applied by the ONE fetch-and-persist path `lyrics/LyricsStore` (`ensure` for
+`LyricsScreen`'s open-time fetch, `prefetch(current, next, connected)` for the service's track-start warm-up - every
+track start, pane open or not, 3 s deferred, current song then the next queue item, skipped offline - so opening
+the pane is a Room read, `refetch` for the menu's explicit
 delete-then-refresh - the delete lands FIRST so the pane visibly reloads even when the chain answers the same
 body, and fetches are single-flight per videoId so the screen's re-fetch joins the refetch's walk; JVM-tested with
 injected storage - never re-roll the decision per call site): a not-found row is
 a negative cache; a pre-provider row with a body is re-resolved once — a PLAIN legacy body is always kept
 (stamped `legacy`; it may be a manual entry, Refetch is the explicit way out), a SYNCED legacy body is replaced
-when the chain answers (nobody types timestamps: it is an old ungated LrcLib match). The one-time purge drops
-only legacy not-found rows (pre-provider rows carry no provider stamp, so a `provider = 'LrcLib'` clause could
-only ever hit NEW gated rows). Do not add DB migrations for lyrics (the 35→36 `provider` column is the one that exists).
+when the chain answers (nobody types timestamps: it is an old ungated LrcLib match). Cache refresh is by chain generation (`LyricsEntity.CHAIN_GENERATION` vs `LyricsChainGenerationKey`): each
+generation step runs `DatabaseDao.purgeRefreshableLyrics` once, dropping not-found rows and auto-cached PLAIN rows
+while retaining synced, `manual` and `legacy` rows. Do not add DB migrations for lyrics (the 35→36 `provider` column is the one that exists).
 
 ### Shared UI components (componentized - import, don't re-roll)
 

--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -576,9 +576,10 @@ interface DatabaseDao {
      * step, see `MusicService`): not-found rows (the chain may cover the song now) and auto-cached PLAIN rows
      * (the chain may sync them now). Kept: every SYNCED body (already the best the chain offers), `manual`
      * rows (user-typed text) and `legacy` rows (pre-provider bodies that may be manual and are handled by
-     * [LyricsEntity.needsFetch]). The GLOB is the `[mm:ss.xx]` line tag no user types.
+     * [LyricsEntity.needsFetch]). The GLOB is the `[mm:ss.xx]` / `[mm:ss.xxx]` line tag no user types (digits
+     * only, two or three fractional digits, the same contract as [LyricsEntity]'s synced-body check).
      */
-    @Query("DELETE FROM lyrics WHERE lyrics = 'LYRICS_NOT_FOUND' OR (provider IS NOT NULL AND provider NOT IN ('manual', 'legacy') AND lyrics NOT GLOB '*[[]??:??.??]*')")
+    @Query("DELETE FROM lyrics WHERE lyrics = 'LYRICS_NOT_FOUND' OR (provider IS NOT NULL AND provider NOT IN ('manual', 'legacy') AND lyrics NOT GLOB '*[[][0-9][0-9]:[0-9][0-9].[0-9][0-9]*')")
     fun purgeRefreshableLyrics(): Int
 
     @Transaction

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsChainWalk.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsChainWalk.kt
@@ -1,0 +1,38 @@
+package com.jtech.zemer.lyrics
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * HOW the chain is walked for one song, pure so it is unit-tested. The answer is exactly what a sequential
+ * walk in the user's order gives ([SyncedFirstPicker] is offered the results in that order); only the network
+ * schedule differs:
+ *  1. the primary trusted provider alone: a synced answer ends the walk with no other request made (the common
+ *     Zemer case costs nothing extra);
+ *  2. the remaining trusted providers CONCURRENTLY, offered in priority order (they were a serial 4 s tail
+ *     after every plain answer);
+ *  3. the low-trust providers only when NO trusted provider answered, and concurrently too. They are served
+ *     only in that case (the pick rule), so deferring them changes nothing but the seconds they used to burn
+ *     at the head of a user order that listed them first.
+ */
+object LyricsChainWalk {
+    /** [fetch] runs one provider and returns its body, or null for no answer (errors are the caller's to report). */
+    suspend fun run(providers: List<LyricsProvider>, fetch: suspend (LyricsProvider) -> LabeledLyrics?): LyricsHelper.Fetched {
+        val picker = SyncedFirstPicker()
+        val (trusted, lowTrust) = providers.partition { !it.lowTrust }
+        val primary = trusted.firstOrNull()
+        if (primary != null) fetch(primary)?.let { picker.offer(primary, it) }?.let { return it }
+        offerAll(picker, trusted.drop(1), fetch)?.let { return it }
+        if (picker.hasTrustedAnswer) return picker.result()
+        offerAll(picker, lowTrust, fetch)?.let { return it }
+        return picker.result()
+    }
+
+    private suspend fun offerAll(picker: SyncedFirstPicker, providers: List<LyricsProvider>, fetch: suspend (LyricsProvider) -> LabeledLyrics?): LyricsHelper.Fetched? {
+        if (providers.isEmpty()) return null
+        val results = coroutineScope { providers.map { p -> async { p to fetch(p) } }.awaitAll() }
+        for ((provider, labeled) in results) labeled?.let { picker.offer(provider, it) }?.let { return it }
+        return null
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 class LyricsHelper
@@ -73,10 +74,11 @@ constructor(
         val providers = enabledProviders()
         val scope = CoroutineScope(SupervisorJob())
         val deferred = scope.async {
-            // Walk providers in trust order; the pick rule (synced-first among trusted providers, low-trust
-            // YouTube only as a last resort) is the pure, tested SyncedFirstPicker.
-            val picker = SyncedFirstPicker()
-            for (provider in providers) {
+            // The pick rule (synced-first among trusted providers, low-trust YouTube only as a last resort) is
+            // the pure SyncedFirstPicker; the schedule (primary alone, then the rest concurrently, low-trust
+            // deferred) is the pure LyricsChainWalk. Both are tested without a network.
+            LyricsChainWalk.run(providers) { provider ->
+                val startedAt = System.currentTimeMillis()
                 try {
                     val result = provider.getLabeledLyrics(
                         videoId,
@@ -85,21 +87,20 @@ constructor(
                         mediaMetadata.duration,
                         mediaMetadata.album?.title,
                     )
-                    result.onSuccess { labeled ->
-                        picker.offer(provider, labeled)?.let { return@async it }
-                    }.onFailure {
+                    Timber.d("Lyrics %s %s in %d ms", provider.name, if (result.isSuccess) "answered" else "no answer", System.currentTimeMillis() - startedAt)
+                    result.onFailure {
                         // Not found here is normal — keep looking. Report only unexpected exceptions.
                         if (it !is LyricsUnavailableException &&
                             !(it is IllegalStateException && it.message?.contains("Lyrics") == true)) {
                             reportException(it)
                         }
-                    }
+                    }.getOrNull()
                 } catch (e: Exception) {
                     // Catch network-related exceptions like UnresolvedAddressException
                     reportException(e)
+                    null
                 }
             }
-            return@async picker.result()
         }
 
         val lyrics = deferred.await()

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt
@@ -57,6 +57,20 @@ class LyricsStore(
     }
 
     /**
+     * Warm the cache for the playing song and the one after it, so opening the lyrics pane later is a Room read
+     * instead of a chain walk. Runs [ensure] for [current] then [next]; each is the ordinary cache-gated path, so
+     * a cached song costs one query and nothing is fetched twice (fetches are single-flight per videoId). Skipped
+     * entirely while offline: the chain would only mint not-found rows that then hide the song's lyrics online.
+     * Returns how many songs actually fetched (for tests and the debug log).
+     */
+    suspend fun prefetch(current: MediaMetadata?, next: MediaMetadata?, connected: Boolean): Int {
+        if (!connected) return 0
+        var fetched = 0
+        for (item in listOfNotNull(current, next).distinctBy { it.id }) if (ensure(item)) fetched++
+        return fetched
+    }
+
+    /**
      * The menu's Refetch: an explicit user request drops whatever is cached (manual text included) and stores
      * a fresh chain answer. The delete lands first so the pane visibly reloads.
      */

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt
@@ -27,6 +27,9 @@ class SyncedFirstPicker {
         return null
     }
 
+    /** Whether a trusted provider has answered (plain): the low-trust providers are then never needed. */
+    val hasTrustedAnswer: Boolean get() = trustedPlain != null
+
     /** The answer once every provider was walked: the first trusted plain body, else the first low-trust body, else not found. */
     fun result(): LyricsHelper.Fetched = trustedPlain ?: lowTrust ?: LyricsHelper.Fetched(LYRICS_NOT_FOUND, null)
 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -106,7 +106,6 @@ import com.jtech.zemer.constants.StopMusicOnTaskClearKey
 import com.jtech.zemer.constants.PlayerVolumeKey
 import com.jtech.zemer.constants.RepeatModeKey
 import com.jtech.zemer.constants.LyricsChainGenerationKey
-import com.jtech.zemer.constants.ShowLyricsKey
 import com.jtech.zemer.constants.SkipSilenceKey
 import com.jtech.zemer.db.MusicDatabase
 import com.jtech.zemer.db.entities.Event
@@ -710,15 +709,16 @@ class MusicService :
             }
         }
 
-        combine(
-            currentMediaMetadata.distinctUntilChangedBy { it?.id },
-            dataStore.data.map { it[ShowLyricsKey] ?: false }.distinctUntilChanged(),
-        ) { mediaMetadata, showLyrics ->
-            mediaMetadata to showLyrics
-        }.collectLatest(scope) { (mediaMetadata, showLyrics) ->
-            // The cache decision, the chain and the row policy are LyricsStore's (one path with the lyrics
-            // screen and Refetch); it also skips episodes. A hidden pane costs no Room query per song change.
-            if (showLyrics && mediaMetadata != null) lyricsStore.ensure(mediaMetadata)
+        currentMediaMetadata.distinctUntilChangedBy { it?.id }.collectLatest(scope) { mediaMetadata ->
+            // Lyrics PREFETCH: warm the cache for this song and the next one on every track start, pane open or
+            // not, so opening the pane later is instant. The cache decision, the chain and the row policy are
+            // LyricsStore's (one path with the lyrics screen and Refetch); it also skips episodes. Deferred past
+            // the stream resolution so the chain never competes with playback start; collectLatest cancels a
+            // pending prefetch when the track changes first (a fast skip costs nothing).
+            if (mediaMetadata == null) return@collectLatest
+            delay(LYRICS_PREFETCH_DELAY_MS)
+            val next = player.nextMediaItemIndex.takeIf { it != C.INDEX_UNSET }?.let { player.getMediaItemAt(it).metadata }
+            lyricsStore.prefetch(mediaMetadata, next, isNetworkConnected.value)
         }
 
         dataStore.data
@@ -3136,6 +3136,9 @@ class MusicService :
         private const val REVERT_RECOVERY_WINDOW_MS = 6_000L
         const val PERSISTENT_QUEUE_FILE = "persistent_queue.data"
         const val PERSISTENT_PLAYER_STATE_FILE = "persistent_player_state.data"
+        /** Lyrics prefetch waits for the stream resolution + first buffer before the chain walks (see the collector). */
+        const val LYRICS_PREFETCH_DELAY_MS = 3_000L
+
         const val MAX_CONSECUTIVE_ERR = 5
         // Constants for audio normalization
         private const val MAX_GAIN_MB = 800 // Maximum gain in millibels (8 dB)

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt
@@ -1,0 +1,81 @@
+package com.jtech.zemer.lyrics
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import com.jtech.zemer.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+
+/** The walk's schedule must never change the answer a sequential user-order walk gives, only how long it takes. */
+class LyricsChainWalkTest {
+    private fun provider(name: String, low: Boolean = false) = object : LyricsProvider {
+        override val name = name
+        override val enabledKey: Preferences.Key<Boolean> = booleanPreferencesKey("enable$name")
+        override val lowTrust = low
+        override suspend fun getLyrics(id: String, title: String, artist: String, duration: Int, album: String?): Result<String> = Result.failure(IllegalStateException("unused"))
+    }
+    private val zemer = provider("Zemer")
+    private val simp = provider("SimpMusic")
+    private val mxm = provider("Musixmatch")
+    private val lrclib = provider("LrcLib")
+    private val ytSub = provider("YouTube Subtitle", low = true)
+    private val ytTab = provider("YouTube Music", low = true)
+    private val plain = "line one\nline two"
+    private val synced = "[00:01.00] line one\n[00:05.00] line two"
+
+    private class Fake(private val answers: Map<String, String?>, private val delayMs: Long = 0) {
+        val calls: MutableList<String> = Collections.synchronizedList(ArrayList())
+        val fetch: suspend (LyricsProvider) -> LabeledLyrics? = { p ->
+            calls += p.name
+            if (delayMs > 0) delay(delayMs)
+            answers[p.name]?.let { LabeledLyrics(p.name, it) }
+        }
+    }
+
+    @Test
+    fun `a synced primary answer ends the walk with no other provider asked`() = runBlocking {
+        val f = Fake(mapOf("Zemer" to synced, "SimpMusic" to synced))
+        assertEquals(LyricsHelper.Fetched(synced, "Zemer"), LyricsChainWalk.run(listOf(zemer, simp, mxm, lrclib, ytSub, ytTab), f.fetch))
+        assertEquals(listOf("Zemer"), f.calls)
+    }
+
+    @Test
+    fun `after a plain primary the other trusted providers run concurrently and the best by priority wins`() = runBlocking {
+        val f = Fake(mapOf("Zemer" to plain, "Musixmatch" to synced, "LrcLib" to synced), delayMs = 150)
+        val startedAt = System.currentTimeMillis()
+        val got = LyricsChainWalk.run(listOf(zemer, simp, mxm, lrclib, ytSub, ytTab), f.fetch)
+        val elapsed = System.currentTimeMillis() - startedAt
+        assertEquals("priority order, not arrival order", LyricsHelper.Fetched(synced, "Musixmatch"), got)
+        assertEquals(setOf("Zemer", "SimpMusic", "Musixmatch", "LrcLib"), f.calls.toSet())
+        assertTrue("three 150 ms providers ran concurrently, not serially (took $elapsed ms)", elapsed < 150 * 3)
+    }
+
+    @Test
+    fun `a plain trusted answer is served without ever asking the low-trust providers`() = runBlocking {
+        val f = Fake(mapOf("LrcLib" to plain, "YouTube Subtitle" to synced))
+        assertEquals(LyricsHelper.Fetched(plain, "LrcLib"), LyricsChainWalk.run(listOf(zemer, simp, mxm, lrclib, ytSub, ytTab), f.fetch))
+        assertTrue(f.calls.none { it.startsWith("YouTube") })
+    }
+
+    @Test
+    fun `low-trust providers are deferred to the end even when the user order lists them first`() = runBlocking {
+        val f = Fake(mapOf("Zemer" to plain, "YouTube Subtitle" to synced))
+        val got = LyricsChainWalk.run(listOf(ytSub, ytTab, zemer, simp, mxm, lrclib), f.fetch)
+        assertEquals(LyricsHelper.Fetched(plain, "Zemer"), got)
+        assertEquals("Zemer", f.calls.first())
+        assertTrue(f.calls.none { it.startsWith("YouTube") })
+    }
+
+    @Test
+    fun `with no trusted answer the low-trust providers run and the first by order is served`() = runBlocking {
+        val f = Fake(mapOf("YouTube Music" to plain, "YouTube Subtitle" to synced))
+        assertEquals(LyricsHelper.Fetched(synced, "YouTube Subtitle"), LyricsChainWalk.run(listOf(zemer, simp, ytSub, ytTab), f.fetch))
+        assertEquals(setOf("Zemer", "SimpMusic", "YouTube Subtitle", "YouTube Music"), f.calls.toSet())
+        assertEquals(LyricsHelper.Fetched(LYRICS_NOT_FOUND, null), LyricsChainWalk.run(listOf(zemer, ytSub), Fake(emptyMap()).fetch))
+        assertEquals(LyricsHelper.Fetched(LYRICS_NOT_FOUND, null), LyricsChainWalk.run(emptyList(), Fake(emptyMap()).fetch))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt
@@ -87,4 +87,22 @@ class LyricsStoreTest {
         assertEquals(1, f.fetches)
         assertTrue(f.persisted.all { it == LyricsEntity("v", "fresh", "LrcLib") })
     }
+
+    @Test
+    fun `prefetch warms the current and next songs through the cache gate and does nothing offline`() = runBlocking {
+        val next = song.copy(id = "n")
+        val f = Fake(null, LyricsHelper.Fetched("words", "Zemer · jyrics"))
+        assertEquals(2, f.store.prefetch(song, next, connected = true))
+        assertEquals(listOf("v", "n"), f.persisted.map { it.id })
+        // offline: no chain walk, no not-found rows minted
+        val off = Fake(null, LyricsHelper.Fetched(LYRICS_NOT_FOUND, null))
+        assertEquals(0, off.store.prefetch(song, next, connected = false))
+        assertEquals(0, off.fetches)
+        // a cached current song costs no fetch; the same id twice fetches once; an episode next is skipped
+        val cached = Fake(LyricsEntity("v", "words", "Zemer · jyrics"), LyricsHelper.Fetched("words", "SimpMusic"))
+        assertEquals(0, cached.store.prefetch(song, song, connected = true))
+        assertEquals(0, cached.store.prefetch(song, episode, connected = true))
+        assertEquals(0, cached.fetches)
+        assertEquals(0, Fake(null, LyricsHelper.Fetched("words", "SimpMusic")).store.prefetch(null, null, connected = true))
+    }
 }

--- a/docs/lyrics/README.md
+++ b/docs/lyrics/README.md
@@ -96,12 +96,19 @@ from X · synced", only once a real body exists) + the lyrics menu + the shared 
 transport row and slider reused through `PlayerTransportRow` and the `ui/component/lyrics/LyricsComponents.kt`
 pieces. Its repeat button's content description follows `repeatModeContentDescriptionRes(repeatMode)`.
 
-## Pick rule (`lyrics/SyncedFirstPicker`, JVM-tested)
-Providers are walked in the user's order from ONE DataStore snapshot (`LyricsHelper.enabledProviders(prefs)`: the
-order key plus every provider's `enabledKey`). Among trusted providers the walk stops at the first SYNCED body and
+## Pick rule (`lyrics/SyncedFirstPicker`) and walk schedule (`lyrics/LyricsChainWalk`), both JVM-tested
+Providers come in the user's order from ONE DataStore snapshot (`LyricsHelper.enabledProviders(prefs)`: the
+order key plus every provider's `enabledKey`). Among trusted providers the pick stops at the first SYNCED body and
 otherwise serves the first plain one. The YouTube providers are `lowTrust`: an auto-caption transcript is
 timestamped but not identity-gated, so it is served only when no trusted provider answered — never over a curated
-Zemer plain body (`SyncedFirstPickerTest`).
+Zemer plain body (`SyncedFirstPickerTest`). `LyricsChainWalk` decides WHEN each provider is asked without changing
+that answer (`LyricsChainWalkTest` pins the equivalence): (1) the primary trusted provider alone — a synced answer
+ends the walk with no other request; (2) the remaining trusted providers CONCURRENTLY, offered to the picker in
+priority order (they were a serial ~4 s tail after every plain answer, LrcLib's title search the long pole);
+(3) the low-trust providers only when NO trusted provider answered, concurrently. Low-trust providers are therefore
+always deferred even when the user order lists them first (each cost 2-4 s of "no answer" at the head of the walk).
+Measured on the emulator: a Zemer-answered song walks in ~1.3-2.2 s (was 8-12 s with YouTube first, ~4-5 s in the
+default order). Each provider's elapsed time is a `Lyrics <name> answered|no answer in N ms` Timber breadcrumb.
 
 ## Feedback (`lyrics/zemer/LyricsFeedback`, JVM-tested)
 "Report wrong lyrics" and a saved edit POST through `LyricsMenuViewModel.feedback`, which rides `viewModelScope`.
@@ -109,7 +116,11 @@ The menu sheet's own `rememberCoroutineScope` is cancelled the frame the sheet i
 dismisses first, so a POST launched there never reached the server (`LyricsFeedbackTest`).
 
 ## Cache hygiene (`LyricsEntity.needsFetch` / `LyricsEntity.resolved`, applied by `LyricsStore`)
-`LyricsScreen` (on open) and `MusicService` (past the `showLyrics` guard) call `LyricsStore.ensure`, which runs the
+`LyricsScreen` (on open) calls `LyricsStore.ensure`, and `MusicService` PREFETCHES on every track start, pane open or
+not: `LyricsStore.prefetch(current, next, connected)` runs `ensure` for the playing song and the next queue item
+(`LYRICS_PREFETCH_DELAY_MS` = 3 s after the track change so the chain never competes with the stream resolution;
+`collectLatest` drops a pending prefetch when the track changes first; skipped offline so no not-found rows are
+minted that would hide lyrics once online). Opening the pane is then a Room read. `ensure` runs the
 chain only when `needsFetch`: nothing cached, or a legacy row (provider null) with a real body. A `LYRICS_NOT_FOUND` row is a
 negative cache and is never re-fetched. A legacy PLAIN body is always kept and stamped `provider = "legacy"`
 (shown as unknown provenance): pre-provider manual entries are indistinguishable from old auto-cached rows and

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -25,7 +25,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 | `com.jtech.zemer.constants` | no | 0 | 1 |  |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 661 | `com.jtech.zemer.constants` | no | 9 | 197 | androidx.annotation, androidx.datastore, java.time |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 | `com.jtech.zemer.db` | no | 4 | 3 | androidx.room, java.time |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1831 | `com.jtech.zemer.db` | no | 65 | 255 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1832 | `com.jtech.zemer.db` | no | 65 | 255 | androidx.room, androidx.sqlite, java.text, java.time, java.util, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 654 | `com.jtech.zemer.db` | no | 44 | 82 | android.annotation, android.content, android.database, androidx.core, androidx.room, androidx.sqlite, java.time, java.util, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/db/SqliteBindLimit.kt` | 14 | `com.jtech.zemer.db` | no | 0 | 2 |  |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 | `com.jtech.zemer.db.entities` | no | 1 | 3 | java.time |
@@ -86,15 +86,15 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt` | 256 | `com.jtech.zemer.latestreleases` | no | 17 | 65 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LrcLibLyricsProvider.kt` | 29 | `com.jtech.zemer.lyrics` | no | 2 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsEntry.kt` | 23 | `com.jtech.zemer.lyrics` | no | 0 | 9 |  |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 175 | `com.jtech.zemer.lyrics` | no | 19 | 30 | android.content, android.util, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 176 | `com.jtech.zemer.lyrics` | no | 20 | 30 | android.content, android.util, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProvider.kt` | 66 | `com.jtech.zemer.lyrics` | no | 1 | 12 | androidx.datastore |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrdering.kt` | 20 | `com.jtech.zemer.lyrics` | no | 0 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistry.kt` | 44 | `com.jtech.zemer.lyrics` | no | 1 | 9 |  |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt` | 87 | `com.jtech.zemer.lyrics` | no | 14 | 16 | javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt` | 101 | `com.jtech.zemer.lyrics` | no | 14 | 18 | javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsUtils.kt` | 135 | `com.jtech.zemer.lyrics` | no | 1 | 35 | android.text |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/MusixmatchLyricsProvider.kt` | 22 | `com.jtech.zemer.lyrics` | no | 4 | 7 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/SimpMusicLyricsProvider.kt` | 29 | `com.jtech.zemer.lyrics` | no | 2 | 5 |  |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt` | 32 | `com.jtech.zemer.lyrics` | no | 1 | 6 |  |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt` | 35 | `com.jtech.zemer.lyrics` | no | 1 | 7 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/YouTubeLyricsProvider.kt` | 30 | `com.jtech.zemer.lyrics` | no | 4 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/YouTubeSubtitleLyricsProvider.kt` | 20 | `com.jtech.zemer.lyrics` | no | 2 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/model/LyricsUnavailableException.kt` | 9 | `com.jtech.zemer.lyrics.model` | no | 0 | 2 |  |
@@ -162,7 +162,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 810 | `com.jtech.zemer.playback` | no | 58 | 80 | android.content, android.net, android.os, androidx.annotation, androidx.core, androidx.media3, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 1226 | `com.jtech.zemer.playback` | no | 66 | 144 | android.content, android.media, android.net, androidx.core, dagger.hilt, java.io, java.time, java.util, javax.inject, kotlin.math, kotlinx.coroutines, okhttp3.OkHttpClient, okhttp3.Request, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadService.kt` | 302 | `com.jtech.zemer.playback` | no | 27 | 48 | android.app, android.content, android.os, androidx.core, dagger.hilt, javax.inject, kotlin.math, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 3149 | `com.jtech.zemer.playback` | no | 192 | 336 | android.app, android.content, android.database, android.media, android.net, android.os, androidx.core, androidx.datastore, androidx.media3, com.zemer, dagger.hilt, java.io, java.time, java.util, javax.inject, kotlin.time, kotlinx.coroutines, okhttp3.OkHttpClient, org.fcast, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 3152 | `com.jtech.zemer.playback` | no | 191 | 338 | android.app, android.content, android.database, android.media, android.net, android.os, androidx.core, androidx.datastore, androidx.media3, com.zemer, dagger.hilt, java.io, java.time, java.util, javax.inject, kotlin.time, kotlinx.coroutines, okhttp3.OkHttpClient, org.fcast, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlaybackNonceRegistry.kt` | 76 | `com.jtech.zemer.playback` | no | 1 | 13 |  |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlaybackProbe.kt` | 31 | `com.jtech.zemer.playback` | no | 0 | 8 |  |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt` | 413 | `com.jtech.zemer.playback` | no | 30 | 71 | android.content, androidx.media3, kotlinx.coroutines, org.fcast |
@@ -606,7 +606,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 | `com.jtech.zemer.latestreleases` | no | 8 | 8 | java.io, java.nio, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrderingTest.kt` | 37 | `com.jtech.zemer.lyrics` | no | 2 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistryTest.kt` | 31 | `com.jtech.zemer.lyrics` | no | 2 | 2 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 90 | `com.jtech.zemer.lyrics` | no | 14 | 20 | kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 108 | `com.jtech.zemer.lyrics` | no | 14 | 24 | kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsUtilsTest.kt` | 68 | `com.jtech.zemer.lyrics` | no | 4 | 7 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/SyncedFirstPickerTest.kt` | 85 | `com.jtech.zemer.lyrics` | no | 10 | 18 | androidx.datastore, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/musixmatch/MusixmatchGatesTest.kt` | 83 | `com.jtech.zemer.lyrics.musixmatch` | no | 7 | 12 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -12,7 +12,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 56 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 3 lines | text `[none]` |
-| `AGENTS.md` | 1887 lines | text `.md` |
+| `AGENTS.md` | 1896 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 9 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -119,7 +119,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 56 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 3 lines | `[none]` |
-| `AGENTS.md` | 1887 lines | `.md` |
+| `AGENTS.md` | 1896 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 9 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -188,7 +188,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/constants/PlaybackMode.kt` | 11 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/constants/PreferenceKeys.kt` | 661 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/Converters.kt` | 20 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1831 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt` | 1832 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/MusicDatabase.kt` | 654 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/SqliteBindLimit.kt` | 14 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/db/entities/ActionSnapshotRow.kt` | 13 lines | `.kt` |
@@ -249,15 +249,15 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStore.kt` | 256 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LrcLibLyricsProvider.kt` | 29 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsEntry.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 175 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 176 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProvider.kt` | 66 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrdering.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistry.kt` | 44 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt` | 87 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsStore.kt` | 101 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsUtils.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/MusixmatchLyricsProvider.kt` | 22 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/SimpMusicLyricsProvider.kt` | 29 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt` | 32 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/SyncedFirstPicker.kt` | 35 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/YouTubeLyricsProvider.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/YouTubeSubtitleLyricsProvider.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/model/LyricsUnavailableException.kt` | 9 lines | `.kt` |
@@ -325,7 +325,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaLibrarySessionCallback.kt` | 810 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadManager.kt` | 1226 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/MediaStoreDownloadService.kt` | 302 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 3149 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt` | 3152 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlaybackNonceRegistry.kt` | 76 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlaybackProbe.kt` | 31 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/playback/PlayerConnection.kt` | 413 lines | `.kt` |
@@ -977,7 +977,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrderingTest.kt` | 37 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistryTest.kt` | 31 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 90 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 108 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsUtilsTest.kt` | 68 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/SyncedFirstPickerTest.kt` | 85 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/musixmatch/MusixmatchGatesTest.kt` | 83 lines | `.kt` |
@@ -1193,7 +1193,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/latest_releases/06-test-harness.md` | 127 lines | `.md` |
 | `docs/latest_releases/07-runbook.md` | 110 lines | `.md` |
 | `docs/latest_releases/README.md` | 80 lines | `.md` |
-| `docs/lyrics/README.md` | 126 lines | `.md` |
+| `docs/lyrics/README.md` | 140 lines | `.md` |
 | `docs/multi_update/01-architecture.md` | 80 lines | `.md` |
 | `docs/multi_update/02-install-methods.md` | 98 lines | `.md` |
 | `docs/multi_update/03-restart.md` | 70 lines | `.md` |


### PR DESCRIPTION
## What

Lyrics open instantly instead of after a multi-second chain walk.

- **Prefetch on track start.** `LyricsStore.prefetch(current, next, connected)` runs the cache-gated `ensure` for the playing song and the next queue item 3s after every track change, pane open or not, skipped offline. Opening the pane later is a Room read. A fast skip cancels the pending prefetch.
- **Concurrent chain walk** (`LyricsChainWalk`, pure, JVM-tested). The answer is identical to the sequential user-order walk through `SyncedFirstPicker`; only the schedule changes: the primary trusted provider alone (a synced answer ends the walk), then the remaining trusted providers concurrently, offered in priority order, then the low-trust providers only when nothing trusted answered. Low-trust providers are deferred even when the user order lists them first.
- Per-provider elapsed-time breadcrumb on every walk.
- The lyrics cache purge GLOB now keeps three-digit synced tags (`[mm:ss.xxx]`) and rejects lookalikes.

## Measured (emulator, live server)

| case | before | after |
|---|---|---|
| chain walk, song with a Zemer answer, YouTube-first user order | 8 to 12 s | 1.3 to 2.2 s |
| pane open on a song playing more than ~5 s | chain walk | instant (cached) |

## Tests

`LyricsChainWalkTest` (synced primary asks nobody else; concurrent tail proven by elapsed time; priority order not arrival order; low-trust never asked when a trusted plain body exists; low-trust deferred under a YouTube-first order; not-found), `LyricsStoreTest` prefetch (current + next, offline no-op, cached costs nothing, episode skipped), plus the full lyrics package. On-device: prefetch log lines for current and next with the pane closed, and the pane opening with lyrics within a second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lyrics are prefetched automatically for the current and next track after playback starts, when online.
  - Lyrics provider lookup now prioritizes trusted sources and falls back to lower-trust sources only when needed.
  - Cached lyrics are reused and refreshed more consistently.

- **Bug Fixes**
  - Improved handling of synchronized lyrics during cache refreshes.
  - Offline playback no longer triggers lyrics fetching.

- **Documentation**
  - Updated lyrics provider behavior and prefetching documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->