### PR TITLE
fix: crash sweep for the open Crashlytics issues on 38

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,11 @@ source** onto the whitelisted relay host `stream.zemer.io`. Full contract + the 
   giants.
 - **Onboarding + gating.** The login gate has a third option **"I have a filter"** (login-less: sets
   `RELAY`, no cookie). `MainActivity`'s gate must NOT bounce a relay session (it derives login + relay from
-  one DataStore snapshot via `produceState`). A **normal login globally resets `RELAY`→`DIRECT`** in
+  one DataStore snapshot via `produceState`). The redirect decision is the pure, tested
+  `ui/screens/LoginGateRedirect`: a **null route means `NavHost` has not set the graph yet** and the effect
+  must NOT navigate (Navigation throws "Cannot navigate to login_gate. Navigation graph has not been set" -
+  a warm start / config-change recreate delivers the DataStore snapshot before the graph exists, and that
+  crash-looped launch); the effect is keyed on the route, so it re-runs on the first real one. A **normal login globally resets `RELAY`→`DIRECT`** in
   `App.kt` (from ANY entry point), and the **Settings toggle + the nav-drawer Account entry are hidden when
   not login-less** (relay is accountless). These gates key off the cookie's `SAPISID` (true for anon too),
   the codebase's standard "has a session" idiom.
@@ -430,7 +434,7 @@ A Zemer Station broadcast is never persisted (see §Zemer Stations).
 
 ### Cipher / player rotation (the most common future break)
 
-The `cipher` submodule (package `com.zemer.cipher`, repo `ZemerTeam/zemer-cipher`) deciphers YouTube's `player_ias` signatures in an Android WebView and mints poTokens. It's wired **two ways**: a git submodule *and* a Gradle composite build - `includeBuild("cipher")` in `settings.gradle.kts` substitutes `com.zemer:cipher` → the local `:library`, so the app always builds the working tree.
+The `cipher` submodule (package `com.zemer.cipher`, repo `ZemerTeam/zemer-cipher`) deciphers YouTube's `player_ias` signatures in an Android WebView and mints poTokens. **The per-track STS lookup never re-reads the player JS**: `CipherDeobfuscator.signatureTimestamp()` -> `PlayerJsFetcher.signatureTimestamp()` serves the remembered Int while the small `current_hash.txt` still names the unexpired player it was extracted from (`stsFastPath`, tested), and only falls through to `getPlayerJs` otherwise. The old path read the whole ~2.8 MB base.js from disk (bytes + String, 5+ MB) on EVERY stream resolve just to return that Int - the `getSignatureTimestampOrNull` OutOfMemoryError on low-RAM phones. It's wired **two ways**: a git submodule *and* a Gradle composite build - `includeBuild("cipher")` in `settings.gradle.kts` substitutes `com.zemer:cipher` → the local `:library`, so the app always builds the working tree.
 
 YouTube rotates `player_ias` frequently. Player configs live in **one JSON file**: `cipher/library/src/main/assets/player_configs.json` - per player the sig call expression (e.g. `mP(4,155,INPUT)`), the n-transform URL class (e.g. `Yx`), the STS, and the md5-of-first-10000-bytes alias. That single file is (1) bundled in the APK as the offline default, (2) **fetched at runtime from raw zemer-cipher `master`** by `PlayerConfigStore` (6 h TTL + ETag, plus a forced refresh + one retry the moment an unknown hash breaks deciphering), and (3) read by the `tests/` harness - so **a config pushed to cipher `master` fixes deployed apps within minutes, no APK release**. Parsing/validation is `PlayerConfigParser` (strict regexes; the n-IIFE is built from a local template - remote data can never inject free-form JS into the WebView; invalid entries are skipped, invalid files - including any duplicate hash/alias key - are rejected wholesale and the previous table kept). The validation rules exist in TWO readers (the Kotlin parser and `tests/player-configs.mjs`); file-level accept/reject verdicts and the n-IIFE template are pinned byte-for-byte by shared fixtures in `cipher/library/src/test/resources/config-parity/` - a rule change must update both readers AND the fixtures, or one of the two test suites goes red. When adding a config:
 - **Validate empirically**: `node tests/validate-player-config.mjs <hash>` deciphers a real stream and checks the CDN returns **HTTP 206**. That 206 is ground truth, not regex extraction - multiple constant pairs can decipher correctly, only the live response confirms which the server accepts. It prints a paste-ready JSON entry (and re-validates the committed entry first if one exists).
@@ -635,7 +639,14 @@ answered — so they are deferred even when the user order lists them first. Lyr
 start (`LyricsStore.prefetch`: current song then the next queue item, 3 s deferred, skipped offline) so opening
 the pane is a Room read; never regress the pane-open path to a live chain walk. `LrcLib.identityMatches` accepts ANY credited artist of a joined credit (`creditedArtists`), not
 just the first. The chain reads ONE DataStore snapshot per walk (`LyricsHelper.enabledProviders(prefs)`: order +
-every `LyricsProvider.enabledKey`), never a blocking read per provider. Musixmatch's `cleanLrc` formats with
+every `LyricsProvider.enabledKey`), never a blocking read per provider. **The walk runs STRUCTURED under its caller**
+(`LyricsHelper.getLyrics` calls `LyricsChainWalk.run` directly; `run` is a `coroutineScope`): it used to
+run on a parentless `SupervisorJob` scope whose `cancel()` sat after the `await`, so a cancelled caller (the
+track-start prefetch skipping to the next song) left every in-flight provider fetch running to completion
+with its body - steady heap churn during background playback on low-RAM phones. Cancelling the caller now
+cancels the fetches (`LyricsChainWalkTest`), and the fetch lambda rethrows `CancellationException` before
+its catch-all so a skipped track is never reported as a provider failure. There is no in-memory lyrics
+cache in the helper (the one it had was never written to); Room via `LyricsStore` is the cache. Musixmatch's `cleanLrc` formats with
 `Locale.US` (a comma-decimal locale produced LRC nothing could parse). Users contribute through the lyrics menu:
 a saved edit is also POSTed to the server's submission queue and "Report" POSTs a report after the shared
 `ConfirmDialog` (`ui/component/MenuDialogs.kt`, the ONE Cancel/OK confirmation - the remove-download confirm rides
@@ -944,6 +955,18 @@ Rules that must not regress:
 - **A brand-new user's empty Quick Picks seeds from Zemer**, not YouTube: `seedQuickPicksFromZemer`
   pulls the `auto-top-50` curated playlist. Returning users seed from local history; the seed is a no-op
   when Quick Picks is non-empty and never breaks Home on failure.
+- **Quick Picks must not churn on a pull-to-refresh** (pure, tested `viewmodels/QuickPicksPresentation`):
+  a refresh over rows already on screen skips the intermediate "local data first" publish and keeps the
+  rows until the FINAL list lands (`showLocalRowsFirst` - two publishes meant two shuffles per pull);
+  items that survive the reload keep their position and newcomers append (`keepDisplayedOrder`, applied to
+  the once-shuffled final list so the See-all contract still holds); and a pool under
+  `MIN_POOL_FOR_ROTATION` (8) allowed songs is shown WHOLE - the recent-artist avoidance + one-per-artist
+  rotation otherwise flips a small library's row between two subsets (3 -> 4 -> 3, "songs jump in").
+  Real libraries still rotate exactly as before.
+- **Home song rows read the live Room row through `ui/utils/rememberLiveSong`** (Quick Picks, Forgotten
+  Favorites, their See-all) - never `database.song(id)` + `!!`. The row CAN vanish under the composable
+  (the whitelist sync deletes a de-whitelisted artist's songs while Home still lists them), and the
+  unwrap was a Home crash; the helper falls back to the snapshot.
 - The **"Zemer Radio" row** (under Zemer Playlists) is the synchronized-broadcast stations shelf - see §Zemer Stations below and `docs/stations/README.md`; its now-playing cards tick every 60s
   while ON SCREEN only (`repeatOnLifecycle(RESUMED)`).
 - **Easter egg:** five quick taps on the Home top-bar title (1.5s idle resets) play a fixed song via
@@ -1769,7 +1792,10 @@ that must not regress:
   theme instead of the brand default. `ZemerTheme` with default params = brand pink and is only correct
   inside MainActivity (which drives `themeColor` itself, incl. album-art). The home-screen **widget**
   (`widget/MusicWidget.kt`) is RemoteViews and can't read the Compose theme - it uses the static
-  `@color/widget_accent` (brand).
+  `@color/widget_accent` (brand). `MusicWidget.hasPlacedWidget` (the per-playback-session placement check
+  `MusicService` runs before ticking the widget) must stay wrapped: Glance builds on
+  `AppWidgetManager.getInstance`, null on ROMs without an AppWidgetService, and the resulting NPE inside
+  `getGlanceIds` escaped the service scope and killed background playback on every play transition.
 
 ### The download system (ONE unified path - never fork it)
 
@@ -1861,7 +1887,11 @@ an audio download can now keep **Opus** instead of being forced to AAC. Rules th
   `utils/mp4/Mp4MetadataWriter` (iTunes-style `moov/udta/meta/ilst` atoms: title/artist/album/year, `covr`
   cover art, `aART`/`trkn` album-artist/track-number, and identity-exact lyrics). **WebM/Ogg Opus** ->
   rewrap WebM to Ogg via `AudioRemux.webmOpusToOgg`, then tag with `utils/ogg/OggOpusTagger` (an OpusTags
-  Vorbis-comment packet + `METADATA_BLOCK_PICTURE` cover). An already-Ogg file is tagged directly. All
+  Vorbis-comment packet + `METADATA_BLOCK_PICTURE` cover). **The Ogg tagger STREAMS page by page**
+  (`PageReader` over a `RandomAccessFile`; only the head page, the OpusTags packet and one audio page are
+  ever resident): the earlier whole-file read plus a per-page copy peaked at ~2x the track size, and three
+  concurrent Opus downloads was an OutOfMemoryError site. Trailing garbage or a truncated page is refused
+  with no output file, exactly as before (`OggOpusTaggerTest`). An already-Ogg file is tagged directly. All
   three are framework/pure-Kotlin - **no native dependency, no NDK.** Guarded by JVM tests
   (`Mp4MetadataWriterTest` / `OggOpusTaggerTest`) plus the on-device `OpusDevicePipelineTest` (real
   itag-251 WebM->Ogg remux + tag, then `MediaMetadataRetriever` reads every field + cover back from BOTH
@@ -1901,7 +1931,7 @@ Node ≥20 scripts (deps vendored in `tests/node_modules`, no install needed) th
 
 ### Modules & app layout
 
-- **`:app`** (`com.jtech.zemer`) - single-activity Jetpack Compose UI, Hilt DI (`App.kt` `@HiltAndroidApp`, modules under `di/`), Media3. `MainActivity` + `NavigationBuilder.kt` host the Compose nav graph; `MusicService` (a Media3 `MediaLibraryService`) owns ExoPlayer and is bridged to the UI by `PlayerConnection`, with `playback/queues/` implementations. State is Room (`db/MusicDatabase.kt`, `song.db`) + DataStore preferences (`utils/DataStore.kt` - holds the auth cookie / visitorData / dataSyncId and all settings). Content-filtering (whitelist, KidZone) lives in `sync/` + `utils/SyncUtils.kt`. The offline search-backup snapshot (sync engine + read-layer port) lives in `offline/` (on-disk store under `filesDir/subset/` - see §Offline search backup). Downloads via Media3 `ExoDownloadService` plus a MediaStore path. Crash/error telemetry is Firebase Crashlytics: `utils/CrashReportingTree.kt` (planted in `App.kt`) turns every Timber log (DEBUG+) into a breadcrumb and `reportException()` calls into non-fatal issues - so report errors via `reportException()`/`Timber`, never `printStackTrace`; release CI uploads R8 mappings and native symbols automatically.
+- **`:app`** (`com.jtech.zemer`) - single-activity Jetpack Compose UI, Hilt DI (`App.kt` `@HiltAndroidApp`, modules under `di/`), Media3. `MainActivity` + `NavigationBuilder.kt` host the Compose nav graph; `MusicService` (a Media3 `MediaLibraryService`) owns ExoPlayer and is bridged to the UI by `PlayerConnection`, with `playback/queues/` implementations. State is Room (`db/MusicDatabase.kt`, `song.db`) + DataStore preferences (`utils/DataStore.kt` - holds the auth cookie / visitorData / dataSyncId and all settings). Content-filtering (whitelist, KidZone) lives in `sync/` + `utils/SyncUtils.kt`. The offline search-backup snapshot (sync engine + read-layer port) lives in `offline/` (on-disk store under `filesDir/subset/` - see §Offline search backup). Downloads via Media3 `ExoDownloadService` plus a MediaStore path. Crash/error telemetry is Firebase Crashlytics: `utils/CrashReportingTree.kt` (planted in `App.kt`) turns every Timber log (DEBUG+) into a breadcrumb and `reportException()` calls into non-fatal issues - so report errors via `reportException()`/`Timber`, never `printStackTrace`; release CI uploads R8 mappings and native symbols automatically. `App.kt` sets the Crashlytics custom key `commit` = `BuildConfig.COMMIT_HASH` because every main build ships as the SAME versionCode/versionName (a nightly reports as "38" like stable) - the key is the only way to tell a nightly crash from a stable one in the console.
 - **`:innertube`** (`com.metrolist.innertube`) - the YouTube Music InnerTube API client (Ktor): request building, auth context, page parsers that turn YouTube renderer trees into typed models. Holds the `YouTubeClient` definitions. (The NewPipe extractor bridge is gone: the cipher player is the single sts/decipher source - a live probe 2026-08-27 showed the extractor's sig parse broken on the current player, and it fetched the player over the same iframe_api route as the cipher, so it could not survive any failure the cipher couldn't.)
 - **`:lrclib`** / **`:simpmusic`** (`com.metrolist.*`) - lyrics provider clients (LrcLib.net and api-lyrics.simpmusic.org).
 - **`cipher`** - see "Cipher / player rotation" above.

--- a/app/src/main/kotlin/com/jtech/zemer/App.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/App.kt
@@ -87,6 +87,9 @@ class App : Application(), SingletonImageLoader.Factory {
                 recordNonFatal = { FirebaseCrashlytics.getInstance().recordException(it) },
             )
         )
+        // Every main build ships as the same versionCode/versionName (nightly = stable's number), so
+        // Crashlytics buckets nightly and stable together; the commit key is what tells them apart.
+        FirebaseCrashlytics.getInstance().setCustomKey("commit", BuildConfig.COMMIT_HASH)
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
             // Ring-buffer tree for the developer-mode Log viewer. Debug builds ONLY —

--- a/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/MainActivity.kt
@@ -239,6 +239,7 @@ import com.jtech.zemer.ui.component.rememberBottomSheetState
 import com.jtech.zemer.ui.component.shimmer.ShimmerTheme
 import com.jtech.zemer.ui.menu.YouTubeSongMenu
 import com.jtech.zemer.ui.player.BottomSheetPlayer
+import com.jtech.zemer.ui.screens.LoginGateRedirect
 import com.jtech.zemer.ui.screens.LoginGateScreen
 import com.jtech.zemer.ui.screens.OnboardingFlow
 import com.jtech.zemer.ui.screens.Screens
@@ -797,10 +798,10 @@ class MainActivity : ComponentActivity() {
                         }
                         LaunchedEffect(loginGate, currentRoute) {
                             val (loggedIn, relay) = loginGate ?: return@LaunchedEffect
-                            if (!loggedIn && !relay &&
-                                currentRoute != "login_gate" && currentRoute != "login"
-                            ) {
-                                navController.navigate("login_gate") {
+                            // A null route = NavHost has not set the graph yet (navigate would throw);
+                            // the effect re-runs on the first real route. Decision: LoginGateRedirect.
+                            if (LoginGateRedirect.shouldRedirect(loggedIn, relay, currentRoute)) {
+                                navController.navigate(LoginGateRedirect.ROUTE) {
                                     popUpTo(0) { inclusive = true }
                                 }
                             }

--- a/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt
@@ -3,7 +3,6 @@
 package com.jtech.zemer.lyrics
 
 import android.content.Context
-import android.util.LruCache
 import androidx.datastore.preferences.core.Preferences
 import com.jtech.zemer.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
 import com.jtech.zemer.lyrics.model.LyricsUnavailableException
@@ -13,10 +12,7 @@ import com.jtech.zemer.models.MediaMetadata
 import com.jtech.zemer.utils.NetworkConnectivityObserver
 import com.jtech.zemer.utils.reportException
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import javax.inject.Inject
@@ -37,8 +33,6 @@ constructor(
      */
     private suspend fun enabledProviders(): List<LyricsProvider> = enabledProviders(context.dataStore.data.first())
 
-    private val cache = LruCache<String, List<LyricsResult>>(MAX_CACHE_SIZE)
-
     /** Lyrics body plus the provider label to persist/show ("Zemer · jkaraoke", "SimpMusic", …). */
     data class Fetched(val lyrics: String, val provider: String?)
 
@@ -46,11 +40,6 @@ constructor(
         // The resolver and SimpMusic are keyed by the YouTube videoId. setVideoId is the playlist-entry
         // token of the queue item, not a video identifier, so it must never be used as the key.
         val videoId = mediaMetadata.id
-
-        val cached = cache.get(mediaMetadata.id)?.firstOrNull()
-        if (cached != null) {
-            return Fetched(cached.lyrics, cached.providerName)
-        }
 
         // Check network connectivity before making network requests
         // Use synchronous check as fallback if flow doesn't emit
@@ -67,46 +56,43 @@ constructor(
         }
 
         val providers = enabledProviders()
-        val scope = CoroutineScope(SupervisorJob())
-        val deferred = scope.async {
-            // The pick rule (synced-first among trusted providers, low-trust YouTube only as a last resort) is
-            // the pure SyncedFirstPicker; the schedule (primary alone, then the rest concurrently, low-trust
-            // deferred) is the pure LyricsChainWalk. Both are tested without a network.
-            LyricsChainWalk.run(providers) { provider ->
-                val startedAt = System.currentTimeMillis()
-                try {
-                    val result = provider.getLabeledLyrics(
-                        videoId,
-                        mediaMetadata.title,
-                        mediaMetadata.artists.joinToString { it.name },
-                        mediaMetadata.duration,
-                        mediaMetadata.album?.title,
-                    )
-                    Timber.d("Lyrics %s %s in %d ms", provider.name, if (result.isSuccess) "answered" else "no answer", System.currentTimeMillis() - startedAt)
-                    result.onFailure {
-                        // Not found here is normal — keep looking. Report only unexpected exceptions.
-                        if (it !is LyricsUnavailableException &&
-                            !(it is IllegalStateException && it.message?.contains("Lyrics") == true)) {
-                            reportException(it)
-                        }
-                    }.getOrNull()
-                } catch (e: Exception) {
-                    // Catch network-related exceptions like UnresolvedAddressException
-                    Timber.d("Lyrics %s threw in %d ms", provider.name, System.currentTimeMillis() - startedAt)
-                    reportException(e)
-                    null
-                }
+        // The pick rule (synced-first among trusted providers, low-trust YouTube only as a last resort) is
+        // the pure SyncedFirstPicker; the schedule (primary alone, then the rest concurrently, low-trust
+        // deferred) is the pure LyricsChainWalk. Both are tested without a network. The walk runs
+        // STRUCTURED under the caller: it used to run on a parentless scope whose cancel() sat after the
+        // await, so a cancelled caller (the track-start prefetch skipping to the next song) left every
+        // in-flight provider fetch running to completion with its body - heap churn during background
+        // playback on low-RAM devices. Cancelling the caller now cancels the fetches (LyricsChainWalkTest).
+        return LyricsChainWalk.run(providers) { provider ->
+            val startedAt = System.currentTimeMillis()
+            try {
+                val result = provider.getLabeledLyrics(
+                    videoId,
+                    mediaMetadata.title,
+                    mediaMetadata.artists.joinToString { it.name },
+                    mediaMetadata.duration,
+                    mediaMetadata.album?.title,
+                )
+                Timber.d("Lyrics %s %s in %d ms", provider.name, if (result.isSuccess) "answered" else "no answer", System.currentTimeMillis() - startedAt)
+                result.onFailure {
+                    // Not found here is normal — keep looking. Report only unexpected exceptions.
+                    if (it !is LyricsUnavailableException &&
+                        !(it is IllegalStateException && it.message?.contains("Lyrics") == true)) {
+                        reportException(it)
+                    }
+                }.getOrNull()
+            } catch (e: CancellationException) {
+                throw e // the caller was cancelled (skipped track): propagate, never report or swallow
+            } catch (e: Exception) {
+                // Catch network-related exceptions like UnresolvedAddressException
+                Timber.d("Lyrics %s threw in %d ms", provider.name, System.currentTimeMillis() - startedAt)
+                reportException(e)
+                null
             }
         }
-
-        val lyrics = deferred.await()
-        scope.cancel()
-        return lyrics
     }
 
     companion object {
-        private const val MAX_CACHE_SIZE = 3
-
         /** Pure: the user's ordered chain filtered to the providers enabled in [prefs] (blank order = default). */
         fun enabledProviders(prefs: Preferences): List<LyricsProvider> =
             LyricsProviderRegistry.getOrderedProviders(prefs[LyricsProviderOrderKey].orEmpty()).filter { it.isEnabled(prefs) }

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt
@@ -98,6 +98,7 @@ import com.jtech.zemer.tracking.PlaySource
 import com.jtech.zemer.ui.component.NavigationTitle
 import com.jtech.zemer.ui.component.ChipsRow
 import com.jtech.zemer.ui.component.ContentTabChipsRow
+import com.jtech.zemer.ui.utils.rememberLiveSong
 import com.jtech.zemer.ui.utils.whitelistedPodcastRoute
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -637,14 +638,12 @@ fun HomeScreen(
                                 key = { it.id },
                                 contentType = { "song" }
                             ) { originalSong ->
-                                // fetch song from database to keep updated
-                                val song by database.song(originalSong.id)
-                                    .collectAsState(initial = originalSong)
+                                val song = rememberLiveSong(database, originalSong)
 
                                 SongListItem(
-                                    song = song!!,
+                                    song = song,
                                     showInLibraryIcon = true,
-                                    isActive = song!!.id == mediaMetadata?.id,
+                                    isActive = song.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,
                                     isSwipeable = false,
                                     trailingContent = {
@@ -652,7 +651,7 @@ fun HomeScreen(
                                             onClick = {
                                                 menuState.show {
                                                     SongMenu(
-                                                        originalSong = song!!,
+                                                        originalSong = song,
                                                         navController = navController,
                                                         onDismiss = menuState::dismiss
                                                     )
@@ -664,12 +663,12 @@ fun HomeScreen(
                                         .width(horizontalLazyGridItemWidth)
                                         .combinedClickable(
                                             onClick = {
-                                                if (activeRowTapTogglesPlayPause(song!!.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
+                                                if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(
                                                         ZemerRadioQueue.song(
-                                                            song!!.toMediaMetadata(), playerConnection.service
+                                                            song.toMediaMetadata(), playerConnection.service
                                                         )
                                                     )
                                                 }
@@ -678,7 +677,7 @@ fun HomeScreen(
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 menuState.show {
                                                     SongMenu(
-                                                        originalSong = song!!,
+                                                        originalSong = song,
                                                         navController = navController,
                                                         onDismiss = menuState::dismiss
                                                     )
@@ -958,13 +957,12 @@ fun HomeScreen(
                                 key = { it.id },
                                 contentType = { "song" }
                             ) { originalSong ->
-                                val song by database.song(originalSong.id)
-                                    .collectAsState(initial = originalSong)
+                                val song = rememberLiveSong(database, originalSong)
 
                                 SongListItem(
-                                    song = song!!,
+                                    song = song,
                                     showInLibraryIcon = true,
-                                    isActive = song!!.id == mediaMetadata?.id,
+                                    isActive = song.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,
                                     isSwipeable = false,
                                     trailingContent = {
@@ -973,7 +971,7 @@ fun HomeScreen(
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 menuState.show {
                                                     SongMenu(
-                                                        originalSong = song!!,
+                                                        originalSong = song,
                                                         navController = navController,
                                                         onDismiss = menuState::dismiss
                                                     )
@@ -985,12 +983,12 @@ fun HomeScreen(
                                         .width(horizontalLazyGridItemWidth)
                                         .combinedClickable(
                                             onClick = {
-                                                if (activeRowTapTogglesPlayPause(song!!.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
+                                                if (activeRowTapTogglesPlayPause(song.id == mediaMetadata?.id, playerConnection.isStationBroadcast.value)) {
                                                     playerConnection.playPause()
                                                 } else {
                                                     playerConnection.playQueue(
                                                         ZemerRadioQueue.song(
-                                                            song!!.toMediaMetadata(), playerConnection.service
+                                                            song.toMediaMetadata(), playerConnection.service
                                                         )
                                                     )
                                                 }
@@ -999,7 +997,7 @@ fun HomeScreen(
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 menuState.show {
                                                     SongMenu(
-                                                        originalSong = song!!,
+                                                        originalSong = song,
                                                         navController = navController,
                                                         onDismiss = menuState::dismiss
                                                     )

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt
@@ -58,6 +58,7 @@ import com.jtech.zemer.ui.menu.AlbumMenu
 import com.jtech.zemer.ui.menu.ArtistMenu
 import com.jtech.zemer.ui.menu.SongMenu
 import com.jtech.zemer.ui.menu.ytItemMenu
+import com.jtech.zemer.ui.utils.rememberLiveSong
 import com.jtech.zemer.ui.utils.activeRowTapTogglesPlayPause
 import com.jtech.zemer.ui.utils.navigateToArtist
 import com.jtech.zemer.ui.utils.navigateToAlbum
@@ -280,8 +281,7 @@ private fun SongList(songs: List<Song>, navController: NavController) {
 
     LazyColumn(contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()) {
         items(items = songs, key = { it.id }) { originalSong ->
-            val song by database.song(originalSong.id).collectAsState(initial = originalSong)
-            val shown = song ?: originalSong
+            val shown = rememberLiveSong(database, originalSong)
             SongListItem(
                 song = shown,
                 showInLibraryIcon = true,

--- a/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateRedirect.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/screens/LoginGateRedirect.kt
@@ -1,0 +1,17 @@
+package com.jtech.zemer.ui.screens
+
+/**
+ * The login-gate redirect decision (`MainActivity`), pure so it is unit-tested. The gate effect fires on
+ * every DataStore snapshot AND on every route change; the route is null until `NavHost` has set the graph,
+ * and navigating in that window throws ("Cannot navigate to login_gate. Navigation graph has not been set")
+ * - a warm start or a config-change recreate delivers the snapshot before the graph exists. A null route
+ * therefore means "not yet", never "somewhere else": the effect re-runs on the first real route.
+ */
+object LoginGateRedirect {
+    const val ROUTE = "login_gate"
+
+    fun shouldRedirect(loggedIn: Boolean, relay: Boolean, currentRoute: String?): Boolean {
+        if (currentRoute == null) return false
+        return !loggedIn && !relay && currentRoute != ROUTE && currentRoute != "login"
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/ui/utils/LiveSong.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/ui/utils/LiveSong.kt
@@ -1,0 +1,20 @@
+package com.jtech.zemer.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.jtech.zemer.db.MusicDatabase
+import com.jtech.zemer.db.entities.Song
+
+/**
+ * The live Room row for a song rendered from a snapshot list (Quick Picks, Forgotten Favorites and their
+ * See-all), so liked / downloaded state stays current - falling back to the snapshot when the row is gone.
+ * The row CAN vanish under the composable: the whitelist sync deletes a de-whitelisted artist's songs
+ * while Home still lists them, and unwrapping the emitted null crashed Home (Crashlytics: HomeScreen
+ * LazyGrid NPE). One helper so no row re-rolls the `!!`.
+ */
+@Composable
+fun rememberLiveSong(database: MusicDatabase, snapshot: Song): Song {
+    val live by database.song(snapshot.id).collectAsState(initial = snapshot)
+    return live ?: snapshot
+}

--- a/app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt
@@ -1,5 +1,6 @@
 package com.jtech.zemer.utils.ogg
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.RandomAccessFile
 import java.util.Base64
@@ -39,32 +40,36 @@ object OggOpusTagger {
     fun write(input: File, output: File, tags: Tags): Boolean {
         if (tags.isEmpty) return false
         return try {
-            val bytes = input.readBytes()
-            val pages = parsePages(bytes) ?: return false
-            if (pages.size < 2) return false
+            // STREAMED, page by page: the whole file is never on the heap. The earlier whole-file read plus a
+            // per-page copy peaked at ~2x the track size, and three concurrent Opus downloads of long tracks
+            // on a low-RAM device was an OutOfMemoryError site. Only the head page, the OpusTags packet and
+            // ONE audio page at a time are resident.
+            val ok = RandomAccessFile(input, "r").use { raf ->
+                val reader = PageReader(raf)
+                val headPage = reader.next() ?: return@use false
+                val serial = headPage.serial
 
-            // Packet boundaries: a packet ends on a segment whose lacing value < 255.
-            // The first page holds OpusHead (packet 0); OpusTags (packet 1) starts at page 1.
-            val headPage = pages[0]
-            val serial = headPage.serial
-            val tagsPacket = extractPacket(pages, startPage = 1) ?: return false
+                // Packet boundaries: a packet ends on a segment whose lacing value < 255. The first page
+                // holds OpusHead (packet 0); OpusTags (packet 1) starts on page 1 and may span pages.
+                val tagsPacket = extractPacket(reader) ?: return@use false
+                val newComment = buildOpusTags(tagsPacket, tags) ?: return@use false
 
-            val newComment = buildOpusTags(tagsPacket.original, tags) ?: return false
-
-            // Pages after the tags packet are audio - keep their payloads, only renumber+recrc.
-            val trailing = pages.drop(tagsPacket.endPageExclusive)
-
-            output.outputStream().buffered().use { out ->
-                out.write(headPage.raw) // OpusHead page unchanged (seq 0)
-                var seq = 1
-                for (page in repaginate(serial, seq, newComment, granule = 0, continued = false, bos = false, eos = false)) {
-                    out.write(page); seq++
+                output.outputStream().buffered().use { out ->
+                    out.write(headPage.raw) // OpusHead page unchanged (seq 0)
+                    var seq = 1
+                    for (page in repaginate(serial, seq, newComment, granule = 0, continued = false, bos = false, eos = false)) {
+                        out.write(page); seq++
+                    }
+                    // Pages after the tags packet are audio - keep their payloads, only renumber+recrc.
+                    while (true) {
+                        val page = reader.next() ?: break
+                        out.write(rewritePageHeader(page.raw, seq)); seq++
+                    }
                 }
-                for (page in trailing) {
-                    out.write(rewritePageHeader(page.raw, seq)); seq++
-                }
+                reader.atEnd // trailing garbage or a truncated page = not a clean Ogg stream: refuse
             }
-            true
+            if (!ok) output.delete()
+            ok
         } catch (e: Exception) {
             output.delete()
             false
@@ -76,55 +81,58 @@ object OggOpusTagger {
     private class Page(
         val raw: ByteArray,
         val serial: Int,
-        val seq: Int,
-        val headerType: Int,
         val segTable: IntArray,
         val bodyOffset: Int,
-        val bodyLength: Int,
     )
 
-    private fun parsePages(b: ByteArray): List<Page>? {
-        val pages = mutableListOf<Page>()
-        var pos = 0
-        while (pos + 27 <= b.size) {
-            if (u32be(b, pos) != CAPTURE) return null
-            val headerType = b[pos + 5].toInt() and 0xFF
-            val serial = u32le(b, pos + 14)
-            val seq = u32le(b, pos + 18)
-            val segCount = b[pos + 26].toInt() and 0xFF
-            if (pos + 27 + segCount > b.size) return null
-            val segTable = IntArray(segCount) { b[pos + 27 + it].toInt() and 0xFF }
+    /**
+     * Sequential page reader over the file. [next] returns null at a clean end of stream OR on a malformed /
+     * truncated page - [atEnd] tells the two apart (true only when every byte was consumed as a valid page).
+     */
+    private class PageReader(private val raf: RandomAccessFile) {
+        private val length = raf.length()
+        private var pos = 0L
+        var atEnd = false
+            private set
+
+        fun next(): Page? {
+            if (pos == length) { atEnd = true; return null }
+            if (pos + 27 > length) return null
+            val header = ByteArray(27)
+            raf.seek(pos)
+            raf.readFully(header)
+            if (u32be(header, 0) != CAPTURE) return null
+            val serial = u32le(header, 14)
+            val segCount = header[26].toInt() and 0xFF
+            if (pos + 27 + segCount > length) return null
+            val segBytes = ByteArray(segCount)
+            raf.readFully(segBytes)
+            val segTable = IntArray(segCount) { segBytes[it].toInt() and 0xFF }
             val bodyLen = segTable.sum()
-            val bodyOffset = pos + 27 + segCount
-            if (bodyOffset + bodyLen > b.size) return null
             val total = 27 + segCount + bodyLen
-            pages.add(Page(b.copyOfRange(pos, pos + total), serial, seq, headerType, segTable, bodyOffset - pos, bodyLen))
+            if (pos + total > length) return null
+            val raw = ByteArray(total)
+            System.arraycopy(header, 0, raw, 0, 27)
+            System.arraycopy(segBytes, 0, raw, 27, segCount)
+            raf.readFully(raw, 27 + segCount, bodyLen)
             pos += total
+            return Page(raw, serial, segTable, 27 + segCount)
         }
-        return pages.takeIf { pos == b.size }
     }
 
-    private class ExtractedPacket(val original: ByteArray, val endPageExclusive: Int)
-
-    /** Concatenate the packet body that begins at [startPage], up to its terminating lace. */
-    private fun extractPacket(pages: List<Page>, startPage: Int): ExtractedPacket? {
-        val buf = ArrayList<Byte>()
-        var pageIdx = startPage
-        while (pageIdx < pages.size) {
-            val page = pages[pageIdx]
-            var consumed = 0
+    /** Concatenate the packet body that begins on the reader's next page, up to its terminating lace. */
+    private fun extractPacket(reader: PageReader): ByteArray? {
+        val buf = ByteArrayOutputStream()
+        while (true) {
+            val page = reader.next() ?: return null
             var bodyPos = page.bodyOffset
-            var ended = false
             for (lace in page.segTable) {
-                repeat(lace) { buf.add(page.raw[bodyPos + it]) }
+                buf.write(page.raw, bodyPos, lace)
                 bodyPos += lace
-                consumed += lace
-                if (lace < 255) { ended = true; break }
+                if (lace < 255) return buf.toByteArray()
             }
-            if (ended) return ExtractedPacket(buf.toByteArray(), pageIdx + 1)
-            pageIdx++ // packet continues onto the next page
+            // packet continues onto the next page
         }
-        return null
     }
 
     // --- OpusTags comment packet ---
@@ -168,24 +176,24 @@ object OggOpusTagger {
         }
 
         val all = kept + added
-        val out = ArrayList<Byte>()
-        out.addAll("OpusTags".toByteArray(Charsets.ISO_8859_1).toList())
-        out.addAll(u32leBytes(vendor.size).toList()); out.addAll(vendor.toList())
-        out.addAll(u32leBytes(all.size).toList())
-        for (c in all) { out.addAll(u32leBytes(c.size).toList()); out.addAll(c.toList()) }
+        val out = ByteArrayOutputStream()
+        out.write("OpusTags".toByteArray(Charsets.ISO_8859_1))
+        out.write(u32leBytes(vendor.size)); out.write(vendor)
+        out.write(u32leBytes(all.size))
+        for (c in all) { out.write(u32leBytes(c.size)); out.write(c) }
         return out.toByteArray()
     }
 
     /** Minimal FLAC METADATA_BLOCK_PICTURE (type 3 = front cover, no dims - players tolerate 0). */
     private fun flacPictureBlock(image: ByteArray, mime: String): ByteArray {
-        val out = ArrayList<Byte>()
-        fun u32(v: Int) { out.add((v ushr 24).toByte()); out.add((v ushr 16).toByte()); out.add((v ushr 8).toByte()); out.add(v.toByte()) }
+        val out = ByteArrayOutputStream()
+        fun u32(v: Int) { out.write(v ushr 24); out.write(v ushr 16); out.write(v ushr 8); out.write(v) }
         u32(3) // picture type: front cover
         val mimeBytes = mime.toByteArray(Charsets.US_ASCII)
-        u32(mimeBytes.size); out.addAll(mimeBytes.toList())
+        u32(mimeBytes.size); out.write(mimeBytes)
         u32(0) // description length
         u32(0); u32(0); u32(0); u32(0) // width, height, depth, colors (unknown)
-        u32(image.size); out.addAll(image.toList())
+        u32(image.size); out.write(image)
         return out.toByteArray()
     }
 
@@ -248,13 +256,12 @@ object OggOpusTagger {
         return page
     }
 
-    /** Renumber an existing (audio) page's seq and recompute its CRC in place. */
+    /** Renumber an existing (audio) page's seq and recompute its CRC, in place (the buffer is the reader's, used once). */
     private fun rewritePageHeader(page: ByteArray, seq: Int): ByteArray {
-        val copy = page.copyOf()
-        putU32le(copy, 18, seq)
-        putU32le(copy, 22, 0)
-        putU32le(copy, 22, oggCrc(copy))
-        return copy
+        putU32le(page, 18, seq)
+        putU32le(page, 22, 0)
+        putU32le(page, 22, oggCrc(page))
+        return page
     }
 
     // --- Ogg CRC-32 (poly 0x04C11DB7, init 0, no reflection, no final xor) ---

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt
@@ -540,8 +540,14 @@ class HomeViewModel @Inject constructor(
                     .take(20)
             }
 
-            // Show local data immediately while network loads
-            if (quick.isNotEmpty() || forgotten.isNotEmpty() || keepListening.isNotEmpty()) {
+            // Show local data immediately while network loads - on a cold start. A refresh over rows already
+            // on screen keeps them until the final list lands, else the row reshuffles twice per pull
+            // (QuickPicksPresentation.showLocalRowsFirst).
+            val hasDisplayedRows = uiState.value.let {
+                it.quickPicks.isNotEmpty() || it.forgottenFavorites.isNotEmpty() || it.keepListening.isNotEmpty()
+            }
+            val showLocalFirst = QuickPicksPresentation.showLocalRowsFirst(force, hasDisplayedRows)
+            if (showLocalFirst && (quick.isNotEmpty() || forgotten.isNotEmpty() || keepListening.isNotEmpty())) {
                 val shownQuick = quick.shuffled(Random(System.nanoTime()))
                 uiState.update {
                     it.copy(
@@ -690,9 +696,15 @@ class HomeViewModel @Inject constructor(
             val fallbackQuick = runCatching {
                 database.allSongs().first().filter { it.isAllowed() }.take(30)
             }.getOrDefault(emptyList())
-            val freshQuick = filteredQuick.filter { song -> song.artistIds().none { it in recentArtistIds } }
-            val quickPool = freshQuick.ifEmpty { filteredQuick }
-            val recentAwareQuick = rotateByArtist(quickPool.ifEmpty { fallbackQuick }, 1, 20)
+            // A pool too small to rotate (a new or light listener) is shown whole: the recent-artist
+            // avoidance + one-per-artist pass otherwise flips such a row between two subsets on every load.
+            val recentAwareQuick = if (QuickPicksPresentation.rotates(filteredQuick.size)) {
+                val freshQuick = filteredQuick.filter { song -> song.artistIds().none { it in recentArtistIds } }
+                val quickPool = freshQuick.ifEmpty { filteredQuick }
+                rotateByArtist(quickPool.ifEmpty { fallbackQuick }, 1, 20)
+            } else {
+                filteredQuick.ifEmpty { fallbackQuick.take(20) }
+            }
             Timber.d("HomeViewModel: quickPicks flow - quick=${quick.size}, filtered=${filteredQuick.size}, rotated=${recentAwareQuick.size}")
 
             // CRITICAL: Never show fewer items than already displayed to user
@@ -711,7 +723,12 @@ class HomeViewModel @Inject constructor(
             Timber.d("HomeViewModel: finalQuick=${finalQuick.size} (original=${quick.size}, rotated=${recentAwareQuick.size})")
             // The Quick Picks row is shown in a per-load shuffle; its "See all" must lead with that SAME
             // order (the See-all contract), so shuffle ONCE here and use it for both the row and the snapshot.
-            val displayedQuick = finalQuick.shuffled(Random(System.nanoTime()))
+            // Items already on screen keep their position (a refresh must not reorder what the user is
+            // looking at); newcomers append in the shuffled order.
+            val displayedQuick = QuickPicksPresentation.keepDisplayedOrder(
+                uiState.value.quickPicks.map { it.id },
+                finalQuick.shuffled(Random(System.nanoTime())),
+            ) { it.id }
             // Featured rows come ONLY from the Zemer /home-rows endpoint — the ranked-row content gate
             // (female/israeli/blocked-ids, not the famous/american proxy) then the one-per-artist rotation.
             // No InnerTube: an empty pool (only possible if search.zemer.io is unreachable) just hides the

--- a/app/src/main/kotlin/com/jtech/zemer/viewmodels/QuickPicksPresentation.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/viewmodels/QuickPicksPresentation.kt
@@ -1,0 +1,36 @@
+package com.jtech.zemer.viewmodels
+
+/**
+ * How the Quick Picks row is PRESENTED across loads (pure, unit-tested). The row's content is a per-load
+ * rotation (recent-artist avoidance + one-per-artist); what must not happen is the row visibly churning on
+ * a pull-to-refresh: a user with a handful of songs saw the set flip 3 -> 4 -> 3 and reorder on every pull
+ * ("songs jump in"). Three rules keep it calm without touching the rotation on real libraries:
+ *  - a refresh keeps the rows already on screen until the FINAL list is ready ([showLocalRowsFirst]);
+ *  - items that stay keep their position, newcomers append ([keepDisplayedOrder]);
+ *  - a pool too small to rotate is shown whole and stable ([rotates]).
+ */
+object QuickPicksPresentation {
+    /** Below this many allowed songs the recent-artist rotation only flips the row between two subsets. */
+    const val MIN_POOL_FOR_ROTATION = 8
+
+    fun rotates(poolSize: Int): Boolean = poolSize >= MIN_POOL_FOR_ROTATION
+
+    /**
+     * The local rows are published immediately (before the network wait) only when nothing is on screen
+     * yet - a cold start's instant paint. A refresh over displayed rows waits for the final list, else
+     * the row reshuffles twice per pull.
+     */
+    fun showLocalRowsFirst(force: Boolean, hasDisplayedRows: Boolean): Boolean = !force || !hasDisplayedRows
+
+    /**
+     * [next] re-ordered so items already displayed keep their relative position and newcomers follow in
+     * [next]'s (shuffled) order. Empty [previousIds] (first paint) leaves [next] untouched.
+     */
+    fun <T> keepDisplayedOrder(previousIds: List<String>, next: List<T>, idOf: (T) -> String): List<T> {
+        if (previousIds.isEmpty()) return next
+        val rank = HashMap<String, Int>()
+        previousIds.forEachIndexed { i, id -> rank.putIfAbsent(id, i) }
+        val (kept, fresh) = next.partition { idOf(it) in rank }
+        return kept.sortedBy { rank.getValue(idOf(it)) } + fresh
+    }
+}

--- a/app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt
+++ b/app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt
@@ -23,6 +23,7 @@ import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
+import timber.log.Timber
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.LinearProgressIndicator
 import androidx.glance.appwidget.SizeMode
@@ -301,8 +302,17 @@ class MusicWidget : GlanceAppWidget() {
         const val ACTION_PREV = "com.jtech.zemer.ACTION_PREV"
 
         /** True iff at least one instance of this widget is currently placed on a home screen. */
-        suspend fun hasPlacedWidget(context: Context): Boolean =
+        suspend fun hasPlacedWidget(context: Context): Boolean = try {
             GlanceAppWidgetManager(context).getGlanceIds(MusicWidget::class.java).isNotEmpty()
+        } catch (e: Exception) {
+            // Glance builds on AppWidgetManager.getInstance(context), which is null on ROMs without an
+            // AppWidgetService (Go / TV / stripped OEM builds) and NPEs inside getGlanceIds; the call
+            // runs from the playback service on every play transition, so an escape here killed
+            // background playback (Crashlytics: GlanceAppWidgetManager.addAllReceiversAndProviders...).
+            // No widget host means no widget to tick.
+            Timber.w(e, "Widget placement check failed; assuming no widget is placed")
+            false
+        }
 
         private fun artFile(context: Context): File = File(context.filesDir, ART_FILE_NAME)
 

--- a/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt
@@ -3,8 +3,11 @@ package com.jtech.zemer.lyrics
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import com.jtech.zemer.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -77,5 +80,32 @@ class LyricsChainWalkTest {
         assertEquals(setOf("Zemer", "SimpMusic", "YouTube Subtitle", "YouTube Music"), f.calls.toSet())
         assertEquals(LyricsHelper.Fetched(LYRICS_NOT_FOUND, null), LyricsChainWalk.run(listOf(zemer, ytSub), Fake(emptyMap()).fetch))
         assertEquals(LyricsHelper.Fetched(LYRICS_NOT_FOUND, null), LyricsChainWalk.run(emptyList(), Fake(emptyMap()).fetch))
+    }
+
+    @Test
+    fun `cancelling the walk cancels the in-flight concurrent fetches`() = runBlocking {
+        // The walk must be STRUCTURED under its caller: a skipped track cancels the prefetch, and the
+        // provider fetches must die with it instead of running to completion off a detached scope.
+        val cancelled = Collections.synchronizedList(ArrayList<String>())
+        val started = Collections.synchronizedList(ArrayList<String>())
+        val fetch: suspend (LyricsProvider) -> LabeledLyrics? = { p ->
+            if (p.name == "Zemer") {
+                LabeledLyrics(p.name, plain) // a plain primary sends the walk on to the concurrent tail
+            } else {
+                started += p.name
+                try {
+                    delay(60_000)
+                    null
+                } catch (e: CancellationException) {
+                    cancelled += p.name
+                    throw e
+                }
+            }
+        }
+        val job = launch { LyricsChainWalk.run(listOf(zemer, simp, mxm, lrclib), fetch) }
+        while (started.size < 3) yield()
+        job.cancel()
+        job.join()
+        assertEquals(setOf("SimpMusic", "Musixmatch", "LrcLib"), cancelled.toSet())
     }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/ui/screens/LoginGateRedirectTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/ui/screens/LoginGateRedirectTest.kt
@@ -1,0 +1,30 @@
+package com.jtech.zemer.ui.screens
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LoginGateRedirectTest {
+    @Test
+    fun `no route yet means the graph is not set - never navigate`() {
+        assertFalse(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = false, currentRoute = null))
+    }
+
+    @Test
+    fun `a logged-out non-relay session on any other route is redirected`() {
+        assertTrue(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = false, currentRoute = "home"))
+        assertTrue(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = false, currentRoute = "settings"))
+    }
+
+    @Test
+    fun `already on the gate or the login page is left alone`() {
+        assertFalse(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = false, currentRoute = "login_gate"))
+        assertFalse(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = false, currentRoute = "login"))
+    }
+
+    @Test
+    fun `a logged-in or relay session is never bounced`() {
+        assertFalse(LoginGateRedirect.shouldRedirect(loggedIn = true, relay = false, currentRoute = "home"))
+        assertFalse(LoginGateRedirect.shouldRedirect(loggedIn = false, relay = true, currentRoute = "home"))
+    }
+}

--- a/app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt
@@ -192,4 +192,46 @@ class OggOpusTaggerTest {
         assertTrue("every page CRC must be valid", allCrcsValid(out.readBytes()))
         println("REALOGG_OUT=${out.absolutePath}")
     }
+
+    @Test
+    fun `a long stream is streamed page by page - every audio payload survives byte-exact`() {
+        // 400 audio pages: the tagger must never hold the file on the heap, and the pages it forwards
+        // must be the input's payloads in order with only seq + CRC rewritten.
+        val input = syntheticOpus(listOf("ARTIST=old"), audioPages = 400)
+        val out = tmp.newFile("out.ogg")
+        assertTrue(OggOpusTagger.write(input, out, OggOpusTagger.Tags(title = "T")))
+        val inBytes = input.readBytes()
+        val outBytes = out.readBytes()
+        assertTrue(allCrcsValid(outBytes))
+        val inAudio = pageBoundaries(inBytes).drop(2).map { audioPayload(inBytes, it) }
+        val outAudio = pageBoundaries(outBytes).drop(2).map { audioPayload(outBytes, it) }
+        assertEquals(400, outAudio.size)
+        assertEquals(inAudio.map { it.toList() }, outAudio.map { it.toList() })
+        assertEquals((0 until 402).toList(), seqNumbers(outBytes))
+    }
+
+    @Test
+    fun `trailing garbage after the last page is refused and leaves no output file`() {
+        val input = syntheticOpus()
+        input.appendBytes(byteArrayOf(1, 2, 3))
+        val out = tmp.newFile("out.ogg")
+        assertFalse(OggOpusTagger.write(input, out, OggOpusTagger.Tags(title = "T")))
+        assertFalse(out.exists())
+    }
+
+    @Test
+    fun `a truncated final page is refused and leaves no output file`() {
+        val input = syntheticOpus()
+        val bytes = input.readBytes()
+        input.writeBytes(bytes.copyOf(bytes.size - 10))
+        val out = tmp.newFile("out.ogg")
+        assertFalse(OggOpusTagger.write(input, out, OggOpusTagger.Tags(title = "T")))
+        assertFalse(out.exists())
+    }
+
+    private fun audioPayload(b: ByteArray, start: Int): ByteArray {
+        val segc = b[start + 26].toInt() and 0xFF
+        val body = (0 until segc).sumOf { b[start + 27 + it].toInt() and 0xFF }
+        return b.copyOfRange(start + 27 + segc, start + 27 + segc + body)
+    }
 }

--- a/app/src/test/kotlin/com/jtech/zemer/viewmodels/QuickPicksPresentationTest.kt
+++ b/app/src/test/kotlin/com/jtech/zemer/viewmodels/QuickPicksPresentationTest.kt
@@ -1,0 +1,49 @@
+package com.jtech.zemer.viewmodels
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuickPicksPresentationTest {
+    @Test
+    fun `a small pool is shown whole and stable, a real library rotates`() {
+        assertFalse(QuickPicksPresentation.rotates(0))
+        assertFalse(QuickPicksPresentation.rotates(5))
+        assertFalse(QuickPicksPresentation.rotates(QuickPicksPresentation.MIN_POOL_FOR_ROTATION - 1))
+        assertTrue(QuickPicksPresentation.rotates(QuickPicksPresentation.MIN_POOL_FOR_ROTATION))
+        assertTrue(QuickPicksPresentation.rotates(200))
+    }
+
+    @Test
+    fun `local rows paint first on a cold start, but a refresh keeps the displayed rows until the final list`() {
+        assertTrue(QuickPicksPresentation.showLocalRowsFirst(force = false, hasDisplayedRows = false))
+        assertTrue(QuickPicksPresentation.showLocalRowsFirst(force = false, hasDisplayedRows = true))
+        assertTrue(QuickPicksPresentation.showLocalRowsFirst(force = true, hasDisplayedRows = false))
+        assertFalse(QuickPicksPresentation.showLocalRowsFirst(force = true, hasDisplayedRows = true))
+    }
+
+    @Test
+    fun `displayed items keep their order and newcomers append in the new list's order`() {
+        val previous = listOf("b", "a", "c")
+        val next = listOf("x", "c", "a", "y", "b")
+        assertEquals(listOf("b", "a", "c", "x", "y"), QuickPicksPresentation.keepDisplayedOrder(previous, next) { it })
+    }
+
+    @Test
+    fun `items that left the pool simply drop out, nothing is re-added`() {
+        val previous = listOf("gone", "a", "b")
+        assertEquals(listOf("a", "b", "n"), QuickPicksPresentation.keepDisplayedOrder(previous, listOf("n", "b", "a")) { it })
+    }
+
+    @Test
+    fun `first paint passes the shuffled list through untouched`() {
+        val next = listOf("z", "y", "x")
+        assertEquals(next, QuickPicksPresentation.keepDisplayedOrder(emptyList(), next) { it })
+    }
+
+    @Test
+    fun `a duplicated previous id ranks by its first position`() {
+        assertEquals(listOf("a", "b"), QuickPicksPresentation.keepDisplayedOrder(listOf("a", "b", "a"), listOf("b", "a")) { it })
+    }
+}

--- a/docs/home_rows/README.md
+++ b/docs/home_rows/README.md
@@ -15,7 +15,12 @@ serves **what the Zemer audience actually plays**, and touches InnerTube for **z
    ranked by real distinct-device listening (albums/videos/artists) and YouTube view count (community
    playlists), 30-day live window, whitelist-pure + content-filtered server-side.
 2. **Quick Picks / Keep Listening / Forgotten Favorites** come from local Room. A brand-new user's empty
-   Quick Picks seeds from the Zemer `auto-top-50` curated playlist, not YouTube.
+   Quick Picks seeds from the Zemer `auto-top-50` curated playlist, not YouTube. Presentation across loads
+   is the pure `QuickPicksPresentation`: a pull-to-refresh keeps the displayed rows until the final list
+   lands (no intermediate reshuffle), surviving items keep their position with newcomers appended, and a
+   pool under 8 allowed songs is shown whole instead of rotated (the rotation flipped a tiny library's row
+   between two subsets on every pull). The rows read the live Room row via `rememberLiveSong`, which
+   falls back to the snapshot when the whitelist sync deleted the row mid-display.
 3. **Latest Releases** comes from the flipphoneguy feed; **Zemer Playlists** from `/zemer-playlists`.
 4. **Zemer Radio** (under Zemer Playlists) comes from `GET /stations` — the synchronized broadcast
    stations, with a live now-playing line per card (lifecycle-scoped 60s on-screen ticker) and a

--- a/docs/lyrics/README.md
+++ b/docs/lyrics/README.md
@@ -144,7 +144,10 @@ dismisses first, so a POST launched there never reached the server (`LyricsFeedb
 not: `LyricsStore.prefetch(current, next, connected)` runs `ensure` for the playing song and the next queue item
 (`LYRICS_PREFETCH_DELAY_MS` = 3 s after the track change so the chain never competes with the stream resolution;
 `collectLatest` drops a pending prefetch when the track changes first; skipped offline so no not-found rows are
-minted that would hide lyrics once online). Opening the pane is then a Room read. `ensure` runs the
+minted that would hide lyrics once online). Opening the pane is then a Room read. The walk itself runs
+structured under its caller (`LyricsHelper.getLyrics` -> `LyricsChainWalk.run`, a `coroutineScope`), so a
+cancelled prefetch cancels its in-flight provider fetches instead of leaving them to finish on a detached
+scope (`LyricsChainWalkTest` "cancelling the walk cancels the in-flight concurrent fetches"). `ensure` runs the
 chain only when `needsFetch`: nothing cached, or a legacy row (provider null) with a real body. A `LYRICS_NOT_FOUND` row is a
 negative cache and is never re-fetched. A legacy PLAIN body is always kept and stamped `provider = "legacy"`
 (shown as unknown provenance): pre-provider manual entries are indistinguishable from old auto-cached rows and

--- a/docs/reference/kotlin-files.md
+++ b/docs/reference/kotlin-files.md
@@ -12,8 +12,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 121 | `com.dpi` | no | 7 | 14 | android.annotation, android.app, android.content, android.util, timber.log |
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 | `com.dpi` | no | 1 | 3 | kotlin.math |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 | `com.dpi` | no | 4 | 13 | android.app, android.content, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 | `com.jtech.zemer` | no | 60 | 29 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, java.util, javax.inject, kotlinx.coroutines, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2447 | `com.jtech.zemer` | no | 313 | 245 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 407 | `com.jtech.zemer` | no | 60 | 29 | android.app, android.content, android.os, android.util, android.webkit, androidx.datastore, coil3.ImageLoader, coil3.PlatformContext, coil3.SingletonImageLoader, coil3.disk, coil3.network, coil3.request, coil3.svg, com.google, com.zemer, dagger.hilt, java.util, javax.inject, kotlinx.coroutines, okhttp3.Dispatcher, okhttp3.OkHttpClient, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2448 | `com.jtech.zemer` | no | 314 | 245 | android.annotation, android.app, android.content, android.os, android.view, androidx.activity, androidx.compose, androidx.core, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.media3, androidx.navigation, coil3.compose, coil3.imageLoader, coil3.request, coil3.toBitmap, com.google, com.valentinilk, dagger.hilt, java.net, java.util, javax.inject, kotlin.time, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 | `com.jtech.zemer.accessibility` | no | 7 | 6 | android.accessibilityservice, android.annotation, android.view |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 | `com.jtech.zemer.auth` | no | 0 | 13 |  |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 | `com.jtech.zemer.auth` | no | 13 | 21 | android.content, com.google, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -87,7 +87,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LrcLibLyricsProvider.kt` | 18 | `com.jtech.zemer.lyrics` | no | 2 | 4 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsChainWalk.kt` | 38 | `com.jtech.zemer.lyrics` | no | 3 | 8 | kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsEntry.kt` | 23 | `com.jtech.zemer.lyrics` | no | 0 | 9 |  |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 119 | `com.jtech.zemer.lyrics` | no | 18 | 23 | android.content, android.util, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 105 | `com.jtech.zemer.lyrics` | no | 14 | 17 | android.content, androidx.datastore, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProvider.kt` | 43 | `com.jtech.zemer.lyrics` | no | 1 | 10 | androidx.datastore |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrdering.kt` | 20 | `com.jtech.zemer.lyrics` | no | 0 | 5 |  |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistry.kt` | 44 | `com.jtech.zemer.lyrics` | no | 1 | 9 |  |
@@ -396,8 +396,8 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 | `com.jtech.zemer.ui.screens` | no | 0 | 3 |  |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 106 | `com.jtech.zemer.ui.screens` | yes | 33 | 4 | androidx.compose, coil3.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 | `com.jtech.zemer.ui.screens` | yes | 31 | 8 | androidx.compose, androidx.navigation |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1525 | `com.jtech.zemer.ui.screens` | yes | 151 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 | `com.jtech.zemer.ui.screens` | yes | 68 | 31 | androidx.compose, androidx.navigation |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1523 | `com.jtech.zemer.ui.screens` | yes | 152 | 104 | android.net, androidx.annotation, androidx.compose, androidx.datastore, androidx.hilt, androidx.lifecycle, androidx.navigation, kotlin.math, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 | `com.jtech.zemer.ui.screens` | yes | 69 | 30 | androidx.compose, androidx.navigation |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 | `com.jtech.zemer.ui.screens` | yes | 18 | 2 | androidx.compose |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 164 | `com.jtech.zemer.ui.screens` | yes | 29 | 11 | androidx.compose, androidx.hilt, androidx.navigation, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneTab.kt` | 22 | `com.jtech.zemer.ui.screens` | no | 0 | 3 |  |
@@ -542,7 +542,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 199 | `com.jtech.zemer.utils.markdown` | no | 0 | 64 |  |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 | `com.jtech.zemer.utils.mp4` | no | 8 | 16 | android.media, android.os, java.io, java.nio, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 | `com.jtech.zemer.utils.mp4` | no | 3 | 76 | java.io, java.nio |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 | `com.jtech.zemer.utils.ogg` | no | 3 | 100 | java.io, java.util |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 306 | `com.jtech.zemer.utils.ogg` | no | 4 | 93 | java.io, java.util |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 | `com.jtech.zemer.utils.updater` | yes | 15 | 15 | androidx.activity, androidx.compose, java.io, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppInstaller.kt` | 267 | `com.jtech.zemer.utils.updater` | no | 28 | 41 | android.app, android.content, android.net, android.os, android.provider, androidx.core, com.topjohnwu, dev.rikka, java.io, kotlinx.coroutines, org.lsposed, rikka.shizuku, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 | `com.jtech.zemer.utils.updater` | no | 1 | 4 | android.content |
@@ -562,7 +562,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 39 | `com.jtech.zemer.viewmodels` | no | 18 | 3 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 | `com.jtech.zemer.viewmodels` | no | 20 | 22 | androidx.lifecycle, dagger.hilt, java.time, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 | `com.jtech.zemer.viewmodels` | no | 14 | 38 | androidx.annotation, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 991 | `com.jtech.zemer.viewmodels` | no | 57 | 199 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 1008 | `com.jtech.zemer.viewmodels` | no | 57 | 201 | android.content, androidx.datastore, androidx.lifecycle, com.google, dagger.hilt, javax.inject, kotlin.random, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 99 | `com.jtech.zemer.viewmodels` | no | 21 | 17 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 | `com.jtech.zemer.viewmodels` | no | 18 | 12 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 41 | `com.jtech.zemer.viewmodels` | no | 13 | 8 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
@@ -599,7 +599,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenresViewModel.kt` | 59 | `com.jtech.zemer.viewmodels` | no | 18 | 9 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt` | 47 | `com.jtech.zemer.viewmodels` | no | 13 | 7 | androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 | `com.jtech.zemer.viewmodels` | no | 18 | 6 | android.content, androidx.lifecycle, dagger.hilt, javax.inject, kotlinx.coroutines |
-| `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 | `com.jtech.zemer.widget` | no | 62 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines |
+| `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 401 | `com.jtech.zemer.widget` | no | 63 | 49 | android.content, android.graphics, androidx.compose, androidx.datastore, androidx.glance, coil3.SingletonImageLoader, coil3.request, coil3.toBitmap, java.io, kotlinx.coroutines, timber.log |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 | `com.jtech.zemer.widget` | no | 0 | 3 |  |
 | `app/src/test/kotlin/com/dpi/DensityMathTest.kt` | 69 | `com.dpi` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/constants/PreferenceKeysTest.kt` | 26 | `com.jtech.zemer.constants` | no | 4 | 3 | androidx.datastore, java.lang, org.junit |
@@ -611,7 +611,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt` | 46 | `com.jtech.zemer.latestreleases` | no | 2 | 11 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlaybackTest.kt` | 120 | `com.jtech.zemer.latestreleases` | no | 6 | 9 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 | `com.jtech.zemer.latestreleases` | no | 8 | 8 | java.io, java.nio, kotlinx.coroutines, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt` | 81 | `com.jtech.zemer.lyrics` | no | 9 | 28 | androidx.datastore, java.util, kotlinx.coroutines, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt` | 111 | `com.jtech.zemer.lyrics` | no | 12 | 32 | androidx.datastore, java.util, kotlinx.coroutines, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrderingTest.kt` | 37 | `com.jtech.zemer.lyrics` | no | 2 | 8 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistryTest.kt` | 31 | `com.jtech.zemer.lyrics` | no | 2 | 2 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 108 | `com.jtech.zemer.lyrics` | no | 14 | 24 | kotlinx.coroutines, org.junit |
@@ -778,7 +778,7 @@ Every tracked Kotlin file is listed with hard metadata extracted from the file t
 | `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 114 | `com.jtech.zemer.utils.markdown` | no | 10 | 3 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 | `com.jtech.zemer.utils.mp4` | no | 7 | 8 | java.io, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 | `com.jtech.zemer.utils.mp4` | no | 9 | 69 | java.io, java.nio, org.junit |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 | `com.jtech.zemer.utils.ogg` | no | 9 | 61 | java.io, java.util, org.junit |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 237 | `com.jtech.zemer.utils.ogg` | no | 9 | 75 | java.io, java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 | `com.jtech.zemer.utils.updater` | no | 3 | 1 | org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 199 | `com.jtech.zemer.utils.updater` | no | 9 | 15 | java.util, org.junit |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 58 | `com.jtech.zemer.utils.updater` | no | 8 | 3 | io.ktor, java.io, java.net, java.util, org.junit |

--- a/docs/reference/non-kotlin-files.md
+++ b/docs/reference/non-kotlin-files.md
@@ -12,7 +12,7 @@ Every tracked non-Kotlin path outside `docs/` is listed. Text files report line 
 | `.github/workflows/ui-audit.yml` | 56 lines | text `.yml` |
 | `.gitignore` | 117 lines | text `[none]` |
 | `.gitmodules` | 3 lines | text `[none]` |
-| `AGENTS.md` | 1921 lines | text `.md` |
+| `AGENTS.md` | 1951 lines | text `.md` |
 | `LICENSE` | 674 lines | text `[none]` |
 | `README.md` | 9 lines | text `.md` |
 | `app/.gitignore` | 1 lines | text `[none]` |

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -120,7 +120,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `.github/workflows/ui-audit.yml` | 56 lines | `.yml` |
 | `.gitignore` | 117 lines | `[none]` |
 | `.gitmodules` | 3 lines | `[none]` |
-| `AGENTS.md` | 1921 lines | `.md` |
+| `AGENTS.md` | 1951 lines | `.md` |
 | `LICENSE` | 674 lines | `[none]` |
 | `README.md` | 9 lines | `.md` |
 | `app/.gitignore` | 1 lines | `[none]` |
@@ -176,8 +176,8 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/dpi/DensityConfiguration.kt` | 121 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityMath.kt` | 25 lines | `.kt` |
 | `app/src/main/kotlin/com/dpi/DensityScaler.kt` | 80 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 404 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2447 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/App.kt` | 407 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/MainActivity.kt` | 2448 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/accessibility/ButtonMapperAccessibilityService.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/AuthState.kt` | 45 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/auth/UserAuthManager.kt` | 120 lines | `.kt` |
@@ -251,7 +251,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LrcLibLyricsProvider.kt` | 18 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsChainWalk.kt` | 38 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsEntry.kt` | 23 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 119 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsHelper.kt` | 105 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProvider.kt` | 43 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrdering.kt` | 20 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistry.kt` | 44 lines | `.kt` |
@@ -560,7 +560,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContentTab.kt` | 23 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeContinueListeningRow.kt` | 106 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeGenresRow.kt` | 118 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1525 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeScreen.kt` | 1523 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeSeeAllScreen.kt` | 369 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/HomeStatusesRow.kt` | 58 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/ui/screens/KidZoneScreen.kt` | 164 lines | `.kt` |
@@ -706,7 +706,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdown.kt` | 199 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/AudioRemux.kt` | 94 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriter.kt` | 303 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 299 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/utils/ogg/OggOpusTagger.kt` | 306 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/ApkInstallController.kt` | 102 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppInstaller.kt` | 267 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/utils/updater/AppRestarter.kt` | 30 lines | `.kt` |
@@ -726,7 +726,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/DownloadedVideosViewModel.kt` | 39 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HistoryViewModel.kt` | 108 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeSeeAllStore.kt` | 131 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 991 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/viewmodels/HomeViewModel.kt` | 1008 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/KidZoneViewModel.kt` | 99 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LatestReleasesViewModel.kt` | 74 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/LibraryVideosViewModel.kt` | 41 lines | `.kt` |
@@ -763,7 +763,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerGenresViewModel.kt` | 59 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStationsViewModel.kt` | 47 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/viewmodels/ZemerStatusesViewModel.kt` | 63 lines | `.kt` |
-| `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 391 lines | `.kt` |
+| `app/src/main/kotlin/com/jtech/zemer/widget/MusicWidget.kt` | 401 lines | `.kt` |
 | `app/src/main/kotlin/com/jtech/zemer/widget/WidgetLayout.kt` | 14 lines | `.kt` |
 | `app/src/main/res/drawable-night/widget_background.xml` | 6 lines | `.xml` |
 | `app/src/main/res/drawable/account.xml` | 9 lines | `.xml` |
@@ -983,7 +983,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleaseFilterTest.kt` | 46 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasePlaybackTest.kt` | 120 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/latestreleases/LatestReleasesStoreTest.kt` | 120 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt` | 81 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsChainWalkTest.kt` | 111 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderOrderingTest.kt` | 37 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsProviderRegistryTest.kt` | 31 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/lyrics/LyricsStoreTest.kt` | 108 lines | `.kt` |
@@ -1150,7 +1150,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `app/src/test/kotlin/com/jtech/zemer/utils/markdown/LiteMarkdownTest.kt` | 114 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterRealFileTest.kt` | 60 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/mp4/Mp4MetadataWriterTest.kt` | 225 lines | `.kt` |
-| `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 195 lines | `.kt` |
+| `app/src/test/kotlin/com/jtech/zemer/utils/ogg/OggOpusTaggerTest.kt` | 237 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/InstallerTest.kt` | 43 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/NightlyUpdatesTest.kt` | 199 lines | `.kt` |
 | `app/src/test/kotlin/com/jtech/zemer/utils/updater/UpdateDownloadFailureTest.kt` | 58 lines | `.kt` |
@@ -1202,7 +1202,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/fcast/README.md` | 79 lines | `.md` |
 | `docs/generate.py` | 483 lines | `.py` |
 | `docs/genres/README.md` | 120 lines | `.md` |
-| `docs/home_rows/README.md` | 101 lines | `.md` |
+| `docs/home_rows/README.md` | 106 lines | `.md` |
 | `docs/innertube/README.md` | 170 lines | `.md` |
 | `docs/latest_releases/01-architecture-and-data-flow.md` | 94 lines | `.md` |
 | `docs/latest_releases/02-feed-format-and-server.md` | 95 lines | `.md` |
@@ -1212,7 +1212,7 @@ The following inventory is generated from repository files outside `.git`, `.gra
 | `docs/latest_releases/06-test-harness.md` | 127 lines | `.md` |
 | `docs/latest_releases/07-runbook.md` | 110 lines | `.md` |
 | `docs/latest_releases/README.md` | 80 lines | `.md` |
-| `docs/lyrics/README.md` | 164 lines | `.md` |
+| `docs/lyrics/README.md` | 167 lines | `.md` |
 | `docs/multi_update/01-architecture.md` | 80 lines | `.md` |
 | `docs/multi_update/02-install-methods.md` | 98 lines | `.md` |
 | `docs/multi_update/03-restart.md` | 70 lines | `.md` |


### PR DESCRIPTION
## Summary
Fixes for the open Crashlytics issues that are still live on `main`, plus the two heap suspects behind the fresh `OutOfMemoryError`s in 38, and the Quick Picks refresh churn a user reported on video.

| Crashlytics issue | Fix |
|---|---|
| `HomeScreen` LazyGrid `NullPointerException` (31-38) | Quick Picks / Forgotten Favorites / See-all read the live Room row through the shared `rememberLiveSong`, which falls back to the snapshot when the whitelist sync deleted the row mid-display. No more `song!!`. |
| `MainActivity` "Cannot navigate to login_gate" (31-38, both lambda signatures) | The gate decision is the pure `LoginGateRedirect`; a null route means `NavHost` has not set the graph yet, so the effect waits for the first real route instead of throwing. |
| `GlanceAppWidgetManager.addAllReceiversAndProvidersToPreferences` NPE (36-38) | `MusicWidget.hasPlacedWidget` is guarded. It runs from the service on every play transition, and `AppWidgetManager.getInstance` is null on ROMs without an AppWidgetService, so the escaped NPE killed background playback. |
| `OutOfMemoryError` at `YTPlayerUtils.getSignatureTimestampOrNull` (fresh in 38) | Cipher submodule bump to ZemerTeam/zemer-cipher#105: the per-track STS lookup no longer re-reads the ~2.8 MB player JS (bytes + String) just to return an already-cached Int. |
| Bare `OutOfMemoryError` (fresh in 38) | `OggOpusTagger` now streams page by page instead of holding the whole file plus a per-page copy (about 2x track size, up to 3 concurrent downloads). Boxed `ArrayList<Byte>` builders replaced. |
| Heap pressure (`GcWatcher.finalize()` timeout, 38) | The lyrics chain walk runs structured under its caller; a cancelled prefetch now cancels its in-flight provider fetches instead of leaving them to finish on a detached scope. Dead `LruCache` removed. |
| Nightly vs stable indistinguishable in the console | Crashlytics custom key `commit` = `BuildConfig.COMMIT_HASH`. |
| Quick Picks "songs jump in" on pull-to-refresh (user video) | `QuickPicksPresentation` (pure): a refresh keeps displayed rows until the final list lands, surviving items keep their position with newcomers appended, and a pool under 8 songs is shown whole instead of rotated. |

Already fixed on `main` and not touched here: `Util.percentInt` out of range (12f57a754) and `getSongsByIds` too many SQL variables (8f4a86486); both are still live on the v38 stable binary until the next release.

Deliberately not changed: the Room "migration 33 to 32" issue is a user rolling back to a v25-v31 APK over a newer database (v38 stable is schema 34), and adding a destructive downgrade fallback is a product decision. Noted that the destructive-migration retry in `MusicDatabase` is dead code (Room's `build()` never opens the database) if that decision is taken later. `SIGSEGV` in libart needs a symbolized native trace.

## Tests
- New: `LoginGateRedirectTest` (4), `QuickPicksPresentationTest` (6), `LyricsChainWalkTest` cancellation case, `OggOpusTaggerTest` 400-page byte-exact round trip + trailing-garbage and truncated-page refusal, cipher `PlayerJsFetcherStsTest` (3).
- Full `:app:testDebugUnitTest`: 1228 tests, 0 failures. `:app:assembleDebug` green. `ui-audit.sh`, `check-download-unification.sh`, `check-dead-resources.sh` all pass. Generated docs regenerated.
- Not unit-testable without Robolectric (stated rather than skipped): the composable `rememberLiveSong` fallback and the Glance `hasPlacedWidget` guard.

## On-device (emulator, API 30, debug build)
- Cold launch and four consecutive pull-to-refresh cycles on Home: no crash; the top Quick Picks rows keep their position across refreshes (17-song pool, so rotation still runs as designed).
- Three consecutive track plays over WEB_REMIX: the STS was delivered on every resolve with zero full player-JS reads (the old path logged one per resolve). No fatal exceptions.

## Merge order
ZemerTeam/zemer-cipher#105 first, merged with a merge or rebase (not squash) so the pointer commit `49bab45` stays reachable; otherwise re-bump the pointer after it lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quick Picks refreshes now preserve displayed ordering, reduce unnecessary rotation, and avoid visible row churn.
  - Home song lists remain stable when items are removed during synchronization.
  - Login redirects now wait for navigation to be ready and avoid redirect loops.

- **Bug Fixes**
  - Prevented widget checks and Home list updates from causing crashes.
  - Cancelled lyrics requests now stop in-flight provider fetches.
  - Ogg downloads handle large files more efficiently and reject incomplete or corrupted output.

- **Documentation**
  - Updated guidance for Home rows, lyrics cancellation, and repository references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->