### PR TITLE
fix(lyrics): exact synced-tag purge match, timing breadcrumb on thrown providers

### DIFF
--- a/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/db/DatabaseDao.kt
@@ -579,7 +579,7 @@ interface DatabaseDao {
      * [LyricsEntity.needsFetch]). The GLOB is the `[mm:ss.xx]` / `[mm:ss.xxx]` line tag no user types (digits
      * only, two or three fractional digits, the same contract as [LyricsEntity]'s synced-body check).
      */
-    @Query("DELETE FROM lyrics WHERE lyrics = 'LYRICS_NOT_FOUND' OR (provider IS NOT NULL AND provider NOT IN ('manual', 'legacy') AND lyrics NOT GLOB '*[[][0-9][0-9]:[0-9][0-9].[0-9][0-9]*')")
+    @Query("DELETE FROM lyrics WHERE lyrics = 'LYRICS_NOT_FOUND' OR (provider IS NOT NULL AND provider NOT IN ('manual', 'legacy') AND lyrics NOT GLOB '*[[][0-9][0-9]:[0-9][0-9].[0-9][0-9]]*' AND lyrics NOT GLOB '*[[][0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9]]*')")
     fun purgeRefreshableLyrics(): Int
 
     @Transaction

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
@@ -97,6 +97,7 @@ constructor(
                     }.getOrNull()
                 } catch (e: Exception) {
                     // Catch network-related exceptions like UnresolvedAddressException
+                    Timber.d("Lyrics %s threw in %d ms", provider.name, System.currentTimeMillis() - startedAt)
                     reportException(e)
                     null
                 }

--- a/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/playback/MusicService.kt
@@ -712,8 +712,9 @@ class MusicService :
         currentMediaMetadata.distinctUntilChangedBy { it?.id }.collectLatest(scope) { mediaMetadata ->
             // Lyrics PREFETCH: warm the cache for this song and the next one on every track start, pane open or
             // not, so opening the pane later is instant. The cache decision, the chain and the row policy are
-            // LyricsStore's (one path with the lyrics screen and Refetch); it also skips episodes. Deferred past
-            // the stream resolution so the chain never competes with playback start; collectLatest cancels a
+            // LyricsStore's (one path with the lyrics screen and Refetch); it also skips episodes. A short
+            // deferral keeps the chain off the first seconds of the stream resolution (a coarse yield, not a
+            // readiness gate: a slow or failing resolve must not hold the lyrics back); collectLatest cancels a
             // pending prefetch when the track changes first (a fast skip costs nothing).
             if (mediaMetadata == null) return@collectLatest
             delay(LYRICS_PREFETCH_DELAY_MS)
@@ -3136,7 +3137,7 @@ class MusicService :
         private const val REVERT_RECOVERY_WINDOW_MS = 6_000L
         const val PERSISTENT_QUEUE_FILE = "persistent_queue.data"
         const val PERSISTENT_PLAYER_STATE_FILE = "persistent_player_state.data"
-        /** Lyrics prefetch waits for the stream resolution + first buffer before the chain walks (see the collector). */
+        /** Lyrics prefetch yields the first seconds of a track start to the stream resolution (see the collector). */
         const val LYRICS_PREFETCH_DELAY_MS = 3_000L
 
         const val MAX_CONSECUTIVE_ERR = 5


### PR DESCRIPTION
Review follow-ups on the lyrics work.

- The cache purge GLOB now requires the closing bracket and exactly two or three fractional digits (two alternatives), matching the synced-body contract. Proven in sqlite: `[00:01.00]` and `[00:01.000]` bodies are kept; a bracketless, four-digit or trailing-character lookalike is purged with the plain rows; manual and legacy rows are kept. The Room query itself is not JVM-testable here.
- A provider that throws during the chain walk logs its elapsed time like one that answers.
- The prefetch deferral comment no longer claims it waits for the stream resolution: the 3s delay is a coarse yield. Gating on STATE_READY was considered and rejected, since it would postpone lyrics on exactly the slow resolves where users wait longest and would never fire for a stream that errors while the song stays current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lyrics prefetch timing so lyrics requests can begin shortly after track metadata changes, without waiting for stream readiness or buffering.
  - Refined refreshable-lyrics cleanup to recognize supported timestamp formats more precisely.

- **Diagnostics**
  - Added more detailed troubleshooting information when lyrics providers encounter errors, including the provider involved and request duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->