### PR TITLE
fix(updater): no download timeout, real progress, redesigned update dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -728,7 +728,14 @@ select-mode cluster) and `SelectionActions` (the select-all + overflow pair for 
 `actions` slot), all over the shared `ItemWrapper`. Also shared: `PlaylistDetailHeader` (the playlist
 detail screens' header block), `ErrorRetryState` (the "something went wrong" + Retry block, with an
 optional `detail` line for the caught message), `GenreCatalogShimmer` (the genre-catalog loading
-shimmer) and `RemoveDownloadConfirmDialog` (the remove-download confirm).
+shimmer) and `RemoveDownloadConfirmDialog` (the remove-download confirm). The **update dialog family**
+(`UpdateDownloadDialog.kt`) contributed three general pieces: `MarkdownText` (renders the pure
+`utils/markdown/LiteMarkdown` subset - headings, bullet/numbered lists, bold/italic/code, tappable
+links - for release notes and any other server-authored prose; a nightly's commit message is formatted
+into it by `NightlyUpdates.commitMessageMarkdown`), `LabeledWavyProgress` (the ONE label + percent +
+expressive wavy bar + detail-caption stack for any in-progress row) and `InlineMessagePanel` /
+`InlineErrorPanel` (icon + text on a tonal container - an error the user must read and act on renders
+here, never as a bare red `Text`).
 New screens use these; a hand-rolled duplicate is a
 review miss.
 

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -303,6 +303,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -973,9 +974,15 @@ class MainActivity : ComponentActivity() {
                                     }
                                 },
                                 onCancelDownload = {
-                                    downloadJob?.cancel()
+                                    // Wait for the cancelled download to finish its cleanup (delete
+                                    // its part file) before returning to Idle, so a retry can start
+                                    // clean and the teardown can never touch the retry's files.
+                                    val job = downloadJob
                                     downloadJob = null
-                                    downloadState = com.jtech.zemer.utils.UpdateChecker.DownloadState.Idle
+                                    updateScope.launch {
+                                        job?.cancelAndJoin()
+                                        downloadState = com.jtech.zemer.utils.UpdateChecker.DownloadState.Idle
+                                    }
                                 },
                                 onInstall = { apk -> installController.install(apk) },
                                 onDismiss = {

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -897,6 +897,7 @@ class MainActivity : ComponentActivity() {
                         var pendingUpdateIsNightly by rememberSaveable { mutableStateOf(false) }
                         var downloadState by remember { mutableStateOf<com.jtech.zemer.utils.UpdateChecker.DownloadState>(com.jtech.zemer.utils.UpdateChecker.DownloadState.Idle) }
                         var installError by remember { mutableStateOf<String?>(null) }
+                        var downloadJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
                         val updateScope = rememberCoroutineScope()
                         val snackbarHostState = remember { SnackbarHostState() }
 
@@ -956,6 +957,7 @@ class MainActivity : ComponentActivity() {
                             com.jtech.zemer.ui.component.UpdateDownloadDialog(
                                 currentVersion = BuildConfig.VERSION_NAME,
                                 latestVersion = pendingUpdateVersion!!,
+                                isNightly = pendingUpdateIsNightly,
                                 notes = pendingUpdateNotes,
                                 downloadState = downloadState,
                                 isInstalling = installController.isInstalling,
@@ -964,11 +966,16 @@ class MainActivity : ComponentActivity() {
                                 onDownload = {
                                     downloadState = com.jtech.zemer.utils.UpdateChecker.DownloadState.Downloading(0f)
                                     installError = null
-                                    updateScope.launch {
+                                    downloadJob = updateScope.launch {
                                         com.jtech.zemer.utils.UpdateChecker.downloadUpdate(this@MainActivity, pendingUpdateIsNightly).collect { state ->
                                             downloadState = state
                                         }
                                     }
+                                },
+                                onCancelDownload = {
+                                    downloadJob?.cancel()
+                                    downloadJob = null
+                                    downloadState = com.jtech.zemer.utils.UpdateChecker.DownloadState.Idle
                                 },
                                 onInstall = { apk -> installController.install(apk) },
                                 onDismiss = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/InlineMessagePanel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/InlineMessagePanel.kt
@@ -1,0 +1,57 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+
+/**
+ * A tonal inline message: leading icon + text on a rounded container. The generic shell for any
+ * in-content notice; [InlineErrorPanel] is the error-toned variant (the update dialog's failure
+ * row). Prefer this over a bare red `Text` for an error the user has to read and act on.
+ */
+@Composable
+fun InlineMessagePanel(
+    text: String,
+    icon: Painter,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerHighest,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = containerColor,
+        contentColor = contentColor,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(painter = icon, contentDescription = null)
+            Spacer(Modifier.width(12.dp))
+            Text(text = text, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun InlineErrorPanel(text: String, modifier: Modifier = Modifier) {
+    InlineMessagePanel(
+        text = text,
+        icon = painterResource(R.drawable.warning),
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    )
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/LabeledWavyProgress.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/LabeledWavyProgress.kt
@@ -1,0 +1,64 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.R
+
+/**
+ * The ONE labelled expressive progress block: a label row (with the percent at the trailing edge
+ * when [progress] is known), the wavy bar (determinate when [progress] is non-null, indeterminate
+ * otherwise), and an optional [detail] caption ("3.2 MB of 9.9 MB", an installer note). Used by
+ * the update dialog's downloading + installing states; any new "work in progress" row should
+ * render through it rather than hand-rolling the label + bar + caption stack.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun LabeledWavyProgress(
+    label: String,
+    progress: Float?,
+    modifier: Modifier = Modifier,
+    detail: String? = null,
+) {
+    Column(modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.weight(1f),
+            )
+            if (progress != null) {
+                Text(
+                    text = stringResource(R.string.percent_value, (progress * 100).toInt()),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        if (progress != null) {
+            LinearWavyProgressIndicator(progress = { progress.coerceIn(0f, 1f) }, modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+        if (detail != null) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = detail,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt
@@ -1,0 +1,88 @@
+package com.jtech.zemer.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.jtech.zemer.utils.markdown.LiteMarkdown
+import com.jtech.zemer.utils.markdown.MarkdownBlock
+import com.jtech.zemer.utils.markdown.MarkdownInline
+
+/**
+ * Renders [LiteMarkdown] (release notes, commit messages) as themed text: headings, bullet and
+ * numbered lists, bold / italic / inline code, and tappable links. Body text inherits
+ * [LocalTextStyle], so a dialog's bodyMedium applies without a style argument.
+ */
+@Composable
+fun MarkdownText(
+    markdown: String,
+    modifier: Modifier = Modifier,
+    onLinkClick: ((String) -> Unit)? = null,
+) {
+    val uriHandler = LocalUriHandler.current
+    val openLink: (String) -> Unit = onLinkClick ?: { url -> runCatching { uriHandler.openUri(url) }.getOrNull() ?: Unit }
+    val linkColor = MaterialTheme.colorScheme.primary
+    val codeBackground = MaterialTheme.colorScheme.surfaceContainerHighest
+    val blocks = LiteMarkdown.parse(markdown)
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        blocks.forEach { block ->
+            when (block) {
+                is MarkdownBlock.Heading -> Text(
+                    text = block.inlines.toAnnotated(linkColor, codeBackground, openLink),
+                    style = if (block.level <= 2) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                is MarkdownBlock.Paragraph -> Text(block.inlines.toAnnotated(linkColor, codeBackground, openLink))
+                is MarkdownBlock.ListItem -> Row {
+                    Text(
+                        text = block.ordinal?.let { "$it." } ?: "•",
+                        modifier = Modifier.width(20.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(block.inlines.toAnnotated(linkColor, codeBackground, openLink))
+                }
+            }
+        }
+    }
+}
+
+private fun List<MarkdownInline>.toAnnotated(
+    linkColor: Color,
+    codeBackground: Color,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString = buildAnnotatedString {
+    forEach { inline ->
+        when (inline) {
+            is MarkdownInline.Text -> append(inline.text)
+            is MarkdownInline.Bold -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(inline.text) }
+            is MarkdownInline.Italic -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(inline.text) }
+            is MarkdownInline.Code -> withStyle(
+                SpanStyle(fontFamily = FontFamily.Monospace, background = codeBackground),
+            ) { append(inline.text) }
+            is MarkdownInline.Link -> withStyle(
+                SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+            ) {
+                withLink(LinkAnnotation.Clickable(inline.href) { onLinkClick(inline.href) }) { append(inline.text) }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
@@ -41,7 +42,7 @@ fun MarkdownText(
     val openLink: (String) -> Unit = onLinkClick ?: { url -> runCatching { uriHandler.openUri(url) }.getOrNull() ?: Unit }
     val linkColor = MaterialTheme.colorScheme.primary
     val codeBackground = MaterialTheme.colorScheme.surfaceContainerHighest
-    val blocks = LiteMarkdown.parse(markdown)
+    val blocks = remember(markdown) { LiteMarkdown.parse(markdown) }
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
         blocks.forEach { block ->

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.jtech.zemer.R
@@ -198,6 +199,7 @@ private fun VersionTransitionCard(currentVersion: String, latestVersion: String,
                 label = stringResource(R.string.update_installed_version),
                 value = currentVersion,
                 emphasized = false,
+                modifier = Modifier.weight(1f),
             )
             Icon(
                 painter = painterResource(R.drawable.arrow_forward),
@@ -217,17 +219,20 @@ private fun VersionTransitionCard(currentVersion: String, latestVersion: String,
 
 @Composable
 private fun VersionColumn(label: String, value: String, emphasized: Boolean, modifier: Modifier = Modifier) {
-    Column(modifier) {
+    // Equal-width, centered columns around the arrow: a symmetric "from -> to", not a left-heavy row.
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(2.dp))
         Text(
             text = value,
             style = MaterialTheme.typography.titleSmall,
             color = if (emphasized) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -58,6 +58,17 @@ fun updateVersionValue(latestVersion: String, isNightly: Boolean): String =
     if (isNightly) latestVersion.removePrefix("nightly").trimStart() else latestVersion
 
 /**
+ * Pure: the label over the new-version column. A nightly names its channel; the forced
+ * return-to-stable path names the channel too (the version may equal the installed one, so
+ * "New version 38 -> 38" would read as a no-op); a plain stable update says "New version".
+ */
+fun updateNewVersionLabelRes(isNightly: Boolean, isReturnToStable: Boolean): Int = when {
+    isNightly -> R.string.update_nightly_build
+    isReturnToStable -> R.string.update_stable_release
+    else -> R.string.update_new_version
+}
+
+/**
  * The "update available -> download -> install" dialog, shared by the Updater settings screen
  * and the startup update prompt so both behave identically. Purely presentational: the caller
  * owns the state (download/install) and the actions.
@@ -72,6 +83,7 @@ fun UpdateDownloadDialog(
     currentVersion: String,
     latestVersion: String,
     isNightly: Boolean,
+    isReturnToStable: Boolean = false,
     notes: String?,
     downloadState: UpdateChecker.DownloadState,
     isInstalling: Boolean,
@@ -99,7 +111,7 @@ fun UpdateDownloadDialog(
             }
         },
         content = {
-            VersionTransitionCard(currentVersion, latestVersion, isNightly)
+            VersionTransitionCard(currentVersion, latestVersion, isNightly, isReturnToStable)
 
             if (!notes.isNullOrBlank()) {
                 Spacer(Modifier.height(12.dp))
@@ -192,7 +204,7 @@ fun UpdateDownloadDialog(
 }
 
 @Composable
-private fun VersionTransitionCard(currentVersion: String, latestVersion: String, isNightly: Boolean) {
+private fun VersionTransitionCard(currentVersion: String, latestVersion: String, isNightly: Boolean, isReturnToStable: Boolean) {
     Surface(
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -215,7 +227,7 @@ private fun VersionTransitionCard(currentVersion: String, latestVersion: String,
                 modifier = Modifier.padding(horizontal = 10.dp),
             )
             VersionColumn(
-                label = stringResource(if (isNightly) R.string.update_nightly_build else R.string.update_new_version),
+                label = stringResource(updateNewVersionLabelRes(isNightly, isReturnToStable)),
                 value = updateVersionValue(latestVersion, isNightly),
                 emphasized = true,
                 modifier = Modifier.weight(1f),

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -1,6 +1,7 @@
 package com.jtech.zemer.ui.component
 
 import android.text.format.Formatter
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -90,7 +91,13 @@ fun UpdateDownloadDialog(
     DefaultDialog(
         onDismiss = { if (!busy) onDismiss() },
         horizontalAlignment = Alignment.Start,
-        title = { Text(stringResource(R.string.update_available)) },
+        // Centered over the symmetric version card (DefaultDialog starts a title only when an
+        // icon is present).
+        title = {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text(stringResource(R.string.update_available), textAlign = TextAlign.Center)
+            }
+        },
         content = {
             VersionTransitionCard(currentVersion, latestVersion, isNightly)
 

--- a/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt
@@ -1,63 +1,97 @@
 package com.jtech.zemer.ui.component
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.heightIn
+import android.text.format.Formatter
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.jtech.zemer.R
 import com.jtech.zemer.utils.UpdateChecker
 import com.jtech.zemer.utils.updater.InstallerType
+import com.jtech.zemer.utils.updater.UpdateDownloadFailure
 import java.io.File
+
+/** The primary action the update dialog offers for a given download / install state. */
+enum class UpdateDialogAction { DOWNLOAD, RETRY, INSTALL, CANCEL, NONE }
+
+/**
+ * Pure: which primary action the dialog shows. Downloading offers only Cancel; installing offers
+ * nothing (an install cannot be interrupted); a finished download offers Install (also the retry
+ * for a failed install); a failed download offers Retry; otherwise Download.
+ */
+fun updateDialogPrimaryAction(state: UpdateChecker.DownloadState, isInstalling: Boolean): UpdateDialogAction = when {
+    isInstalling -> UpdateDialogAction.NONE
+    state is UpdateChecker.DownloadState.Downloading -> UpdateDialogAction.CANCEL
+    state is UpdateChecker.DownloadState.Downloaded -> UpdateDialogAction.INSTALL
+    state is UpdateChecker.DownloadState.Error -> UpdateDialogAction.RETRY
+    else -> UpdateDialogAction.DOWNLOAD
+}
+
+/**
+ * Pure: the value shown under the "Nightly build" label. `NightlyUpdates.versionLabel` reads
+ * "nightly #1215 (0f8e9f8)"; with the channel already named by the label the prefix is redundant
+ * and pushed the value onto two lines, so it is dropped here.
+ */
+fun updateVersionValue(latestVersion: String, isNightly: Boolean): String =
+    if (isNightly) latestVersion.removePrefix("nightly").trimStart() else latestVersion
 
 /**
  * The "update available -> download -> install" dialog, shared by the Updater settings screen
  * and the startup update prompt so both behave identically. Purely presentational: the caller
  * owns the state (download/install) and the actions.
  *
- * Correctly reflects the install phase: while downloading or installing the action buttons and
- * dismissal are disabled (you can't re-trigger a download mid-install), and the per-method
- * heads-up + errors (download or install, including async Shizuku failures) are surfaced here
- * rather than only as a toast.
+ * Shows the installed -> new version transition, the release notes rendered as Markdown (the
+ * stable changelog is Markdown; a nightly's commit message is formatted into it), byte-level
+ * download progress with a Cancel, and a classified, human-readable failure instead of the raw
+ * exception text. Dismissal is disabled while downloading or installing.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun UpdateDownloadDialog(
     currentVersion: String,
     latestVersion: String,
+    isNightly: Boolean,
     notes: String?,
     downloadState: UpdateChecker.DownloadState,
     isInstalling: Boolean,
     installError: String?,
     installerType: InstallerType,
     onDownload: () -> Unit,
+    onCancelDownload: () -> Unit,
     onInstall: (File) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val isDownloading = downloadState is UpdateChecker.DownloadState.Downloading
-    val downloadProgress = (downloadState as? UpdateChecker.DownloadState.Downloading)?.progress ?: 0f
-    val downloadError = (downloadState as? UpdateChecker.DownloadState.Error)?.message
+    val downloading = downloadState as? UpdateChecker.DownloadState.Downloading
+    val downloadFailure = (downloadState as? UpdateChecker.DownloadState.Error)?.failure
     val downloadedApk = (downloadState as? UpdateChecker.DownloadState.Downloaded)?.apkFile
-    val busy = isDownloading || isInstalling
+    val busy = downloading != null || isInstalling
+    val action = updateDialogPrimaryAction(downloadState, isInstalling)
 
     DefaultDialog(
         onDismiss = { if (!busy) onDismiss() },
         horizontalAlignment = Alignment.Start,
         title = { Text(stringResource(R.string.update_available)) },
         content = {
-            Text(stringResource(R.string.update_available_message, currentVersion, latestVersion))
+            VersionTransitionCard(currentVersion, latestVersion, isNightly)
 
             if (!notes.isNullOrBlank()) {
                 Spacer(Modifier.height(12.dp))
@@ -67,65 +101,143 @@ fun UpdateDownloadDialog(
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Spacer(Modifier.height(4.dp))
-                // Long release notes scroll within a bounded region so the action buttons stay reachable.
-                Column(Modifier.heightIn(max = 200.dp).verticalScroll(rememberScrollState())) {
-                    Text(text = notes, style = MaterialTheme.typography.bodySmall)
+                // The notes take whatever height the dialog has left (the body column is weighted
+                // by DefaultDialog), capped so a long changelog scrolls; on a small screen the
+                // panel shrinks instead of pushing the actions off-screen.
+                Surface(
+                    shape = MaterialTheme.shapes.medium,
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f, fill = false)
+                        .heightIn(max = 360.dp),
+                ) {
+                    Column(
+                        Modifier
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 10.dp, vertical = 8.dp),
+                    ) {
+                        MarkdownText(notes)
+                    }
                 }
             }
 
-            if (isDownloading) {
-                Spacer(Modifier.height(16.dp))
-                Text(stringResource(R.string.downloading_update), style = MaterialTheme.typography.labelMedium)
-                Spacer(Modifier.height(8.dp))
-                if (downloadProgress >= 0) {
-                    LinearWavyProgressIndicator(progress = { downloadProgress }, modifier = Modifier.fillMaxWidth())
-                    Spacer(Modifier.height(4.dp))
-                    Text("${(downloadProgress * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
-                } else {
-                    LinearWavyProgressIndicator(modifier = Modifier.fillMaxWidth())
-                }
+            if (downloading != null) {
+                Spacer(Modifier.height(14.dp))
+                val context = LocalContext.current
+                val downloaded = Formatter.formatShortFileSize(context, downloading.downloadedBytes)
+                LabeledWavyProgress(
+                    label = stringResource(R.string.downloading_update),
+                    progress = downloading.progress.takeIf { it >= 0f },
+                    detail = if (downloading.totalBytes > 0) {
+                        stringResource(
+                            R.string.update_download_progress,
+                            downloaded,
+                            Formatter.formatShortFileSize(context, downloading.totalBytes),
+                        )
+                    } else {
+                        stringResource(R.string.update_download_progress_unsized, downloaded)
+                    },
+                )
             }
 
             if (isInstalling) {
-                Spacer(Modifier.height(16.dp))
-                Text(stringResource(R.string.installing), style = MaterialTheme.typography.labelMedium)
-                installerType.installingNote?.let { note ->
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = stringResource(note),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
-            val errorText = installError?.let { stringResource(R.string.install_failed, it) } ?: downloadError
-            if (errorText != null) {
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = errorText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
+                Spacer(Modifier.height(14.dp))
+                LabeledWavyProgress(
+                    label = stringResource(R.string.installing),
+                    progress = null,
+                    detail = installerType.installingNote?.let { stringResource(it) },
                 )
             }
-        },
-        // No buttons while busy (download/install in progress) — passing null avoids reserving an
-        // empty button row.
-        buttons = if (busy) null else {
-            {
-                TextButton(onClick = onDismiss) { Text(stringResource(R.string.later)) }
 
-                if (downloadedApk != null) {
-                    // Download finished — install (or retry a failed install) with the chosen method.
-                    TextButton(onClick = { onInstall(downloadedApk) }) {
-                        Text(stringResource(R.string.install))
-                    }
-                } else {
-                    TextButton(onClick = onDownload) {
-                        Text(stringResource(R.string.download_and_install))
+            val errorText = installError?.let { stringResource(R.string.install_failed, it) }
+                ?: downloadFailure?.let { stringResource(it.messageRes()) }
+            if (errorText != null) {
+                Spacer(Modifier.height(12.dp))
+                InlineErrorPanel(errorText)
+            }
+        },
+        buttons = when (action) {
+            UpdateDialogAction.NONE -> null
+            UpdateDialogAction.CANCEL -> {
+                { TextButton(onClick = onCancelDownload) { Text(stringResource(R.string.cancel)) } }
+            }
+            else -> {
+                {
+                    TextButton(onClick = onDismiss) { Text(stringResource(R.string.later)) }
+                    Spacer(Modifier.width(8.dp))
+                    when (action) {
+                        UpdateDialogAction.INSTALL -> Button(onClick = { onInstall(downloadedApk!!) }) {
+                            Text(stringResource(R.string.install))
+                        }
+                        UpdateDialogAction.RETRY -> Button(onClick = onDownload) {
+                            Text(stringResource(R.string.retry))
+                        }
+                        else -> Button(onClick = onDownload) {
+                            Text(stringResource(R.string.download_and_install))
+                        }
                     }
                 }
             }
         },
     )
+}
+
+@Composable
+private fun VersionTransitionCard(currentVersion: String, latestVersion: String, isNightly: Boolean) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            VersionColumn(
+                label = stringResource(R.string.update_installed_version),
+                value = currentVersion,
+                emphasized = false,
+            )
+            Icon(
+                painter = painterResource(R.drawable.arrow_forward),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 10.dp),
+            )
+            VersionColumn(
+                label = stringResource(if (isNightly) R.string.update_nightly_build else R.string.update_new_version),
+                value = updateVersionValue(latestVersion, isNightly),
+                emphasized = true,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VersionColumn(label: String, value: String, emphasized: Boolean, modifier: Modifier = Modifier) {
+    Column(modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleSmall,
+            color = if (emphasized) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+private fun UpdateDownloadFailure.messageRes(): Int = when (this) {
+    UpdateDownloadFailure.TIMEOUT -> R.string.update_error_timeout
+    UpdateDownloadFailure.NETWORK -> R.string.update_error_network
+    UpdateDownloadFailure.STORAGE -> R.string.update_error_storage
+    UpdateDownloadFailure.CORRUPT_ARTIFACT -> R.string.update_error_corrupt
+    UpdateDownloadFailure.UNKNOWN -> R.string.update_error_unknown
 }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -325,6 +325,7 @@ fun UpdaterScreen(
                     currentVersion = result.currentVersion,
                     latestVersion = result.latestVersion,
                     isNightly = result.isNightly,
+                    isReturnToStable = result.isReturnToStable,
                     notes = result.notes,
                     downloadState = downloadState,
                     isInstalling = isInstalling,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -61,6 +61,7 @@ import com.jtech.zemer.utils.updater.InstallResult
 import com.jtech.zemer.utils.updater.InstallerType
 import com.jtech.zemer.utils.updater.rememberApkInstallController
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -86,6 +87,7 @@ fun UpdaterScreen(
     var showResultDialog by remember { mutableStateOf(false) }
     var updateResult by remember { mutableStateOf<UpdateChecker.UpdateResult?>(null) }
     var downloadState by remember { mutableStateOf<UpdateChecker.DownloadState>(UpdateChecker.DownloadState.Idle) }
+    var downloadJob by remember { mutableStateOf<Job?>(null) }
     var installError by remember { mutableStateOf<String?>(null) }
     var installerSelectionError by remember { mutableStateOf<String?>(null) }
 
@@ -322,6 +324,7 @@ fun UpdaterScreen(
                 UpdateDownloadDialog(
                     currentVersion = result.currentVersion,
                     latestVersion = result.latestVersion,
+                    isNightly = result.isNightly,
                     notes = result.notes,
                     downloadState = downloadState,
                     isInstalling = isInstalling,
@@ -330,11 +333,16 @@ fun UpdaterScreen(
                     onDownload = {
                         downloadState = UpdateChecker.DownloadState.Downloading(0f)
                         installError = null
-                        scope.launch {
+                        downloadJob = scope.launch {
                             UpdateChecker.downloadUpdate(context, result.isNightly).collectLatest { state ->
                                 downloadState = state
                             }
                         }
+                    },
+                    onCancelDownload = {
+                        downloadJob?.cancel()
+                        downloadJob = null
+                        downloadState = UpdateChecker.DownloadState.Idle
                     },
                     onInstall = { apk -> installWithPermissionCheck(apk) },
                     onDismiss = {

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt
@@ -62,6 +62,7 @@ import com.jtech.zemer.utils.updater.InstallerType
 import com.jtech.zemer.utils.updater.rememberApkInstallController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -341,9 +342,14 @@ fun UpdaterScreen(
                         }
                     },
                     onCancelDownload = {
-                        downloadJob?.cancel()
+                        // Wait for the cancelled download's cleanup before returning to Idle, so a
+                        // retry starts clean (the download writes a unique part file per run).
+                        val job = downloadJob
                         downloadJob = null
-                        downloadState = UpdateChecker.DownloadState.Idle
+                        scope.launch {
+                            job?.cancelAndJoin()
+                            downloadState = UpdateChecker.DownloadState.Idle
+                        }
                     },
                     onInstall = { apk -> installWithPermissionCheck(apk) },
                     onDismiss = {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.jtech.zemer.BuildConfig
 import com.jtech.zemer.utils.updater.NightlyUpdates
 import io.ktor.client.*
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -24,6 +25,16 @@ object UpdateChecker {
     private const val DOWNLOAD_URL = "https://ghtrack.zemer.io/download"
     private const val APK_FILENAME = "zemer-update.apk"
     private const val NIGHTLY_ZIP_FILENAME = "zemer-nightly.zip"
+
+    /**
+     * The client for the APK/artifact body download. CIO's default caps a WHOLE request at 15 s,
+     * which a ~10 MB download over a slow mobile or filtered link cannot meet ("Request timeout
+     * has expired" on the update dialog), so the request timeout is disabled here; connect
+     * failures still surface through the engine's connect timeout.
+     */
+    internal fun downloadHttpClient(): HttpClient = HttpClient(CIO) {
+        engine { requestTimeout = 0 }
+    }
 
     sealed class UpdateResult {
         data class UpdateAvailable(
@@ -162,7 +173,7 @@ object UpdateChecker {
         emit(DownloadState.Downloading(0f))
 
         try {
-            val httpClient = HttpClient()
+            val httpClient = downloadHttpClient()
 
             val response = httpClient
                 .prepareGet(if (nightly) NightlyUpdates.DOWNLOAD_URL else DOWNLOAD_URL)

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -195,12 +195,14 @@ object UpdateChecker {
         emit(DownloadState.Downloading(0f))
 
         val apkFile = File(context.cacheDir, APK_FILENAME)
-        // Each run streams into its OWN uniquely-named part file, never a shared fixed path. So a
-        // cancelled download (whose cleanup deletes only its part file) can never unlink the file
-        // a concurrent retry is writing, and a failed run never leaves the final apk behind - the
-        // finalized apkFile appears only on success. (The cancel-then-retry corruption fix.)
-        val partFile = File(context.cacheDir, "$APK_FILENAME.${System.nanoTime()}.part")
+        // Each run streams into its OWN atomically-created, guaranteed-unique part file, never a
+        // shared fixed path. So a cancelled download (whose cleanup deletes only its part file) can
+        // never unlink the file a concurrent retry is writing, and a failed run never leaves the
+        // final apk behind - the finalized apkFile appears only on success. (The cancel-then-retry
+        // corruption fix.) The nullable ref lets the finally clean up even if creation threw.
+        var partFile: File? = null
         try {
+            val part = File.createTempFile(APK_FILENAME, ".part", context.cacheDir).also { partFile = it }
             downloadHttpClient().use { httpClient ->
                 // The block form STREAMS the body. The no-block `execute()` loads the whole body
                 // into memory before returning, which made the progress loop run after the real
@@ -227,7 +229,7 @@ object UpdateChecker {
                         var downloadedBytes = 0L
                         var lastEmittedBytes = 0L
 
-                        partFile.outputStream().use { output ->
+                        part.outputStream().use { output ->
                             val buffer = ByteArray(8192)
                             while (!channel.isClosedForRead) {
                                 val bytesRead = channel.readAvailable(buffer)
@@ -246,12 +248,19 @@ object UpdateChecker {
                         emit(downloadingState(downloadedBytes, contentLength))
                     }
             }
-            // Finalize into apkFile only after a fully-read body: a nightly extracts its APK from
-            // the part (a zip), a stable moves the part into place, replacing any stale apk.
+            // Finalize into apkFile only after a fully-read body, and only via an atomic move so a
+            // failure never leaves a partial apk: a nightly extracts its APK into a temp file first,
+            // a stable moves its part directly. Either way apkFile is replaced in one step.
             if (nightly) {
-                NightlyUpdates.extractApk(partFile, apkFile)
+                val extractedApk = File.createTempFile(APK_FILENAME, ".extracted", context.cacheDir)
+                try {
+                    NightlyUpdates.extractApk(part, extractedApk)
+                    Files.move(extractedApk.toPath(), apkFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                } finally {
+                    extractedApk.delete()
+                }
             } else {
-                Files.move(partFile.toPath(), apkFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                Files.move(part.toPath(), apkFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             }
             emit(DownloadState.Downloaded(apkFile))
         } catch (e: CancellationException) {
@@ -262,7 +271,7 @@ object UpdateChecker {
         } finally {
             // Always drop this run's part file (a no-op after a successful stable move). Never
             // touches apkFile, so a cancelled run cannot delete a concurrent retry's result.
-            partFile.delete()
+            partFile?.delete()
         }
     }.flowOn(Dispatchers.IO)
 

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -30,14 +30,22 @@ object UpdateChecker {
     private const val APK_FILENAME = "zemer-update.apk"
     private const val NIGHTLY_ZIP_FILENAME = "zemer-nightly.zip"
 
+    /** Inactivity bound on the download: a connection that sends nothing for this long fails. */
+    internal const val DOWNLOAD_IDLE_TIMEOUT_MS = 60_000L
+
     /**
      * The client for the APK/artifact body download. CIO's default caps a WHOLE request at 15 s,
      * which a ~10 MB download over a slow mobile or filtered link cannot meet ("Request timeout
-     * has expired" on the update dialog), so the request timeout is disabled here; connect
-     * failures still surface through the engine's connect timeout.
+     * has expired" on the update dialog), so the request timeout is disabled. The bound that
+     * remains is per-packet inactivity ([idleTimeoutMs], CIO's `socketTimeout`, infinite by
+     * default): a slow transfer that keeps delivering bytes runs to completion, while a server
+     * that accepts the connection and then goes silent fails as a timeout instead of hanging.
      */
-    internal fun downloadHttpClient(): HttpClient = HttpClient(CIO) {
-        engine { requestTimeout = 0 }
+    internal fun downloadHttpClient(idleTimeoutMs: Long = DOWNLOAD_IDLE_TIMEOUT_MS): HttpClient = HttpClient(CIO) {
+        engine {
+            requestTimeout = 0
+            endpoint.socketTimeout = idleTimeoutMs
+        }
     }
 
     sealed class UpdateResult {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -56,6 +56,9 @@ object UpdateChecker {
             // Tags the result with its channel so the download uses the source this result came
             // from, even if the nightly preference is toggled between check and download.
             val isNightly: Boolean = false,
+            // The nightly user's forced way back to stable: the version may equal the installed
+            // one (nightlies share the stable versionName), so the dialog labels the channel.
+            val isReturnToStable: Boolean = false,
         ) : UpdateResult()
         data class UpToDate(val currentVersion: String) : UpdateResult()
         data class Error(val message: String) : UpdateResult()
@@ -180,6 +183,7 @@ object UpdateChecker {
                         currentVersion
                     },
                     notes = notes,
+                    isReturnToStable = force,
                 )
             } else {
                 httpClient.close()

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -22,13 +22,15 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import timber.log.Timber
 import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 object UpdateChecker {
     private const val API_URL = "https://ghtrack.zemer.io/api"
     private const val CHANGELOG_URL = "https://ghtrack.zemer.io/changelog"
     private const val DOWNLOAD_URL = "https://ghtrack.zemer.io/download"
     private const val APK_FILENAME = "zemer-update.apk"
-    private const val NIGHTLY_ZIP_FILENAME = "zemer-nightly.zip"
 
     /** Inactivity bound on the download: a connection that sends nothing for this long fails. */
     internal const val DOWNLOAD_IDLE_TIMEOUT_MS = 60_000L
@@ -147,47 +149,42 @@ object UpdateChecker {
 
     private suspend fun checkForStableUpdate(force: Boolean = false): UpdateResult {
         return try {
-            val httpClient = HttpClient()
-            val response = httpClient.get(API_URL)
-            val responseText = response.bodyAsText()
+            // `use` closes the client on every exit path (early return, throw), fixing the leak
+            // the old manual close() calls left when an exception was thrown mid-check.
+            HttpClient().use { httpClient ->
+                val responseText = httpClient.get(API_URL).bodyAsText()
 
-            val json = Json.parseToJsonElement(responseText)
-            val latestVersionRaw = json.jsonObject["latestVersion"]?.jsonPrimitive?.content
-                ?: run {
-                    httpClient.close()
-                    return UpdateResult.Error("Invalid API response")
+                val json = Json.parseToJsonElement(responseText)
+                val latestVersionRaw = json.jsonObject["latestVersion"]?.jsonPrimitive?.content
+                    ?: return UpdateResult.Error("Invalid API response")
+
+                // Strip "v" prefix if present (API returns "v4", app version is "4")
+                val latestVersion = latestVersionRaw.removePrefix("v").removePrefix("V")
+                val currentVersion = BuildConfig.VERSION_NAME
+
+                if (force || isNewerVersion(latestVersion, currentVersion)) {
+                    // Fetch changelog notes; a failed fetch must not block the update.
+                    val notes = try {
+                        val changelogText = httpClient.get(CHANGELOG_URL).bodyAsText()
+                        Json.parseToJsonElement(changelogText).jsonObject["notes"]?.jsonPrimitive?.content
+                    } catch (e: Exception) {
+                        null
+                    }
+                    UpdateResult.UpdateAvailable(
+                        latestVersion = latestVersion,
+                        // A forced download is the nightly user's return path — show which build
+                        // they are leaving by labelling the current version with its commit.
+                        currentVersion = if (force) {
+                            NightlyUpdates.currentVersionLabel(currentVersion, BuildConfig.COMMIT_HASH)
+                        } else {
+                            currentVersion
+                        },
+                        notes = notes,
+                        isReturnToStable = force,
+                    )
+                } else {
+                    UpdateResult.UpToDate(currentVersion)
                 }
-
-            // Strip "v" prefix if present (API returns "v4", app version is "4")
-            val latestVersion = latestVersionRaw.removePrefix("v").removePrefix("V")
-            val currentVersion = BuildConfig.VERSION_NAME
-
-            if (force || isNewerVersion(latestVersion, currentVersion)) {
-                // Fetch changelog notes
-                val notes = try {
-                    val changelogResponse = httpClient.get(CHANGELOG_URL)
-                    val changelogText = changelogResponse.bodyAsText()
-                    val changelogJson = Json.parseToJsonElement(changelogText)
-                    changelogJson.jsonObject["notes"]?.jsonPrimitive?.content
-                } catch (e: Exception) {
-                    null
-                }
-                httpClient.close()
-                UpdateResult.UpdateAvailable(
-                    latestVersion = latestVersion,
-                    // A forced download is the nightly user's return path — show which build
-                    // they are leaving by labelling the current version with its commit.
-                    currentVersion = if (force) {
-                        NightlyUpdates.currentVersionLabel(currentVersion, BuildConfig.COMMIT_HASH)
-                    } else {
-                        currentVersion
-                    },
-                    notes = notes,
-                    isReturnToStable = force,
-                )
-            } else {
-                httpClient.close()
-                UpdateResult.UpToDate(currentVersion)
             }
         } catch (e: Exception) {
             UpdateResult.Error(e.message ?: "Failed to check for updates")
@@ -198,8 +195,11 @@ object UpdateChecker {
         emit(DownloadState.Downloading(0f))
 
         val apkFile = File(context.cacheDir, APK_FILENAME)
-        // A nightly arrives as the artifact zip; the APK is extracted from it afterwards.
-        val targetFile = if (nightly) File(context.cacheDir, NIGHTLY_ZIP_FILENAME) else apkFile
+        // Each run streams into its OWN uniquely-named part file, never a shared fixed path. So a
+        // cancelled download (whose cleanup deletes only its part file) can never unlink the file
+        // a concurrent retry is writing, and a failed run never leaves the final apk behind - the
+        // finalized apkFile appears only on success. (The cancel-then-retry corruption fix.)
+        val partFile = File(context.cacheDir, "$APK_FILENAME.${System.nanoTime()}.part")
         try {
             downloadHttpClient().use { httpClient ->
                 // The block form STREAMS the body. The no-block `execute()` loads the whole body
@@ -208,6 +208,12 @@ object UpdateChecker {
                 httpClient
                     .prepareGet(if (nightly) NightlyUpdates.DOWNLOAD_URL else DOWNLOAD_URL)
                     .execute { response ->
+                        // The client does not validate status (expectSuccess is default-false), so a
+                        // 4xx/5xx would otherwise be written and offered for install as an error
+                        // document. Reject it as a network failure instead.
+                        if (!response.status.isSuccess()) {
+                            throw IOException("Update download failed: HTTP ${response.status.value}")
+                        }
                         // Size of the actual body we'll read, taken after redirects. A separate HEAD
                         // is unreliable here: /download redirects through a worker + CDN, so a HEAD can
                         // be answered by a different hop (e.g. a challenge page) whose Content-Length is
@@ -217,14 +223,11 @@ object UpdateChecker {
                         val isEncoded = response.headers[HttpHeaders.ContentEncoding]?.isNotBlank() == true
                         val contentLength = if (isEncoded) -1L else response.contentLength() ?: -1L
 
-                        if (apkFile.exists()) apkFile.delete()
-                        if (nightly && targetFile.exists()) targetFile.delete()
-
                         val channel = response.bodyAsChannel()
                         var downloadedBytes = 0L
                         var lastEmittedBytes = 0L
 
-                        targetFile.outputStream().use { output ->
+                        partFile.outputStream().use { output ->
                             val buffer = ByteArray(8192)
                             while (!channel.isClosedForRead) {
                                 val bytesRead = channel.readAvailable(buffer)
@@ -243,18 +246,23 @@ object UpdateChecker {
                         emit(downloadingState(downloadedBytes, contentLength))
                     }
             }
+            // Finalize into apkFile only after a fully-read body: a nightly extracts its APK from
+            // the part (a zip), a stable moves the part into place, replacing any stale apk.
             if (nightly) {
-                NightlyUpdates.extractApk(targetFile, apkFile)
-                targetFile.delete()
+                NightlyUpdates.extractApk(partFile, apkFile)
+            } else {
+                Files.move(partFile.toPath(), apkFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             }
             emit(DownloadState.Downloaded(apkFile))
         } catch (e: CancellationException) {
-            // A user cancel: drop the partial file and let the caller's cancellation propagate.
-            targetFile.delete()
-            throw e
+            throw e // cleanup runs in finally; propagate the cancel
         } catch (e: Exception) {
             Timber.w(e, "Update download failed")
             emit(DownloadState.Error(e.message ?: "Download failed", classifyUpdateDownloadFailure(e)))
+        } finally {
+            // Always drop this run's part file (a no-op after a successful stable move). Never
+            // touches apkFile, so a cancelled run cannot delete a concurrent retry's result.
+            partFile.delete()
         }
     }.flowOn(Dispatchers.IO)
 

--- a/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt
@@ -3,12 +3,15 @@ package com.jtech.zemer.utils
 import android.content.Context
 import com.jtech.zemer.BuildConfig
 import com.jtech.zemer.utils.updater.NightlyUpdates
+import com.jtech.zemer.utils.updater.UpdateDownloadFailure
+import com.jtech.zemer.utils.updater.classifyUpdateDownloadFailure
 import io.ktor.client.*
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -17,6 +20,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import timber.log.Timber
 import java.io.File
 
 object UpdateChecker {
@@ -54,9 +58,18 @@ object UpdateChecker {
 
     sealed class DownloadState {
         data object Idle : DownloadState()
-        data class Downloading(val progress: Float) : DownloadState()
+        /** [progress] is -1 when the total is unknown; byte counts feed the "x of y" label. */
+        data class Downloading(
+            val progress: Float,
+            val downloadedBytes: Long = 0L,
+            val totalBytes: Long = -1L,
+        ) : DownloadState()
         data class Downloaded(val apkFile: File) : DownloadState()
-        data class Error(val message: String) : DownloadState()
+        /** [message] is the raw detail for logs; the dialog renders [failure]. */
+        data class Error(
+            val message: String,
+            val failure: UpdateDownloadFailure = UpdateDownloadFailure.UNKNOWN,
+        ) : DownloadState()
     }
 
     suspend fun checkForUpdates(nightly: Boolean = false): UpdateResult = withContext(Dispatchers.IO) {
@@ -107,7 +120,7 @@ object UpdateChecker {
                     UpdateResult.UpdateAvailable(
                         latestVersion = NightlyUpdates.versionLabel(run),
                         currentVersion = currentVersion,
-                        notes = run.commitTitle,
+                        notes = run.commitTitle?.let(NightlyUpdates::commitMessageMarkdown),
                         isNightly = true,
                     )
                 }
@@ -172,65 +185,78 @@ object UpdateChecker {
     fun downloadUpdate(context: Context, nightly: Boolean = false): Flow<DownloadState> = flow {
         emit(DownloadState.Downloading(0f))
 
+        val apkFile = File(context.cacheDir, APK_FILENAME)
+        // A nightly arrives as the artifact zip; the APK is extracted from it afterwards.
+        val targetFile = if (nightly) File(context.cacheDir, NIGHTLY_ZIP_FILENAME) else apkFile
         try {
-            val httpClient = downloadHttpClient()
+            downloadHttpClient().use { httpClient ->
+                // The block form STREAMS the body. The no-block `execute()` loads the whole body
+                // into memory before returning, which made the progress loop run after the real
+                // download had already finished - the bar jumped 0 -> 100 with nothing between.
+                httpClient
+                    .prepareGet(if (nightly) NightlyUpdates.DOWNLOAD_URL else DOWNLOAD_URL)
+                    .execute { response ->
+                        // Size of the actual body we'll read, taken after redirects. A separate HEAD
+                        // is unreliable here: /download redirects through a worker + CDN, so a HEAD can
+                        // be answered by a different hop (e.g. a challenge page) whose Content-Length is
+                        // not the APK's, which would make the progress bar scale to the wrong total.
+                        // If the body is gzip-encoded the header is the compressed size and won't match
+                        // the decoded bytes we count, so treat that as unknown.
+                        val isEncoded = response.headers[HttpHeaders.ContentEncoding]?.isNotBlank() == true
+                        val contentLength = if (isEncoded) -1L else response.contentLength() ?: -1L
 
-            val response = httpClient
-                .prepareGet(if (nightly) NightlyUpdates.DOWNLOAD_URL else DOWNLOAD_URL)
-                .execute()
+                        if (apkFile.exists()) apkFile.delete()
+                        if (nightly && targetFile.exists()) targetFile.delete()
 
-            // Size of the actual body we'll read, taken after redirects. A separate HEAD
-            // is unreliable here: /download redirects through a worker + CDN, so a HEAD can
-            // be answered by a different hop (e.g. a challenge page) whose Content-Length is
-            // not the APK's, which would make the progress bar scale to the wrong total.
-            // If the body is gzip-encoded the header is the compressed size and won't match
-            // the decoded bytes we count, so treat that as unknown.
-            val isEncoded = response.headers[HttpHeaders.ContentEncoding]?.isNotBlank() == true
-            val contentLength = if (isEncoded) -1L else response.contentLength() ?: -1L
+                        val channel = response.bodyAsChannel()
+                        var downloadedBytes = 0L
+                        var lastEmittedBytes = 0L
 
-            val apkFile = File(context.cacheDir, APK_FILENAME)
-            // A nightly arrives as the artifact zip; the APK is extracted from it afterwards.
-            val targetFile = if (nightly) File(context.cacheDir, NIGHTLY_ZIP_FILENAME) else apkFile
-
-            // Delete existing files if present
-            if (apkFile.exists()) {
-                apkFile.delete()
-            }
-            if (nightly && targetFile.exists()) {
-                targetFile.delete()
-            }
-
-            val channel = response.bodyAsChannel()
-            var downloadedBytes = 0L
-
-            targetFile.outputStream().use { output ->
-                val buffer = ByteArray(8192)
-                while (!channel.isClosedForRead) {
-                    val bytesRead = channel.readAvailable(buffer)
-                    if (bytesRead > 0) {
-                        output.write(buffer, 0, bytesRead)
-                        downloadedBytes += bytesRead
-
-                        val progress = if (contentLength > 0) {
-                            (downloadedBytes.toFloat() / contentLength.toFloat()).coerceIn(0f, 1f)
-                        } else {
-                            -1f // Indeterminate
+                        targetFile.outputStream().use { output ->
+                            val buffer = ByteArray(8192)
+                            while (!channel.isClosedForRead) {
+                                val bytesRead = channel.readAvailable(buffer)
+                                if (bytesRead > 0) {
+                                    output.write(buffer, 0, bytesRead)
+                                    downloadedBytes += bytesRead
+                                    // Emit per ~128 KB, not per 8 KB chunk, so a 10 MB download
+                                    // doesn't drive a thousand recompositions.
+                                    if (downloadedBytes - lastEmittedBytes >= PROGRESS_EMIT_BYTES) {
+                                        lastEmittedBytes = downloadedBytes
+                                        emit(downloadingState(downloadedBytes, contentLength))
+                                    }
+                                }
+                            }
                         }
-                        emit(DownloadState.Downloading(progress))
+                        emit(downloadingState(downloadedBytes, contentLength))
                     }
-                }
             }
-
-            httpClient.close()
             if (nightly) {
                 NightlyUpdates.extractApk(targetFile, apkFile)
                 targetFile.delete()
             }
             emit(DownloadState.Downloaded(apkFile))
+        } catch (e: CancellationException) {
+            // A user cancel: drop the partial file and let the caller's cancellation propagate.
+            targetFile.delete()
+            throw e
         } catch (e: Exception) {
-            emit(DownloadState.Error(e.message ?: "Download failed"))
+            Timber.w(e, "Update download failed")
+            emit(DownloadState.Error(e.message ?: "Download failed", classifyUpdateDownloadFailure(e)))
         }
     }.flowOn(Dispatchers.IO)
+
+    private const val PROGRESS_EMIT_BYTES = 128L * 1024
+
+    private fun downloadingState(downloadedBytes: Long, contentLength: Long) = DownloadState.Downloading(
+        progress = if (contentLength > 0) {
+            (downloadedBytes.toFloat() / contentLength.toFloat()).coerceIn(0f, 1f)
+        } else {
+            -1f // Indeterminate
+        },
+        downloadedBytes = downloadedBytes,
+        totalBytes = contentLength,
+    )
 
     private fun isNewerVersion(latest: String, current: String): Boolean {
         try {

--- a/app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt
@@ -1,0 +1,155 @@
+package com.jtech.zemer.utils.markdown
+
+/** An inline run inside a [MarkdownBlock]. */
+sealed interface MarkdownInline {
+    data class Text(val text: String) : MarkdownInline
+    data class Bold(val text: String) : MarkdownInline
+    data class Italic(val text: String) : MarkdownInline
+    data class Code(val text: String) : MarkdownInline
+    data class Link(val text: String, val href: String) : MarkdownInline
+}
+
+/** A block-level element. Lists are flattened to items; nesting is not modelled. */
+sealed interface MarkdownBlock {
+    data class Heading(val level: Int, val inlines: List<MarkdownInline>) : MarkdownBlock
+    data class Paragraph(val inlines: List<MarkdownInline>) : MarkdownBlock
+    data class ListItem(val ordinal: Int?, val inlines: List<MarkdownInline>) : MarkdownBlock
+}
+
+/**
+ * The subset of Markdown that release notes and commit messages actually use: ATX headings,
+ * bullet / numbered lists, paragraphs (single newlines are soft breaks and join with a space, so a
+ * hard-wrapped commit body reflows), `**bold**`, `*italic*` / `_italic_` at word boundaries,
+ * `` `code` ``, `[text](url)` and bare `http(s)://` links. Anything else is literal text - the
+ * parser never drops characters it does not understand.
+ */
+object LiteMarkdown {
+    private val HEADING = Regex("^(#{1,6})\\s+(.*)$")
+    private val BULLET = Regex("^\\s{0,3}[-*+]\\s+(.*)$")
+    private val ORDERED = Regex("^\\s{0,3}(\\d{1,3})[.)]\\s+(.*)$")
+    private val LINK = Regex("^\\[([^\\]]+)]\\(([^)\\s]+)\\)")
+    private val AUTOLINK = Regex("^https?://[^\\s<>]+")
+    private const val TRAILING_PUNCTUATION = ".,;:!?)]'\""
+
+    fun parse(text: String): List<MarkdownBlock> {
+        val blocks = mutableListOf<MarkdownBlock>()
+        val paragraph = StringBuilder()
+        var listOrdinal: Int? = null
+        val listText = StringBuilder()
+        var inList = false
+
+        fun flushParagraph() {
+            if (paragraph.isNotBlank()) blocks += MarkdownBlock.Paragraph(parseInlines(paragraph.toString()))
+            paragraph.clear()
+        }
+
+        fun flushList() {
+            if (inList) blocks += MarkdownBlock.ListItem(listOrdinal, parseInlines(listText.toString()))
+            inList = false
+            listOrdinal = null
+            listText.clear()
+        }
+
+        for (raw in text.lines()) {
+            val line = raw.trimEnd()
+            if (line.isBlank()) {
+                flushParagraph()
+                flushList()
+                continue
+            }
+            val heading = HEADING.matchEntire(line)
+            if (heading != null) {
+                flushParagraph()
+                flushList()
+                blocks += MarkdownBlock.Heading(
+                    level = heading.groupValues[1].length,
+                    inlines = parseInlines(heading.groupValues[2].trim()),
+                )
+                continue
+            }
+            val bullet = BULLET.matchEntire(line)
+            val ordered = if (bullet == null) ORDERED.matchEntire(line) else null
+            if (bullet != null || ordered != null) {
+                flushParagraph()
+                flushList()
+                inList = true
+                listOrdinal = ordered?.groupValues?.get(1)?.toInt()
+                listText.append((bullet ?: ordered)!!.groupValues.last().trim())
+                continue
+            }
+            // A plain line continues whatever is open (lazy continuation), joined by a soft break.
+            val target = if (inList) listText else paragraph
+            if (target.isNotEmpty()) target.append(' ')
+            target.append(line.trim())
+        }
+        flushParagraph()
+        flushList()
+        return blocks
+    }
+
+    fun parseInlines(text: String): List<MarkdownInline> {
+        val out = mutableListOf<MarkdownInline>()
+        val plain = StringBuilder()
+
+        fun flushPlain() {
+            if (plain.isNotEmpty()) out += MarkdownInline.Text(plain.toString())
+            plain.clear()
+        }
+
+        var i = 0
+        while (i < text.length) {
+            val rest = text.substring(i)
+            val c = text[i]
+            val consumed: Int = when {
+                c == '`' -> spanned(rest, "`", "`")?.let { (body, len) ->
+                    flushPlain(); out += MarkdownInline.Code(body); len
+                } ?: 0
+                rest.startsWith("**") -> spanned(rest, "**", "**")?.let { (body, len) ->
+                    flushPlain(); out += MarkdownInline.Bold(body); len
+                } ?: 0
+                rest.startsWith("__") && atWordStart(text, i) -> spanned(rest, "__", "__")
+                    ?.takeIf { atWordEnd(text, i + it.second) }
+                    ?.let { (body, len) -> flushPlain(); out += MarkdownInline.Bold(body); len } ?: 0
+                c == '*' -> spanned(rest, "*", "*")?.let { (body, len) ->
+                    flushPlain(); out += MarkdownInline.Italic(body); len
+                } ?: 0
+                c == '_' && atWordStart(text, i) -> spanned(rest, "_", "_")
+                    ?.takeIf { atWordEnd(text, i + it.second) }
+                    ?.let { (body, len) -> flushPlain(); out += MarkdownInline.Italic(body); len } ?: 0
+                c == '[' -> LINK.find(rest)?.let { m ->
+                    flushPlain(); out += MarkdownInline.Link(m.groupValues[1], m.groupValues[2]); m.value.length
+                } ?: 0
+                c == 'h' && (rest.startsWith("http://") || rest.startsWith("https://")) ->
+                    AUTOLINK.find(rest)?.let { m ->
+                        val url = m.value.trimEnd { it in TRAILING_PUNCTUATION }
+                        flushPlain(); out += MarkdownInline.Link(url, url); url.length
+                    } ?: 0
+                else -> 0
+            }
+            if (consumed > 0) {
+                i += consumed
+            } else {
+                plain.append(c)
+                i++
+            }
+        }
+        flushPlain()
+        return out
+    }
+
+    /** Body + total consumed length for `open…close` at the start of [s]; null when unbalanced/empty. */
+    private fun spanned(s: String, open: String, close: String): Pair<String, Int>? {
+        if (!s.startsWith(open)) return null
+        val end = s.indexOf(close, startIndex = open.length)
+        if (end <= open.length) return null
+        val body = s.substring(open.length, end)
+        if (body.first().isWhitespace() || body.last().isWhitespace()) return null
+        return body to end + close.length
+    }
+
+    private fun atWordStart(text: String, index: Int): Boolean =
+        index == 0 || !text[index - 1].isLetterOrDigit()
+
+    private fun atWordEnd(text: String, index: Int): Boolean =
+        index >= text.length || !text[index].isLetterOrDigit()
+}

--- a/app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt
@@ -27,9 +27,11 @@ object LiteMarkdown {
     private val HEADING = Regex("^(#{1,6})\\s+(.*)$")
     private val BULLET = Regex("^\\s{0,3}[-*+]\\s+(.*)$")
     private val ORDERED = Regex("^\\s{0,3}(\\d{1,3})[.)]\\s+(.*)$")
-    private val LINK = Regex("^\\[([^\\]]+)]\\(([^)\\s]+)\\)")
+    private val LINK_HEAD = Regex("^\\[([^\\]]+)]\\(")
     private val AUTOLINK = Regex("^https?://[^\\s<>]+")
-    private const val TRAILING_PUNCTUATION = ".,;:!?)]'\""
+    // Trailing punctuation stripped from a bare URL. ')' is handled separately, by balance, so a
+    // link whose own path contains a matched '(' keeps its closing ')'.
+    private const val TRAILING_PUNCTUATION = ".,;:!?]'\""
 
     fun parse(text: String): List<MarkdownBlock> {
         val blocks = mutableListOf<MarkdownBlock>()
@@ -116,12 +118,16 @@ object LiteMarkdown {
                 c == '_' && atWordStart(text, i) -> spanned(rest, "_", "_")
                     ?.takeIf { atWordEnd(text, i + it.second) }
                     ?.let { (body, len) -> flushPlain(); out += MarkdownInline.Italic(body); len } ?: 0
-                c == '[' -> LINK.find(rest)?.let { m ->
-                    flushPlain(); out += MarkdownInline.Link(m.groupValues[1], m.groupValues[2]); m.value.length
+                c == '[' -> LINK_HEAD.find(rest)?.let { m ->
+                    val head = m.value.length
+                    balancedTarget(rest, head)?.let { target ->
+                        flushPlain(); out += MarkdownInline.Link(m.groupValues[1], target)
+                        head + target.length + 1 // + the closing ')'
+                    }
                 } ?: 0
                 c == 'h' && (rest.startsWith("http://") || rest.startsWith("https://")) ->
                     AUTOLINK.find(rest)?.let { m ->
-                        val url = m.value.trimEnd { it in TRAILING_PUNCTUATION }
+                        val url = trimAutolink(m.value)
                         flushPlain(); out += MarkdownInline.Link(url, url); url.length
                     } ?: 0
                 else -> 0
@@ -135,6 +141,44 @@ object LiteMarkdown {
         }
         flushPlain()
         return out
+    }
+
+    /**
+     * Reads an explicit link target `(...)` starting at [start], honoring nested parentheses so a
+     * URL like `.../Function_(mathematics)` keeps its inner pair. Returns the target (without the
+     * closing paren) or null when the parens are unbalanced or a space/newline appears first.
+     */
+    private fun balancedTarget(s: String, start: Int): String? {
+        var depth = 0
+        var i = start
+        while (i < s.length) {
+            when (val ch = s[i]) {
+                '(' -> depth++
+                ')' -> if (depth == 0) return s.substring(start, i) else depth--
+                else -> if (ch.isWhitespace()) return null
+            }
+            i++
+        }
+        return null
+    }
+
+    /**
+     * Trims trailing punctuation from a bare URL. A closing `)` is dropped only when it is
+     * unbalanced (more `)` than `(`), so `.../Function_(mathematics)` is preserved while a URL that
+     * merely ends a sentence in parentheses, like `(see https://x)`, is not over-consumed.
+     */
+    private fun trimAutolink(raw: String): String {
+        var url = raw
+        while (url.isNotEmpty()) {
+            val last = url.last()
+            val strip = when {
+                last == ')' -> url.count { it == '(' } < url.count { it == ')' }
+                last in TRAILING_PUNCTUATION -> true
+                else -> false
+            }
+            if (strip) url = url.dropLast(1) else break
+        }
+        return url
     }
 
     /** Body + total consumed length for `open…close` at the start of [s]; null when unbalanced/empty. */

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
@@ -109,7 +109,7 @@ object NightlyUpdates {
         ZipFile(zip).use { archive ->
             val entry = archive.entries().asSequence()
                 .firstOrNull { !it.isDirectory && it.name.endsWith(".apk") }
-                ?: error("No APK found in the nightly archive")
+                ?: throw CorruptUpdateArtifactException("No APK found in the nightly archive")
             archive.getInputStream(entry).use { input ->
                 destination.outputStream().use { output -> input.copyTo(output) }
             }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt
@@ -51,6 +51,17 @@ object NightlyUpdates {
 
     fun versionLabel(run: NightlyRun): String = "nightly #${run.runNumber} (${run.headSha.take(7)})"
 
+    /**
+     * Formats a commit message as the nightly's release notes: the subject line becomes a heading
+     * and the body follows as Markdown (hard-wrapped lines reflow). Null for a blank message.
+     */
+    fun commitMessageMarkdown(message: String): String? {
+        val lines = message.trim().lines()
+        val title = lines.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val body = lines.drop(1).joinToString("\n").trim()
+        return if (body.isEmpty()) "### $title" else "### $title\n\n$body"
+    }
+
     fun currentVersionLabel(versionName: String, installedSha: String): String =
         if (installedSha.isBlank()) versionName else "$versionName (${installedSha.take(7)})"
 

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt
@@ -14,13 +14,22 @@ import javax.net.ssl.SSLException
  */
 enum class UpdateDownloadFailure { TIMEOUT, NETWORK, STORAGE, CORRUPT_ARTIFACT, UNKNOWN }
 
+/**
+ * The downloaded artifact was structurally unusable (e.g. the nightly zip held no APK). A
+ * dedicated type so the classifier can report [UpdateDownloadFailure.CORRUPT_ARTIFACT] without
+ * swallowing every unrelated [IllegalStateException] as a corrupt download.
+ */
+class CorruptUpdateArtifactException(message: String) : Exception(message)
+
 /** Classifies [error] by walking its cause chain; the most specific class wins. */
 fun classifyUpdateDownloadFailure(error: Throwable): UpdateDownloadFailure {
     val chain = generateSequence(error) { it.cause?.takeIf { cause -> cause !== it } }.take(8).toList()
     return when {
         chain.any { it.isTimeout() } -> UpdateDownloadFailure.TIMEOUT
         chain.any { it.isStorage() } -> UpdateDownloadFailure.STORAGE
-        chain.any { it is ZipException || it is IllegalStateException } -> UpdateDownloadFailure.CORRUPT_ARTIFACT
+        // A malformed zip or a zip with no APK entry - never a bare IllegalStateException, which
+        // is a common runtime type an unrelated failure would carry.
+        chain.any { it is ZipException || it is CorruptUpdateArtifactException } -> UpdateDownloadFailure.CORRUPT_ARTIFACT
         chain.any { it.isNetwork() } -> UpdateDownloadFailure.NETWORK
         else -> UpdateDownloadFailure.UNKNOWN
     }

--- a/app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt
@@ -1,0 +1,41 @@
+package com.jtech.zemer.utils.updater
+
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.zip.ZipException
+import javax.net.ssl.SSLException
+
+/**
+ * Why an update download failed, at the granularity the dialog can act on. The raw exception
+ * message (a Ktor timeout carries the full CDN URL) is logged, never shown.
+ */
+enum class UpdateDownloadFailure { TIMEOUT, NETWORK, STORAGE, CORRUPT_ARTIFACT, UNKNOWN }
+
+/** Classifies [error] by walking its cause chain; the most specific class wins. */
+fun classifyUpdateDownloadFailure(error: Throwable): UpdateDownloadFailure {
+    val chain = generateSequence(error) { it.cause?.takeIf { cause -> cause !== it } }.take(8).toList()
+    return when {
+        chain.any { it.isTimeout() } -> UpdateDownloadFailure.TIMEOUT
+        chain.any { it.isStorage() } -> UpdateDownloadFailure.STORAGE
+        chain.any { it is ZipException || it is IllegalStateException } -> UpdateDownloadFailure.CORRUPT_ARTIFACT
+        chain.any { it.isNetwork() } -> UpdateDownloadFailure.NETWORK
+        else -> UpdateDownloadFailure.UNKNOWN
+    }
+}
+
+private fun Throwable.isTimeout(): Boolean =
+    this is SocketTimeoutException ||
+        // Ktor's HttpRequestTimeoutException / ConnectTimeoutException / SocketTimeoutException,
+        // matched by name so this stays engine-agnostic.
+        this::class.simpleName?.contains("Timeout") == true
+
+private fun Throwable.isStorage(): Boolean =
+    this is FileNotFoundException ||
+        message?.contains("ENOSPC") == true ||
+        message?.contains("No space left", ignoreCase = true) == true
+
+private fun Throwable.isNetwork(): Boolean =
+    this is UnknownHostException || this is ConnectException || this is SSLException || this is IOException

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -220,7 +220,6 @@
     <string name="check_for_updates_now">Check for updates now</string>
     <string name="update_available_title">Update available</string>
     <string name="update_available">Update available</string>
-    <string name="update_available_message">You are on version %1$s. Version %2$s is available.</string>
     <string name="up_to_date">Up to date</string>
     <string name="up_to_date_message">You are running the latest version (%1$s).</string>
     <string name="update_channel_name">App updates</string>
@@ -228,7 +227,7 @@
     <string name="download_and_install">Download &amp; Install</string>
     <string name="downloading_update">Downloading update…</string>
     <string name="later">Later</string>
-    <string name="whats_new">What\'s new:</string>
+    <string name="whats_new">What\'s new</string>
     <string name="error">Error</string>
     <string name="installer_method">Installation method</string>
     <string name="installer_native_title">Standard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,4 +451,16 @@
     <string name="widget_name">Zemer Music</string>
     <string name="widget_description">Control your music playback</string>
     <string name="widget_tap_to_open">Tap to open</string>
+    <!-- Update dialog -->
+    <string name="update_installed_version">Installed</string>
+    <string name="update_new_version">New version</string>
+    <string name="percent_value">%1$d%%</string>
+    <string name="update_nightly_build">Nightly build</string>
+    <string name="update_download_progress">%1$s of %2$s</string>
+    <string name="update_download_progress_unsized">%1$s downloaded</string>
+    <string name="update_error_timeout">The download timed out. Check your connection and try again.</string>
+    <string name="update_error_network">Couldn\'t reach the update server. Check your connection and try again.</string>
+    <string name="update_error_storage">Not enough free storage to save the update.</string>
+    <string name="update_error_corrupt">The downloaded file was incomplete or damaged. Try again.</string>
+    <string name="update_error_unknown">The download failed. Try again.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,7 @@
     <string name="update_new_version">New version</string>
     <string name="percent_value">%1$d%%</string>
     <string name="update_nightly_build">Nightly build</string>
+    <string name="update_stable_release">Stable release</string>
     <string name="update_download_progress">%1$s of %2$s</string>
     <string name="update_download_progress_unsized">%1$s downloaded</string>
     <string name="update_error_timeout">The download timed out. Check your connection and try again.</string>

--- a/app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt
@@ -1,0 +1,29 @@
+package com.jtech.zemer.ui.component
+
+import com.jtech.zemer.utils.UpdateChecker.DownloadState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class UpdateDownloadDialogLogicTest {
+
+    @Test
+    fun `primary action follows the download and install state`() {
+        assertEquals(UpdateDialogAction.DOWNLOAD, updateDialogPrimaryAction(DownloadState.Idle, isInstalling = false))
+        assertEquals(UpdateDialogAction.CANCEL, updateDialogPrimaryAction(DownloadState.Downloading(0.4f), isInstalling = false))
+        assertEquals(UpdateDialogAction.INSTALL, updateDialogPrimaryAction(DownloadState.Downloaded(File("a.apk")), isInstalling = false))
+        assertEquals(UpdateDialogAction.RETRY, updateDialogPrimaryAction(DownloadState.Error("x"), isInstalling = false))
+    }
+
+    @Test
+    fun `installing offers no action regardless of download state`() {
+        assertEquals(UpdateDialogAction.NONE, updateDialogPrimaryAction(DownloadState.Downloaded(File("a.apk")), isInstalling = true))
+        assertEquals(UpdateDialogAction.NONE, updateDialogPrimaryAction(DownloadState.Error("x"), isInstalling = true))
+    }
+
+    @Test
+    fun `nightly value drops the redundant channel prefix, stable value is untouched`() {
+        assertEquals("#1215 (0f8e9f8)", updateVersionValue("nightly #1215 (0f8e9f8)", isNightly = true))
+        assertEquals("39", updateVersionValue("39", isNightly = false))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt
@@ -1,6 +1,7 @@
 package com.jtech.zemer.ui.component
 
 import com.jtech.zemer.utils.UpdateChecker.DownloadState
+import com.jtech.zemer.R
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.File
@@ -25,5 +26,12 @@ class UpdateDownloadDialogLogicTest {
     fun `nightly value drops the redundant channel prefix, stable value is untouched`() {
         assertEquals("#1215 (0f8e9f8)", updateVersionValue("nightly #1215 (0f8e9f8)", isNightly = true))
         assertEquals("39", updateVersionValue("39", isNightly = false))
+    }
+
+    @Test
+    fun `new-version label names the channel for nightly and return-to-stable`() {
+        assertEquals(R.string.update_nightly_build, updateNewVersionLabelRes(isNightly = true, isReturnToStable = false))
+        assertEquals(R.string.update_stable_release, updateNewVersionLabelRes(isNightly = false, isReturnToStable = true))
+        assertEquals(R.string.update_new_version, updateNewVersionLabelRes(isNightly = false, isReturnToStable = false))
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt
@@ -1,0 +1,15 @@
+package com.jtech.zemer.utils
+
+import io.ktor.client.engine.cio.CIOEngineConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UpdateCheckerDownloadClientTest {
+    @Test
+    fun `download client has no whole-request timeout`() {
+        UpdateChecker.downloadHttpClient().use { client ->
+            val config = client.engineConfig as CIOEngineConfig
+            assertEquals(0L, config.requestTimeout)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt
@@ -1,15 +1,66 @@
 package com.jtech.zemer.utils
 
+import com.jtech.zemer.utils.updater.UpdateDownloadFailure
+import com.jtech.zemer.utils.updater.classifyUpdateDownloadFailure
 import io.ktor.client.engine.cio.CIOEngineConfig
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
+import java.net.ServerSocket
+import kotlin.concurrent.thread
 
 class UpdateCheckerDownloadClientTest {
+
     @Test
-    fun `download client has no whole-request timeout`() {
+    fun `download client has no whole-request timeout but a bounded idle timeout`() {
         UpdateChecker.downloadHttpClient().use { client ->
             val config = client.engineConfig as CIOEngineConfig
             assertEquals(0L, config.requestTimeout)
+            assertEquals(UpdateChecker.DOWNLOAD_IDLE_TIMEOUT_MS, config.endpoint.socketTimeout)
+        }
+    }
+
+    /**
+     * A server that accepts the connection, sends complete headers with a body length, then never
+     * sends a byte. Without the idle bound this read would hang forever (the request timeout is
+     * disabled); with it the download fails as a TIMEOUT within the idle interval.
+     */
+    @Test
+    fun `an established connection that sends no body bytes fails as a timeout`() {
+        ServerSocket(0).use { server ->
+            val accepted = thread(isDaemon = true) {
+                runCatching {
+                    val socket = server.accept()
+                    socket.getOutputStream().apply {
+                        write("HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nContent-Type: application/zip\r\n\r\n".toByteArray())
+                        flush()
+                    }
+                    Thread.sleep(10_000) // hold the socket open, silent
+                    socket.close()
+                }
+            }
+            val started = System.currentTimeMillis()
+            val thrown: Throwable? = runCatching {
+                runBlocking {
+                    UpdateChecker.downloadHttpClient(idleTimeoutMs = 500).use { client ->
+                        client.prepareGet("http://127.0.0.1:${server.localPort}/stalled.zip").execute { response ->
+                            val channel = response.bodyAsChannel()
+                            val buffer = ByteArray(8192)
+                            while (!channel.isClosedForRead) channel.readAvailable(buffer)
+                        }
+                    }
+                }
+            }.exceptionOrNull()
+            if (thrown == null) fail("stalled body read did not fail")
+            val elapsed = System.currentTimeMillis() - started
+            assertTrue("failed after ${elapsed}ms, expected within the idle bound", elapsed < 8_000)
+            assertEquals(UpdateDownloadFailure.TIMEOUT, classifyUpdateDownloadFailure(thrown!!))
+            accepted.interrupt()
         }
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt
@@ -76,6 +76,26 @@ class LiteMarkdownTest {
     }
 
     @Test
+    fun `explicit link keeps balanced parentheses in the target`() {
+        assertEquals(
+            listOf(Text("see "), Link("wiki", "https://example.org/Function_(mathematics)")),
+            LiteMarkdown.parseInlines("see [wiki](https://example.org/Function_(mathematics))"),
+        )
+    }
+
+    @Test
+    fun `bare link keeps a balanced trailing paren but drops an unbalanced one`() {
+        assertEquals(
+            listOf(Link("https://example.org/Function_(mathematics)", "https://example.org/Function_(mathematics)")),
+            LiteMarkdown.parseInlines("https://example.org/Function_(mathematics)"),
+        )
+        assertEquals(
+            listOf(Text("(see "), Link("https://zemer.io/x", "https://zemer.io/x"), Text(")")),
+            LiteMarkdown.parseInlines("(see https://zemer.io/x)"),
+        )
+    }
+
+    @Test
     fun `underscores inside identifiers are literal`() {
         assertEquals(
             listOf(Text("renamed release_apk to release_zip")),

--- a/app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt
@@ -1,0 +1,94 @@
+package com.jtech.zemer.utils.markdown
+
+import com.jtech.zemer.utils.markdown.MarkdownBlock.Heading
+import com.jtech.zemer.utils.markdown.MarkdownBlock.ListItem
+import com.jtech.zemer.utils.markdown.MarkdownBlock.Paragraph
+import com.jtech.zemer.utils.markdown.MarkdownInline.Bold
+import com.jtech.zemer.utils.markdown.MarkdownInline.Code
+import com.jtech.zemer.utils.markdown.MarkdownInline.Italic
+import com.jtech.zemer.utils.markdown.MarkdownInline.Link
+import com.jtech.zemer.utils.markdown.MarkdownInline.Text
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LiteMarkdownTest {
+
+    @Test
+    fun `stable changelog bullet list parses to list items`() {
+        assertEquals(
+            listOf(ListItem(null, listOf(Text("Hotfix - podcasts")))),
+            LiteMarkdown.parse("- Hotfix - podcasts"),
+        )
+    }
+
+    @Test
+    fun `headings bullets and paragraphs separate correctly`() {
+        val blocks = LiteMarkdown.parse(
+            """
+            ## Release 39
+            First paragraph line one
+            line two continues.
+
+            * bullet a
+            2. numbered
+            """.trimIndent(),
+        )
+        assertEquals(
+            listOf(
+                Heading(2, listOf(Text("Release 39"))),
+                Paragraph(listOf(Text("First paragraph line one line two continues."))),
+                ListItem(null, listOf(Text("bullet a"))),
+                ListItem(2, listOf(Text("numbered"))),
+            ),
+            blocks,
+        )
+    }
+
+    @Test
+    fun `hard-wrapped commit body reflows and a wrapped bullet continues its item`() {
+        val blocks = LiteMarkdown.parse("- a bullet that wraps\n  onto the next line\n\nBody line\nwrapped.")
+        assertEquals(
+            listOf(
+                ListItem(null, listOf(Text("a bullet that wraps onto the next line"))),
+                Paragraph(listOf(Text("Body line wrapped."))),
+            ),
+            blocks,
+        )
+    }
+
+    @Test
+    fun `inline emphasis code and links`() {
+        assertEquals(
+            listOf(
+                Text("Use "), Code("StreamSabrKey"), Text(" with "), Bold("care"), Text(" and "),
+                Italic("taste"), Text(" see "), Link("docs", "https://zemer.io/d"), Text("."),
+            ),
+            LiteMarkdown.parseInlines("Use `StreamSabrKey` with **care** and *taste* see [docs](https://zemer.io/d)."),
+        )
+    }
+
+    @Test
+    fun `bare urls autolink without trailing punctuation`() {
+        assertEquals(
+            listOf(Text("See "), Link("https://zemer.io/x", "https://zemer.io/x"), Text(").")),
+            LiteMarkdown.parseInlines("See https://zemer.io/x)."),
+        )
+    }
+
+    @Test
+    fun `underscores inside identifiers are literal`() {
+        assertEquals(
+            listOf(Text("renamed release_apk to release_zip")),
+            LiteMarkdown.parseInlines("renamed release_apk to release_zip"),
+        )
+        assertEquals(
+            listOf(Text("an "), Italic("emphasised"), Text(" word")),
+            LiteMarkdown.parseInlines("an _emphasised_ word"),
+        )
+    }
+
+    @Test
+    fun `unbalanced markers stay literal so no text is lost`() {
+        assertEquals(listOf(Text("2 * 3 and a **dangling")), LiteMarkdown.parseInlines("2 * 3 and a **dangling"))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
@@ -185,4 +185,14 @@ class NightlyUpdatesTest {
             NightlyUpdates.buildGradleUrl("abc123"),
         )
     }
+
+    @Test
+    fun `commit message becomes a heading plus markdown body`() {
+        assertEquals(
+            "### fix(x): subject (#1)\n\nBody line one\nline two.\n\n- a bullet",
+            NightlyUpdates.commitMessageMarkdown("fix(x): subject (#1)\n\nBody line one\nline two.\n\n- a bullet\n"),
+        )
+        assertEquals("### subject only", NightlyUpdates.commitMessageMarkdown("subject only"))
+        assertNull(NightlyUpdates.commitMessageMarkdown("  \n "))
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt
@@ -126,6 +126,7 @@ class NightlyUpdatesTest {
         val result = runCatching { NightlyUpdates.extractApk(zip, destination) }
 
         assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is CorruptUpdateArtifactException)
     }
 
     @Test

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt
@@ -1,0 +1,48 @@
+package com.jtech.zemer.utils.updater
+
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.zip.ZipException
+
+class UpdateDownloadFailureTest {
+
+    @Test
+    fun `ktor request timeout is a timeout`() {
+        val e = HttpRequestTimeoutException("https://nightly.link/x", 15_000L)
+        assertEquals(UpdateDownloadFailure.TIMEOUT, classifyUpdateDownloadFailure(e))
+    }
+
+    @Test
+    fun `socket timeout wrapped in an io exception is a timeout`() {
+        val e = IOException("wrapped", SocketTimeoutException("read timed out"))
+        assertEquals(UpdateDownloadFailure.TIMEOUT, classifyUpdateDownloadFailure(e))
+    }
+
+    @Test
+    fun `dns and generic io failures are network`() {
+        assertEquals(UpdateDownloadFailure.NETWORK, classifyUpdateDownloadFailure(UnknownHostException("nightly.link")))
+        assertEquals(UpdateDownloadFailure.NETWORK, classifyUpdateDownloadFailure(IOException("connection reset")))
+    }
+
+    @Test
+    fun `full disk and missing cache dir are storage`() {
+        assertEquals(UpdateDownloadFailure.STORAGE, classifyUpdateDownloadFailure(IOException("write failed: ENOSPC (No space left on device)")))
+        assertEquals(UpdateDownloadFailure.STORAGE, classifyUpdateDownloadFailure(FileNotFoundException("/cache/zemer-update.apk")))
+    }
+
+    @Test
+    fun `broken artifact is corrupt`() {
+        assertEquals(UpdateDownloadFailure.CORRUPT_ARTIFACT, classifyUpdateDownloadFailure(ZipException("not a zip")))
+        assertEquals(UpdateDownloadFailure.CORRUPT_ARTIFACT, classifyUpdateDownloadFailure(IllegalStateException("No APK found in the nightly archive")))
+    }
+
+    @Test
+    fun `anything else is unknown`() {
+        assertEquals(UpdateDownloadFailure.UNKNOWN, classifyUpdateDownloadFailure(RuntimeException("?")))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt
@@ -38,7 +38,17 @@ class UpdateDownloadFailureTest {
     @Test
     fun `broken artifact is corrupt`() {
         assertEquals(UpdateDownloadFailure.CORRUPT_ARTIFACT, classifyUpdateDownloadFailure(ZipException("not a zip")))
-        assertEquals(UpdateDownloadFailure.CORRUPT_ARTIFACT, classifyUpdateDownloadFailure(IllegalStateException("No APK found in the nightly archive")))
+        assertEquals(
+            UpdateDownloadFailure.CORRUPT_ARTIFACT,
+            classifyUpdateDownloadFailure(CorruptUpdateArtifactException("No APK found in the nightly archive")),
+        )
+    }
+
+    @Test
+    fun `a bare IllegalStateException is not misread as a corrupt artifact`() {
+        // A generic runtime ISE (e.g. from a coroutine/Ktor internal) must not be reported as a
+        // damaged download - only the dedicated corrupt type and ZipException are.
+        assertEquals(UpdateDownloadFailure.UNKNOWN, classifyUpdateDownloadFailure(IllegalStateException("some internal state")))
     }
 
     @Test

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` - a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline - they are not duplicated here.
 
-## `app` Kotlin files (768)
+## `app` Kotlin files (769)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -13,7 +13,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 | `com.dpi` | no | 1 | 3 | kotlin.math |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 | `com.dpi` | no | 4 | 13 | android.app, android.content, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 | `com.jtech.zemer` | no | 60 | 29 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, java.util, javax.inject, kotlinx.coroutines, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 | `com.jtech.zemer` | no | 312 | 243 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2440 | `com.jtech.zemer` | no | 312 | 244 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 | `com.jtech.zemer.auth` | no | 0 | 13 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 | `com.jtech.zemer.auth` | no | 13 | 21 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -332,7 +332,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusStoryTopOverlay.kt` | 159 | `com.jtech.zemer.ui.component` | yes | 37 | 6 | androidx.compose, androidx.navigation, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusVideoSurface.kt` | 46 | `com.jtech.zemer.ui.component` | yes | 7 | 1 | android.view, androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 131 | `com.jtech.zemer.ui.component` | yes | 21 | 7 | androidx.compose, java.io |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 243 | `com.jtech.zemer.ui.component` | yes | 30 | 15 | android.text, androidx.compose, java.io |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 | `com.jtech.zemer.ui.component` | yes | 8 | 7 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerFab.kt` | 38 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt` | 60 | `com.jtech.zemer.ui.component` | yes | 10 | 2 | androidx.compose |
@@ -463,7 +463,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 468 | `com.jtech.zemer.ui.screens.settings` | yes | 71 | 36 | android.annotation, android.content, android.net, android.provider, androidx.activity, androidx.compose, androidx.navigation, coil3.annotation, coil3.imageLoader, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 297 | `com.jtech.zemer.ui.screens.settings` | yes | 57 | 24 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ThemeScreen.kt` | 590 | `com.jtech.zemer.ui.screens.settings` | yes | 88 | 42 | android.os, androidx.compose, androidx.navigation, com.materialkolor |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 408 | `com.jtech.zemer.ui.screens.settings` | yes | 66 | 27 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 416 | `com.jtech.zemer.ui.screens.settings` | yes | 67 | 28 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/SavedStatusScreen.kt` | 353 | `com.jtech.zemer.ui.screens.statuses` | yes | 62 | 38 | androidx.activity, androidx.compose, androidx.core, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusDownloadsScreen.kt` | 439 | `com.jtech.zemer.ui.screens.statuses` | yes | 85 | 25 | androidx.annotation, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 140 | `com.jtech.zemer.ui.screens.statuses` | yes | 43 | 11 | androidx.compose, androidx.hilt, androidx.navigation |
@@ -524,7 +524,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 | `com.jtech.zemer.utils` | no | 2 | 10 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 | `com.jtech.zemer.utils` | no | 49 | 131 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 254 | `com.jtech.zemer.utils` | no | 18 | 66 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 280 | `com.jtech.zemer.utils` | no | 22 | 69 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
@@ -543,7 +543,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 | `com.jtech.zemer.utils.updater` | no | 1 | 4 | android.content |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 | `com.jtech.zemer.utils.updater` | no | 10 | 7 | android.content, android.os, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 | `com.jtech.zemer.utils.updater` | no | 2 | 4 | androidx.annotation |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 107 | `com.jtech.zemer.utils.updater` | no | 7 | 29 | java.io, java.util, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 | `com.jtech.zemer.utils.updater` | no | 7 | 33 | java.io, java.util, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 | `com.jtech.zemer.viewmodels` | no | 18 | 14 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 | `com.jtech.zemer.viewmodels` | no | 29 | 31 | android.content, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -764,13 +764,14 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/PodcastWhitelistCacheTest.kt` | 44 | `com.jtech.zemer.utils` | no | 5 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 | `com.jtech.zemer.utils` | no | 4 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 90 | `com.jtech.zemer.utils` | no | 4 | 11 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 15 | `com.jtech.zemer.utils` | no | 3 | 2 | io.ktor, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 | `com.jtech.zemer.utils` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 | `com.jtech.zemer.utils` | no | 7 | 13 | kotlinx.coroutines, kotlinx.serialization, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 | `com.jtech.zemer.utils.mp4` | no | 7 | 8 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 | `com.jtech.zemer.utils.mp4` | no | 9 | 69 | java.io, java.nio, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 | `com.jtech.zemer.utils.ogg` | no | 9 | 61 | java.io, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 | `com.jtech.zemer.viewmodels` | no | 7 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 | `com.jtech.zemer.viewmodels` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -13,7 +13,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 | `com.dpi` | no | 1 | 3 | kotlin.math |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 | `com.dpi` | no | 4 | 13 | android.app, android.content, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 | `com.jtech.zemer` | no | 60 | 29 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, java.util, javax.inject, kotlinx.coroutines, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2440 | `com.jtech.zemer` | no | 312 | 244 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2447 | `com.jtech.zemer` | no | 313 | 245 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 | `com.jtech.zemer.auth` | no | 0 | 13 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 | `com.jtech.zemer.auth` | no | 13 | 21 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -303,7 +303,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 | `com.jtech.zemer.ui.component` | yes | 13 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 987 | `com.jtech.zemer.ui.component` | yes | 120 | 117 | android.annotation, android.content, android.os, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 88 | `com.jtech.zemer.ui.component` | yes | 25 | 7 | androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 89 | `com.jtech.zemer.ui.component` | yes | 26 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 | `com.jtech.zemer.ui.component` | yes | 9 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 | `com.jtech.zemer.ui.component` | yes | 36 | 13 | androidx.compose |
@@ -335,7 +335,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusStoryTopOverlay.kt` | 159 | `com.jtech.zemer.ui.component` | yes | 37 | 6 | androidx.compose, androidx.navigation, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusVideoSurface.kt` | 46 | `com.jtech.zemer.ui.component` | yes | 7 | 1 | android.view, androidx.compose, androidx.media3 |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 243 | `com.jtech.zemer.ui.component` | yes | 30 | 15 | android.text, androidx.compose, java.io |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 267 | `com.jtech.zemer.ui.component` | yes | 32 | 16 | android.text, androidx.compose, java.io |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 | `com.jtech.zemer.ui.component` | yes | 8 | 7 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerFab.kt` | 38 | `com.jtech.zemer.ui.component` | yes | 8 | 1 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt` | 60 | `com.jtech.zemer.ui.component` | yes | 10 | 2 | androidx.compose |
@@ -466,7 +466,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 468 | `com.jtech.zemer.ui.screens.settings` | yes | 71 | 36 | android.annotation, android.content, android.net, android.provider, androidx.activity, androidx.compose, androidx.navigation, coil3.annotation, coil3.imageLoader, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 297 | `com.jtech.zemer.ui.screens.settings` | yes | 57 | 24 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ThemeScreen.kt` | 590 | `com.jtech.zemer.ui.screens.settings` | yes | 88 | 42 | android.os, androidx.compose, androidx.navigation, com.materialkolor |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 416 | `com.jtech.zemer.ui.screens.settings` | yes | 67 | 28 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 423 | `com.jtech.zemer.ui.screens.settings` | yes | 68 | 29 | android.content, androidx.compose, androidx.navigation, java.io, kotlinx.coroutines, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/SavedStatusScreen.kt` | 353 | `com.jtech.zemer.ui.screens.statuses` | yes | 62 | 38 | androidx.activity, androidx.compose, androidx.core, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.request, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusDownloadsScreen.kt` | 439 | `com.jtech.zemer.ui.screens.statuses` | yes | 85 | 25 | androidx.annotation, androidx.compose, androidx.hilt, androidx.navigation, coil3.compose, coil3.request |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 140 | `com.jtech.zemer.ui.screens.statuses` | yes | 43 | 11 | androidx.compose, androidx.hilt, androidx.navigation |
@@ -527,7 +527,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 | `com.jtech.zemer.utils` | no | 2 | 10 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 | `com.jtech.zemer.utils` | no | 49 | 131 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 288 | `com.jtech.zemer.utils` | no | 22 | 70 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 300 | `com.jtech.zemer.utils` | no | 25 | 66 | android.content, io.ktor, java.io, java.nio, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
@@ -538,7 +538,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 | `com.jtech.zemer.utils` | no | 10 | 32 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 795 | `com.jtech.zemer.utils` | no | 31 | 102 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 | `com.jtech.zemer.utils` | no | 21 | 65 | io.ktor, java.io, kotlinx.serialization, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 155 | `com.jtech.zemer.utils.markdown` | no | 0 | 55 |  |
+| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 199 | `com.jtech.zemer.utils.markdown` | no | 0 | 64 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 | `com.jtech.zemer.utils.mp4` | no | 8 | 16 | android.media, android.os, java.io, java.nio, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 | `com.jtech.zemer.utils.mp4` | no | 3 | 76 | java.io, java.nio |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 | `com.jtech.zemer.utils.ogg` | no | 3 | 100 | java.io, java.util |
@@ -548,7 +548,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 | `com.jtech.zemer.utils.updater` | no | 10 | 7 | android.content, android.os, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 | `com.jtech.zemer.utils.updater` | no | 2 | 4 | androidx.annotation |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 | `com.jtech.zemer.utils.updater` | no | 7 | 33 | java.io, java.util, kotlinx.serialization |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 41 | `com.jtech.zemer.utils.updater` | no | 7 | 6 | java.io, java.net, java.util, javax.net |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 50 | `com.jtech.zemer.utils.updater` | no | 7 | 7 | java.io, java.net, java.util, javax.net |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 | `com.jtech.zemer.viewmodels` | no | 18 | 14 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 | `com.jtech.zemer.viewmodels` | no | 29 | 31 | android.content, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -734,7 +734,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt` | 42 | `com.jtech.zemer.ui.component` | no | 3 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SettingsCardGroupTest.kt` | 20 | `com.jtech.zemer.ui.component` | no | 2 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SortHeaderTest.kt` | 20 | `com.jtech.zemer.ui.component` | no | 4 | 2 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 29 | `com.jtech.zemer.ui.component` | no | 4 | 1 | java.io, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 37 | `com.jtech.zemer.ui.component` | no | 5 | 1 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/lyrics/LyricsSourceHeaderTest.kt` | 19 | `com.jtech.zemer.ui.component.lyrics` | no | 4 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/ViewCollectionMenuItemTest.kt` | 31 | `com.jtech.zemer.ui.menu` | no | 3 | 1 | org.junit |
@@ -773,13 +773,13 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 66 | `com.jtech.zemer.utils` | no | 13 | 9 | io.ktor, java.net, kotlin.concurrent, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 | `com.jtech.zemer.utils` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 | `com.jtech.zemer.utils` | no | 7 | 13 | kotlinx.coroutines, kotlinx.serialization, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 94 | `com.jtech.zemer.utils.markdown` | no | 10 | 3 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 114 | `com.jtech.zemer.utils.markdown` | no | 10 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 | `com.jtech.zemer.utils.mp4` | no | 7 | 8 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 | `com.jtech.zemer.utils.mp4` | no | 9 | 69 | java.io, java.nio, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 | `com.jtech.zemer.utils.ogg` | no | 9 | 61 | java.io, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 48 | `com.jtech.zemer.utils.updater` | no | 8 | 3 | io.ktor, java.io, java.net, java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 199 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 58 | `com.jtech.zemer.utils.updater` | no | 8 | 3 | io.ktor, java.io, java.net, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 | `com.jtech.zemer.viewmodels` | no | 7 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 | `com.jtech.zemer.viewmodels` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -524,7 +524,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 | `com.jtech.zemer.utils` | no | 2 | 10 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 | `com.jtech.zemer.utils` | no | 49 | 131 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 | `com.jtech.zemer.utils` | no | 17 | 65 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 254 | `com.jtech.zemer.utils` | no | 18 | 66 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -527,7 +527,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 | `com.jtech.zemer.utils` | no | 2 | 10 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 | `com.jtech.zemer.utils` | no | 49 | 131 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 300 | `com.jtech.zemer.utils` | no | 25 | 66 | android.content, io.ktor, java.io, java.nio, kotlinx.coroutines, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 309 | `com.jtech.zemer.utils` | no | 25 | 68 | android.content, io.ktor, java.io, java.nio, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -2,7 +2,7 @@
 
 Every tracked Kotlin file is listed with hard metadata extracted from the file text: line count, package, whether it declares any `@Composable`, import count, top-level declaration count (`Decls` - a high value flags a god-file), and the external import roots it depends on. Declaration counting is regex-based (after stripping comments and string literals). For the actual declaration names, read the file or use your editor's outline - they are not duplicated here.
 
-## `app` Kotlin files (769)
+## `app` Kotlin files (777)
 
 | File | Lines | Package | Compose | Imports | Decls | External import roots |
 | --- | ---: | --- | --- | ---: | ---: | --- |
@@ -295,12 +295,15 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 | `com.jtech.zemer.ui.component` | yes | 21 | 3 | androidx.annotation, androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 | `com.jtech.zemer.ui.component` | yes | 41 | 9 | androidx.annotation, androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 | `com.jtech.zemer.ui.component` | yes | 24 | 1 | androidx.annotation, androidx.compose |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/InlineMessagePanel.kt` | 57 | `com.jtech.zemer.ui.component` | yes | 17 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1789 | `com.jtech.zemer.ui.component` | yes | 116 | 103 | android.annotation, androidx.compose, androidx.media3, coil3.compose, coil3.request, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/LabeledWavyProgress.kt` | 64 | `com.jtech.zemer.ui.component` | yes | 15 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 | `com.jtech.zemer.ui.component` | yes | 37 | 23 | androidx.compose, kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 541 | `com.jtech.zemer.ui.component` | yes | 43 | 13 | android.annotation, androidx.compose, androidx.navigation, coil3.compose, coil3.request, coil3.size, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 | `com.jtech.zemer.ui.component` | yes | 13 | 1 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 987 | `com.jtech.zemer.ui.component` | yes | 120 | 117 | android.annotation, android.content, android.os, androidx.activity, androidx.annotation, androidx.compose, androidx.lifecycle, androidx.palette, coil3.imageLoader, coil3.request, coil3.toBitmap, kotlin.time, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 | `com.jtech.zemer.ui.component` | yes | 28 | 34 | android.annotation, androidx.compose, coil3.compose, coil3.request |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 88 | `com.jtech.zemer.ui.component` | yes | 25 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 | `com.jtech.zemer.ui.component` | yes | 9 | 7 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 | `com.jtech.zemer.ui.component` | yes | 31 | 13 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 | `com.jtech.zemer.ui.component` | yes | 36 | 13 | androidx.compose |
@@ -524,7 +527,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 | `com.jtech.zemer.utils` | no | 2 | 10 | kotlin.math |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 | `com.jtech.zemer.utils` | no | 0 | 6 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 | `com.jtech.zemer.utils` | no | 49 | 131 | android.content, android.util, androidx.datastore, dagger.hilt, java.time, javax.inject, kotlinx.coroutines, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 280 | `com.jtech.zemer.utils` | no | 22 | 69 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 288 | `com.jtech.zemer.utils` | no | 22 | 70 | android.content, io.ktor, java.io, kotlinx.coroutines, kotlinx.serialization, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 | `com.jtech.zemer.utils` | no | 5 | 21 | io.ktor, org.json |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 | `com.jtech.zemer.utils` | no | 2 | 8 | okhttp3.HttpUrl |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 | `com.jtech.zemer.utils` | no | 4 | 3 | android.content, java.util, timber.log |
@@ -535,6 +538,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 | `com.jtech.zemer.utils` | no | 10 | 32 | java.util, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 795 | `com.jtech.zemer.utils` | no | 31 | 102 | android.net, androidx.core, androidx.media3, com.zemer, kotlinx.coroutines, okhttp3.OkHttpClient, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 | `com.jtech.zemer.utils` | no | 21 | 65 | io.ktor, java.io, kotlinx.serialization, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 155 | `com.jtech.zemer.utils.markdown` | no | 0 | 55 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 | `com.jtech.zemer.utils.mp4` | no | 8 | 16 | android.media, android.os, java.io, java.nio, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 | `com.jtech.zemer.utils.mp4` | no | 3 | 76 | java.io, java.nio |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 | `com.jtech.zemer.utils.ogg` | no | 3 | 100 | java.io, java.util |
@@ -544,6 +548,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 | `com.jtech.zemer.utils.updater` | no | 10 | 7 | android.content, android.os, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 | `com.jtech.zemer.utils.updater` | no | 2 | 4 | androidx.annotation |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 | `com.jtech.zemer.utils.updater` | no | 7 | 33 | java.io, java.util, kotlinx.serialization |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 41 | `com.jtech.zemer.utils.updater` | no | 7 | 6 | java.io, java.net, java.util, javax.net |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 | `com.jtech.zemer.viewmodels` | no | 6 | 3 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 | `com.jtech.zemer.viewmodels` | no | 18 | 14 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 | `com.jtech.zemer.viewmodels` | no | 29 | 31 | android.content, androidx.compose, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -729,6 +734,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt` | 42 | `com.jtech.zemer.ui.component` | no | 3 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SettingsCardGroupTest.kt` | 20 | `com.jtech.zemer.ui.component` | no | 2 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SortHeaderTest.kt` | 20 | `com.jtech.zemer.ui.component` | no | 4 | 2 | org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 29 | `com.jtech.zemer.ui.component` | no | 4 | 1 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/lyrics/LyricsSourceHeaderTest.kt` | 19 | `com.jtech.zemer.ui.component.lyrics` | no | 4 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 | `com.jtech.zemer.ui.menu` | no | 5 | 33 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/ViewCollectionMenuItemTest.kt` | 31 | `com.jtech.zemer.ui.menu` | no | 3 | 1 | org.junit |
@@ -764,14 +770,16 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/PodcastWhitelistCacheTest.kt` | 44 | `com.jtech.zemer.utils` | no | 5 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 | `com.jtech.zemer.utils` | no | 4 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 90 | `com.jtech.zemer.utils` | no | 4 | 11 | org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 15 | `com.jtech.zemer.utils` | no | 3 | 2 | io.ktor, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 66 | `com.jtech.zemer.utils` | no | 13 | 9 | io.ktor, java.net, kotlin.concurrent, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 | `com.jtech.zemer.utils` | no | 2 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 | `com.jtech.zemer.utils` | no | 7 | 13 | kotlinx.coroutines, kotlinx.serialization, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 94 | `com.jtech.zemer.utils.markdown` | no | 10 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 | `com.jtech.zemer.utils.mp4` | no | 7 | 8 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 | `com.jtech.zemer.utils.mp4` | no | 9 | 69 | java.io, java.nio, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 | `com.jtech.zemer.utils.ogg` | no | 9 | 61 | java.io, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 48 | `com.jtech.zemer.utils.updater` | no | 8 | 3 | io.ktor, java.io, java.net, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 | `com.jtech.zemer.viewmodels` | no | 7 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 | `com.jtech.zemer.viewmodels` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 | `com.jtech.zemer.widget` | no | 3 | 1 | org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -260,7 +260,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/metrolist_strings.xml` | 698 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/strings.xml` | 466 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/strings.xml` | 467 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/xml-v25/shortcuts.xml` | 23 lines | text `.xml`; XML root `shortcuts` |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -12,7 +12,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 56 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 3 lines | text `[none]` |
-| `AGENTS.md` | 1896 lines | text `.md` |
+| `AGENTS.md` | 1903 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 9 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |
@@ -259,8 +259,8 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `app/src/main/res/values-v31/styles.xml` | 22 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/app_name.xml` | 4 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/colors.xml` | 9 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/metrolist_strings.xml` | 699 lines | text `.xml`; XML root `resources` |
-| `app/src/main/res/values/strings.xml` | 454 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/metrolist_strings.xml` | 698 lines | text `.xml`; XML root `resources` |
+| `app/src/main/res/values/strings.xml` | 466 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/styles.xml` | 26 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/values/values.xml` | 8 lines | text `.xml`; XML root `resources` |
 | `app/src/main/res/xml-v25/shortcuts.xml` | 23 lines | text `.xml`; XML root `shortcuts` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -687,7 +687,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 243 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 254 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -690,7 +690,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 300 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 309 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1358`
+- Files counted: `1366`
 - By extension:
-  - `.kt`: `863`
+  - `.kt`: `871`
   - `.xml`: `192`
   - `.mjs`: `110`
   - `.md`: `73`
@@ -458,12 +458,15 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/HideOnScrollFAB.kt` | 117 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconButton.kt` | 203 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/IconCategoryCard.kt` | 92 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/InlineMessagePanel.kt` | 57 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Items.kt` | 1789 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/LabeledWavyProgress.kt` | 64 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LetterFastScrollbar.kt` | 217 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Library.kt` | 541 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 987 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 88 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 lines | `.kt` |
@@ -687,7 +690,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 280 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 288 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
@@ -698,6 +701,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 795 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 155 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 lines | `.kt` |
@@ -707,6 +711,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 41 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 lines | `.kt` |
@@ -1100,6 +1105,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt` | 42 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SettingsCardGroupTest.kt` | 20 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SortHeaderTest.kt` | 20 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 29 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/lyrics/LyricsSourceHeaderTest.kt` | 19 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/ViewCollectionMenuItemTest.kt` | 31 lines | `.kt` |
@@ -1135,14 +1141,16 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/PodcastWhitelistCacheTest.kt` | 44 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 90 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 15 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 66 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 94 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 48 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |
@@ -1212,7 +1220,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 886 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 894 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 435 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -1223,7 +1231,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1471 lines | `.md` |
+| `docs/repository-map.md` | 1479 lines | `.md` |
 | `docs/sabr/README.md` | 543 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -176,7 +176,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2440 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2447 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 lines | `.kt` |
@@ -466,7 +466,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LibraryFilterChip.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Lyrics.kt` | 987 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/LyricsImageCard.kt` | 287 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 88 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/MarkdownText.kt` | 89 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Marquee.kt` | 65 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3MenuItem.kt` | 135 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/Material3SettingsGroup.kt` | 206 lines | `.kt` |
@@ -498,7 +498,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusStoryTopOverlay.kt` | 159 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusVideoSurface.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 243 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 267 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerFab.kt` | 38 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt` | 60 lines | `.kt` |
@@ -629,7 +629,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 468 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 297 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ThemeScreen.kt` | 590 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 416 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 423 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/SavedStatusScreen.kt` | 353 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusDownloadsScreen.kt` | 439 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 140 lines | `.kt` |
@@ -690,7 +690,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 288 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 300 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
@@ -701,7 +701,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/WhitelistFilter.kt` | 331 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/YTPlayerUtils.kt` | 795 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ZemerContentClient.kt` | 257 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 155 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 199 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 lines | `.kt` |
@@ -711,7 +711,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 41 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailure.kt` | 50 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 lines | `.kt` |
@@ -961,7 +961,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
 | `app/src/main/res/values/metrolist_strings.xml` | 698 lines | `.xml` |
-| `app/src/main/res/values/strings.xml` | 466 lines | `.xml` |
+| `app/src/main/res/values/strings.xml` | 467 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
 | `app/src/main/res/xml-v25/shortcuts.xml` | 23 lines | `.xml` |
@@ -1105,7 +1105,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/GentleMarqueeTest.kt` | 42 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SettingsCardGroupTest.kt` | 20 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/SortHeaderTest.kt` | 20 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 29 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialogLogicTest.kt` | 37 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/component/lyrics/LyricsSourceHeaderTest.kt` | 19 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/DownloadMenuItemsTest.kt` | 71 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/ui/menu/ViewCollectionMenuItemTest.kt` | 31 lines | `.kt` |
@@ -1144,13 +1144,13 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 66 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 94 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 114 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 48 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 199 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 58 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -77,9 +77,9 @@ The following inventory is generated from repository files outside `.git`, `.gra
 
 ### Counts
 
-- Files counted: `1357`
+- Files counted: `1358`
 - By extension:
-  - `.kt`: `862`
+  - `.kt`: `863`
   - `.xml`: `192`
   - `.mjs`: `110`
   - `.md`: `73`
@@ -119,7 +119,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 56 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 3 lines | `[none]` |
-| `AGENTS.md` | 1896 lines | `.md` |
+| `AGENTS.md` | 1903 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 9 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -176,7 +176,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2433 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2440 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 lines | `.kt` |
@@ -495,7 +495,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusStoryTopOverlay.kt` | 159 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/StatusVideoSurface.kt` | 46 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/SyncAccountWarning.kt` | 58 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 131 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/component/UpdateDownloadDialog.kt` | 243 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerCuratedPlaylistCard.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerFab.kt` | 38 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/component/ZemerLoadingIndicator.kt` | 60 lines | `.kt` |
@@ -626,7 +626,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StorageSettings.kt` | 468 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/StreamSourceSettings.kt` | 297 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/ThemeScreen.kt` | 590 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 408 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/settings/UpdaterSettings.kt` | 416 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/SavedStatusScreen.kt` | 353 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusDownloadsScreen.kt` | 439 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/statuses/StatusesScreen.kt` | 140 lines | `.kt` |
@@ -687,7 +687,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/RefreshRateSelection.kt` | 72 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/StringUtils.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/SyncUtils.kt` | 1162 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 254 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/UpdateChecker.kt` | 280 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Updater.kt` | 55 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/UrlValidator.kt` | 82 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/Utils.kt` | 30 lines | `.kt` |
@@ -706,7 +706,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/InstallReceiver.kt` | 66 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/Installer.kt` | 24 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 107 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/updater/NightlyUpdates.kt` | 118 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AccountSettingsViewModel.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/AlbumViewModel.kt` | 147 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ArtistViewModel.kt` | 216 lines | `.kt` |
@@ -955,8 +955,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/res/values-v31/styles.xml` | 22 lines | `.xml` |
 | `app/src/main/res/values/app_name.xml` | 4 lines | `.xml` |
 | `app/src/main/res/values/colors.xml` | 9 lines | `.xml` |
-| `app/src/main/res/values/metrolist_strings.xml` | 699 lines | `.xml` |
-| `app/src/main/res/values/strings.xml` | 454 lines | `.xml` |
+| `app/src/main/res/values/metrolist_strings.xml` | 698 lines | `.xml` |
+| `app/src/main/res/values/strings.xml` | 466 lines | `.xml` |
 | `app/src/main/res/values/styles.xml` | 26 lines | `.xml` |
 | `app/src/main/res/values/values.xml` | 8 lines | `.xml` |
 | `app/src/main/res/xml-v25/shortcuts.xml` | 23 lines | `.xml` |
@@ -1135,13 +1135,14 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/PodcastWhitelistCacheTest.kt` | 44 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RankedContentGateTest.kt` | 52 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/RefreshRateSelectionTest.kt` | 90 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/UpdateCheckerDownloadClientTest.kt` | 15 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/VideoLinkBuilderTest.kt` | 49 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ZemerContentClientTest.kt` | 115 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 188 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 198 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/ArtistChannelEpisodesTest.kt` | 67 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/viewmodels/StaleAlbumDeleteTest.kt` | 29 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/widget/WidgetLayoutTest.kt` | 26 lines | `.kt` |
@@ -1211,7 +1212,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/recognize_music/05-widget.md` | 72 lines | `.md` |
 | `docs/recognize_music/06-testing-and-maintenance.md` | 54 lines | `.md` |
 | `docs/recognize_music/README.md` | 71 lines | `.md` |
-| `docs/reference/kotlin-files.md` | 885 lines | `.md` |
+| `docs/reference/kotlin-files.md` | 886 lines | `.md` |
 | `docs/reference/non-kotlin-files.md` | 435 lines | `.md` |
 | `docs/reference/resource-index.md` | 255 lines | `.md` |
 | `docs/remote_cipher_config/01-why-it-exists.md` | 88 lines | `.md` |
@@ -1222,7 +1223,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/remote_cipher_config/06-harness-and-monitor.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/07-runbook.md` | 101 lines | `.md` |
 | `docs/remote_cipher_config/README.md` | 112 lines | `.md` |
-| `docs/repository-map.md` | 1470 lines | `.md` |
+| `docs/repository-map.md` | 1471 lines | `.md` |
 | `docs/sabr/README.md` | 543 lines | `.md` |
 | `docs/stations/README.md` | 69 lines | `.md` |
 | `docs/status/README.md` | 122 lines | `.md` |


### PR DESCRIPTION
## Summary
Two user reports on #515 showed the in-app update failing with "Request timeout has expired" and a raw CDN URL in the dialog. Root-causing that surfaced a second bug (progress jumped 0 -> 100) and a dialog that needed work.

- **Timeout:** the download used a bare Ktor client whose CIO engine caps a whole request at 15 s; the ~10 MB nightly / ~14 MB stable APK cannot finish in that window on a slow mobile or filtered link. The download client now has the request timeout disabled (`UpdateChecker.downloadHttpClient()`); update checks are unchanged.
- **Progress:** the no-block `HttpStatement.execute()` loads the entire body into memory before returning, so the progress loop only ran after the download had completed. It now streams via the block form and reports every 128 KB with byte counts and a percent.
- **Dialog redesign:** installed -> new version card (nightly prefix dropped so it fits one line), release notes rendered as Markdown (stable changelog is Markdown; a nightly's commit message gets a bold subject heading and a reflowed body) in a panel that takes the remaining dialog height and scrolls, classified failures (timeout / network / storage / corrupt) with localized copy instead of the raw exception, Retry after a failure, Cancel during a download, filled primary action.
- **Shared components extracted:** `MarkdownText` (over the pure `LiteMarkdown` parser), `LabeledWavyProgress`, `InlineMessagePanel` / `InlineErrorPanel`; registered in AGENTS.md.

Existing installs keep the old 15 s cap until they update once (fast Wi-Fi or a manual APK install); nothing server-side can lift it.

## Verification
- Unit tests: `UpdateCheckerDownloadClientTest`, `UpdateDownloadFailureTest`, `LiteMarkdownTest`, `UpdateDownloadDialogLogicTest`, `NightlyUpdatesTest` (29 total, green).
- `:app:assembleDebug` green; `ui-audit.sh`, `check-download-unification.sh`, `check-dead-resources.sh` pass; `docs/generate.py` regenerated docs included.
- Dialog verified on device (nightly channel): bold subject, one-line version, scrolling notes panel.

Refs #515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Markdown-formatted release notes with headings, lists, links, and inline styling.
  - Added detailed download progress, cancellation, retry, and installation actions.
  - Added nightly-build and return-to-stable update labels with categorized download errors.

- **Bug Fixes**
  - Improved download reliability with bounded inactivity handling and safer cleanup.
  - Improved handling of incomplete or invalid update packages.

- **Documentation**
  - Updated source-file references, repository maps, and shared UI component documentation.

- **Tests**
  - Added coverage for downloads, Markdown, update actions, timeouts, and failure classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->